### PR TITLE
Updated the required version of glib

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -84,7 +84,7 @@ AC_ARG_ENABLE(fast_heartbeat,
 
 PKG_PROG_PKG_CONFIG([0.14])
 
-ARAVIS_REQUIREMENTS="glib-2.0 >= 2.26 gobject-2.0 gio-2.0 libxml-2.0 gthread-2.0"
+ARAVIS_REQUIREMENTS="glib-2.0 >= 2.34 gobject-2.0 gio-2.0 libxml-2.0 gthread-2.0"
 ARAVIS_USB_REQUIREMENTS="libusb-1.0"
 ARAVIS_PACKET_SOCKET_REQUIREMENTS="audit libcap-ng"
 ARAVIS_GSTREAMER_REQUIREMENTS="gstreamer-base-1.0 gstreamer-app-1.0"

--- a/configure.ac
+++ b/configure.ac
@@ -84,7 +84,7 @@ AC_ARG_ENABLE(fast_heartbeat,
 
 PKG_PROG_PKG_CONFIG([0.14])
 
-ARAVIS_REQUIREMENTS="glib-2.0 >= 2.34 gobject-2.0 gio-2.0 libxml-2.0 gthread-2.0"
+ARAVIS_REQUIREMENTS="glib-2.0 >= 2.26 gobject-2.0 gio-2.0 libxml-2.0 gthread-2.0"
 ARAVIS_USB_REQUIREMENTS="libusb-1.0"
 ARAVIS_PACKET_SOCKET_REQUIREMENTS="audit libcap-ng"
 ARAVIS_GSTREAMER_REQUIREMENTS="gstreamer-base-1.0 gstreamer-app-1.0"

--- a/src/arvevaluator.c
+++ b/src/arvevaluator.c
@@ -864,7 +864,7 @@ parse_to_stacks (ArvEvaluator *evaluator, char *expression, ArvEvaluatorParserSt
 		token = arv_get_next_token (&expression, state->previous_token);
 		if (token != NULL) {
 			if (arv_evaluator_token_is_variable (token)) {
-				if (g_hash_table_contains (evaluator->priv->constants, token->data.name)) {
+				if (g_hash_table_lookup_extended (evaluator->priv->constants, token->data.name, NULL, NULL)) {
 					const char *constant;
 
 					constant = g_hash_table_lookup (evaluator->priv->constants, token->data.name);
@@ -878,7 +878,7 @@ parse_to_stacks (ArvEvaluator *evaluator, char *expression, ArvEvaluatorParserSt
 						status = ARV_EVALUATOR_STATUS_UNKNOWN_CONSTANT;
 						goto CLEANUP;
 					}
-				} else if (g_hash_table_contains (evaluator->priv->sub_expressions, token->data.name)) {
+				} else if (g_hash_table_lookup_extended (evaluator->priv->sub_expressions, token->data.name, NULL, NULL)) {
 					const char *sub_expression;
 
 					sub_expression = g_hash_table_lookup (evaluator->priv->sub_expressions, token->data.name);

--- a/src/arvgvdevice.c
+++ b/src/arvgvdevice.c
@@ -646,7 +646,7 @@ arv_gv_device_auto_packet_size (ArvGvDevice *gv_device)
 		}
 	} while ((max_size - min_size) > 16);
 
-	g_clear_pointer (&buffer, g_free);
+	arv_g_clear_pointer (&buffer, g_free);
 	g_clear_object (&socket);
 
 	arv_debug_device ("[GvDevice::auto_packet_size] Packet size set to %d bytes", packet_size);

--- a/src/arvmisc.h
+++ b/src/arvmisc.h
@@ -106,6 +106,31 @@ ArvPixelFormat 	arv_pixel_format_from_gst_0_10_caps 		(const char *name, int bpp
 
 #endif
 
+#if GLIB_CHECK_VERSION(2,34,0)
+
+#define arv_g_clear_pointer(pp, destroy) arv_g_clear_pointer(pp, destroy)
+
+#else
+
+#define arv_g_clear_pointer(pp, destroy)                                   \
+  G_STMT_START {                                                               \
+    G_STATIC_ASSERT (sizeof *(pp) == sizeof (gpointer));                       \
+    /* Only one access, please */                                              \
+    gpointer *_pp = (gpointer *) (pp);                                         \
+    gpointer _p;                                                               \
+    /* This assignment is needed to avoid a gcc warning */                     \
+    GDestroyNotify _destroy = (GDestroyNotify) (destroy);                      \
+                                                                               \
+    _p = *_pp;                                                                 \
+    if (_p)                                                                    \
+      {                                                                        \
+        *_pp = NULL;                                                           \
+        _destroy (_p);                                                         \
+      }                                                                        \
+  } G_STMT_END
+
+#endif
+
 G_END_DECLS
 
 #endif

--- a/src/arvmisc.h
+++ b/src/arvmisc.h
@@ -108,7 +108,7 @@ ArvPixelFormat 	arv_pixel_format_from_gst_0_10_caps 		(const char *name, int bpp
 
 #if GLIB_CHECK_VERSION(2,34,0)
 
-#define arv_g_clear_pointer(pp, destroy) arv_g_clear_pointer(pp, destroy)
+#define arv_g_clear_pointer(pp, destroy) g_clear_pointer(pp, destroy)
 
 #else
 

--- a/src/arvuvdevice.c
+++ b/src/arvuvdevice.c
@@ -616,9 +616,9 @@ arv_uv_device_finalize (GObject *object)
 
 	g_object_unref (uv_device->priv->genicam);
 
-	g_clear_pointer (&uv_device->priv->vendor, g_free);
-	g_clear_pointer (&uv_device->priv->product, g_free);
-	g_clear_pointer (&uv_device->priv->serial_nbr, g_free);
+	arv_g_clear_pointer (&uv_device->priv->vendor, g_free);
+	arv_g_clear_pointer (&uv_device->priv->product, g_free);
+	arv_g_clear_pointer (&uv_device->priv->serial_nbr, g_free);
 	if (uv_device->priv->usb_device != NULL) {
 		libusb_release_interface (uv_device->priv->usb_device, 0);
 		libusb_close (uv_device->priv->usb_device);

--- a/src/arvuvinterface.c
+++ b/src/arvuvinterface.c
@@ -96,11 +96,11 @@ arv_uv_interface_device_infos_unref (ArvUvInterfaceDeviceInfos *infos)
 	g_return_if_fail (g_atomic_int_get (&infos->ref_count) > 0);
 
 	if (g_atomic_int_dec_and_test (&infos->ref_count)) {
-		g_clear_pointer (&infos->name, g_free);
-		g_clear_pointer (&infos->manufacturer, g_free);
-		g_clear_pointer (&infos->product, g_free);
-		g_clear_pointer (&infos->serial_nbr, g_free);
-		g_clear_pointer (&infos, g_free);
+		arv_g_clear_pointer (&infos->name, g_free);
+		arv_g_clear_pointer (&infos->manufacturer, g_free);
+		arv_g_clear_pointer (&infos->product, g_free);
+		arv_g_clear_pointer (&infos->serial_nbr, g_free);
+		arv_g_clear_pointer (&infos, g_free);
 	}
 }
 

--- a/tests/realtimetest.c
+++ b/tests/realtimetest.c
@@ -26,6 +26,7 @@
 
 #include <arv.h>
 
+#include <sched.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
glib-2.0 > 2.34 is required as g_clear_pointer() is used.
https://developer.gnome.org/glib/stable/glib-Memory-Allocation.html#g-clear-pointer