### PR TITLE
Adding -a parameter to specify camera by IP address

### DIFF
--- a/src/arvsystem.c
+++ b/src/arvsystem.c
@@ -201,6 +201,12 @@ arv_get_device_serial_nbr (unsigned int index)
 	return arv_get_info (index, arv_interface_get_device_serial_nbr);
 }
 
+const char *
+arv_get_device_address (unsigned int index)
+{
+	return arv_get_info (index, arv_interface_get_device_address);
+}
+
 /**
  * arv_open_device:
  * @device_id: (allow-none): a device identifier string

--- a/src/arvsystem.h
+++ b/src/arvsystem.h
@@ -42,6 +42,7 @@ const char * 		arv_get_device_id 		(unsigned int index);
 const char * 		arv_get_device_vendor	 	(unsigned int index);
 const char * 		arv_get_device_model	 	(unsigned int index);
 const char * 		arv_get_device_serial_nbr 	(unsigned int index);
+const char * 		arv_get_device_address 	(unsigned int index);
 
 ArvDevice * 		arv_open_device 		(const char *device_id);
 

--- a/src/arvtool.c
+++ b/src/arvtool.c
@@ -216,12 +216,15 @@ arv_tool_execute_command (int argc, char **argv, const char *device_name)
 }
 
 static char *arv_option_device_name = NULL;
+static char *arv_option_device_address = NULL;
 static char *arv_option_debug_domains = NULL;
 
 static const GOptionEntry arv_option_entries[] =
 {
 	{ "name",		'n', 0, G_OPTION_ARG_STRING,
 		&arv_option_device_name,	NULL, "<device_name>"},
+	{ "address",	'a', 0, G_OPTION_ARG_STRING,
+		&arv_option_device_address,	NULL, "<device_address>"},
 	{ "debug", 		'd', 0, G_OPTION_ARG_STRING,
 		&arv_option_debug_domains, 	NULL, "<category>[:<level>][,...]" },
 	{ NULL }
@@ -256,6 +259,7 @@ main (int argc, char **argv)
 	unsigned int n_devices;
 	unsigned int i;
 	unsigned int count = 0;
+	unsigned int use_ip_addr = 0;
 
 	arv_g_thread_init (NULL);
 	arv_g_type_init ();
@@ -279,6 +283,10 @@ main (int argc, char **argv)
 	arv_update_device_list ();
 	n_devices = arv_get_n_devices ();
 
+	if (arv_option_device_address != NULL) {
+		use_ip_addr = 1;
+		pattern = g_pattern_spec_new (arv_option_device_address);
+	} else
 	if (arv_option_device_name != NULL)
 		pattern = g_pattern_spec_new (arv_option_device_name);
 	else
@@ -287,12 +295,15 @@ main (int argc, char **argv)
 	for (i = 0; i < n_devices; i++) {
 		const char *device_id;
 
-		device_id = arv_get_device_id (i);
+		const char *id_ = arv_get_device_id (i);
+		const char *addr_ = arv_get_device_address (i);
+
+		device_id = use_ip_addr ? addr_ : id_;
 
 		if (g_pattern_match_string (pattern, device_id)) {
-			printf ("%s\n", device_id);
+			printf ("%s, %s\n", id_, addr_);
 			if (argc >= 2)
-				arv_tool_execute_command (argc, argv, device_id);
+				arv_tool_execute_command (argc, argv, id_);
 			count++;
 		}
 	}

--- a/src/arvtool.c
+++ b/src/arvtool.c
@@ -286,8 +286,7 @@ main (int argc, char **argv)
 	if (arv_option_device_address != NULL) {
 		use_ip_addr = 1;
 		pattern = g_pattern_spec_new (arv_option_device_address);
-	} else
-	if (arv_option_device_name != NULL)
+	} else if (arv_option_device_name != NULL)
 		pattern = g_pattern_spec_new (arv_option_device_name);
 	else
 		pattern = g_pattern_spec_new ("*");
@@ -295,15 +294,15 @@ main (int argc, char **argv)
 	for (i = 0; i < n_devices; i++) {
 		const char *device_id;
 
-		const char *id_ = arv_get_device_id (i);
-		const char *addr_ = arv_get_device_address (i);
+		const char *id = arv_get_device_id (i);
+		const char *addr = arv_get_device_address (i);
 
-		device_id = use_ip_addr ? addr_ : id_;
+		device_id = use_ip_addr ? addr : id;
 
 		if (g_pattern_match_string (pattern, device_id)) {
-			printf ("%s, %s\n", id_, addr_);
+			printf ("%s (%s)\n", id, addr);
 			if (argc >= 2)
-				arv_tool_execute_command (argc, argv, id_);
+				arv_tool_execute_command (argc, argv, id);
 			count++;
 		}
 	}


### PR DESCRIPTION
Small update to allow controlling cameras by their IP addresses. This update makes arv-tool  more friendly if several cameras are connected to the network.

> ~/aravis$ arv-tool-0.6 
> The Imaging Source Europe GmbH-29510168, 192.168.1.81
> The Imaging Source Europe GmbH-29510170, 192.168.1.80

> ~/aravis$ arv-tool-0.6 control  GevSCPSPacketSize
> The Imaging Source Europe GmbH-29510168, 192.168.1.81
> GevSCPSPacketSize = 2984 (min:576;max:2984)
> The Imaging Source Europe GmbH-29510170, 192.168.1.80
> GevSCPSPacketSize = 1500 (min:576;max:2984)

> ~/aravis$ arv-tool-0.6 -a 192.168.1.80 control GevSCPSPacketSize=9000
> The Imaging Source Europe GmbH-29510170, 192.168.1.80
> GevSCPSPacketSize = 2984 (min:576;max:2984)

