### PR TITLE
Feature/usb3 ximea

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,22 @@ Compilation options may be passed to the configure script. Please run `./configu
 
 On some platforms (like Ubuntu), you may have to configure the dynamic linker (ld) to let it know where the aravis libraries are installed, and run ldconfig as root in order to update ld cache.
 
+#### Building on Mac OS X
+
+Using the GNU build system on Mac OS X is not directly supported, but can be mimicked by augmenting the install procedure above with some environment settings:
+
+```brew install intltool
+brew link --force gettext
+aclocal
+autoconf
+autoheader
+glibtoolize --copy
+automake --add-missing
+./configure
+make
+make install
+```
+
 ### Ethernet Device Performance
 
 #### Stream Packet Size

--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ On some platforms (like Ubuntu), you may have to configure the dynamic linker (l
 
 Using the GNU build system on Mac OS X is not directly supported, but can be mimicked by augmenting the install procedure above with some environment settings:
 
-```brew install intltool
+```
+brew install intltool
 brew link --force gettext
 aclocal
 autoconf

--- a/src/arvcamera.c
+++ b/src/arvcamera.c
@@ -60,6 +60,7 @@
  * @ARV_CAMERA_VENDOR_PROSILICA: Prosilica
  * @ARV_CAMERA_VENDOR_TIS: The Imaging Source
  * @ARV_CAMERA_VENDOR_POINT_GREY: PointGrey
+ * @ARV_CAMERA_VENDOR_XIMEA: XIMEA Gmbh
  */
 
 typedef enum {
@@ -69,7 +70,8 @@ typedef enum {
 	ARV_CAMERA_VENDOR_PROSILICA,
 	ARV_CAMERA_VENDOR_TIS,
 	ARV_CAMERA_VENDOR_POINT_GREY,
-	ARV_CAMERA_VENDOR_RICOH
+	ARV_CAMERA_VENDOR_RICOH,
+	ARV_CAMERA_VENDOR_XIMEA
 } ArvCameraVendor;
 
 typedef enum {
@@ -81,7 +83,8 @@ typedef enum {
 	ARV_CAMERA_SERIES_PROSILICA,
 	ARV_CAMERA_SERIES_TIS,
 	ARV_CAMERA_SERIES_POINT_GREY,
-	ARV_CAMERA_SERIES_RICOH
+	ARV_CAMERA_SERIES_RICOH,
+	ARV_CAMERA_SERIES_XIMEA
 } ArvCameraSeries;
 
 static GObjectClass *parent_class = NULL;
@@ -643,7 +646,6 @@ void
 arv_camera_start_acquisition (ArvCamera *camera)
 {
 	g_return_if_fail (ARV_IS_CAMERA (camera));
-
 	arv_device_execute_command (camera->priv->device, "AcquisitionStart");
 }
 
@@ -841,6 +843,7 @@ arv_camera_set_frame_rate (ArvCamera *camera, double frame_rate)
 			break;
 		case ARV_CAMERA_VENDOR_DALSA:
 		case ARV_CAMERA_VENDOR_RICOH:
+	        case ARV_CAMERA_VENDOR_XIMEA:
 		case ARV_CAMERA_VENDOR_UNKNOWN:
 			arv_device_set_string_feature_value (camera->priv->device, "TriggerSelector", "FrameStart");
 			arv_device_set_string_feature_value (camera->priv->device, "TriggerMode", "Off");
@@ -888,7 +891,9 @@ arv_camera_get_frame_rate (ArvCamera *camera)
 		case ARV_CAMERA_VENDOR_DALSA:
 		case ARV_CAMERA_VENDOR_RICOH:
 		case ARV_CAMERA_VENDOR_BASLER:
-		case ARV_CAMERA_VENDOR_UNKNOWN:
+	        case ARV_CAMERA_VENDOR_XIMEA:
+	        case ARV_CAMERA_VENDOR_UNKNOWN:
+		
 			return arv_device_get_float_feature_value (camera->priv->device,
 								   camera->priv->has_acquisition_frame_rate ?
 								   "AcquisitionFrameRate":
@@ -954,6 +959,7 @@ arv_camera_get_frame_rate_bounds (ArvCamera *camera, double *min, double *max)
 		case ARV_CAMERA_VENDOR_DALSA:
 		case ARV_CAMERA_VENDOR_RICOH:
 		case ARV_CAMERA_VENDOR_BASLER:
+	        case ARV_CAMERA_VENDOR_XIMEA:
 		case ARV_CAMERA_VENDOR_UNKNOWN:
 			arv_device_get_float_feature_bounds (camera->priv->device,
 							     camera->priv->has_acquisition_frame_rate ?
@@ -1091,6 +1097,12 @@ arv_camera_set_exposure_time (ArvCamera *camera, double exposure_time_us)
 			arv_device_set_integer_feature_value (camera->priv->device, "ExposureTimeRaw",
 							    exposure_time_us);
 			break;
+	case ARV_CAMERA_SERIES_XIMEA:
+	  
+	  arv_device_set_integer_feature_value (camera->priv->device, "ExposureTime",
+						(guint32)exposure_time_us);
+	  break;
+	  
 		case ARV_CAMERA_SERIES_BASLER_ACE:
 		default:
 			arv_device_set_float_feature_value (camera->priv->device,
@@ -1116,6 +1128,9 @@ arv_camera_get_exposure_time (ArvCamera *camera)
 	g_return_val_if_fail (ARV_IS_CAMERA (camera), 0.0);
 
 	switch (camera->priv->series) {
+	case ARV_CAMERA_SERIES_XIMEA:
+	  return arv_device_get_integer_feature_value (camera->priv->device,"ExposureTime");
+
 		case ARV_CAMERA_SERIES_RICOH:
 			return arv_device_get_integer_feature_value (camera->priv->device,"ExposureTimeRaw");
 		default:
@@ -1388,6 +1403,7 @@ arv_camera_is_frame_rate_available (ArvCamera *camera)
 		case ARV_CAMERA_VENDOR_DALSA:
 		case ARV_CAMERA_VENDOR_RICOH:
 		case ARV_CAMERA_VENDOR_BASLER:
+	        case ARV_CAMERA_VENDOR_XIMEA:
 		case ARV_CAMERA_VENDOR_UNKNOWN:
 			return arv_device_get_feature (camera->priv->device,
 						       camera->priv->has_acquisition_frame_rate ?
@@ -1950,6 +1966,9 @@ arv_camera_constructor (GType gtype, guint n_properties, GObjectConstructParam *
 	} else if (g_strcmp0 (vendor_name, "Ricoh Company, Ltd.") == 0) {
 		vendor = ARV_CAMERA_VENDOR_RICOH;
 		series = ARV_CAMERA_SERIES_RICOH;
+	} else if (g_strcmp0 (vendor_name, "XIMEA GmbH") == 0) {
+		vendor = ARV_CAMERA_VENDOR_XIMEA;
+		series = ARV_CAMERA_SERIES_XIMEA;
 	} else {
 		vendor = ARV_CAMERA_VENDOR_UNKNOWN;
 		series = ARV_CAMERA_SERIES_UNKNOWN;

--- a/src/arvcamera.c
+++ b/src/arvcamera.c
@@ -1978,7 +1978,17 @@ arv_camera_constructor (GType gtype, guint n_properties, GObjectConstructParam *
 	camera->priv->series = series;
 
 	camera->priv->has_gain = ARV_IS_GC_FLOAT (arv_device_get_feature (camera->priv->device, "Gain"));
-	camera->priv->has_exposure_time = ARV_IS_GC_FLOAT (arv_device_get_feature (camera->priv->device, "ExposureTime"));
+
+	switch (vendor)
+	{
+	  case ARV_CAMERA_VENDOR_XIMEA:
+	    camera->priv->has_exposure_time = ARV_IS_GC_INTEGER(arv_device_get_feature (camera->priv->device, "ExposureTime"));
+	    break;
+	    default:
+	      camera->priv->has_exposure_time = ARV_IS_GC_FLOAT (arv_device_get_feature (camera->priv->device, "ExposureTime"));
+	    break; 
+	}
+	
 	camera->priv->has_acquisition_frame_rate = ARV_IS_GC_FLOAT (arv_device_get_feature (camera->priv->device,
 											    "AcquisitionFrameRate"));
 

--- a/src/arvcamera.h
+++ b/src/arvcamera.h
@@ -152,6 +152,13 @@ guint		arv_camera_gv_auto_packet_size		(ArvCamera *camera);
 
 void 		arv_camera_gv_set_stream_options 	(ArvCamera *camera, ArvGvStreamOption options);
 
+/* USB3Vision-specific API */
+gboolean        arv_camera_is_uv_device                 (ArvCamera *camera);
+gboolean        arv_camera_uv_is_bandwidth_control_available (ArvCamera *camera);
+void            arv_camera_uv_set_bandwidth             (ArvCamera *camera, guint bandwidth);
+guint           arv_camera_uv_get_bandwidth             (ArvCamera *camera);
+void            arv_camera_uv_get_bandwidth_bounds      (ArvCamera *camera, guint* min, guint* max);
+
 /* Chunk data */
 
 void 			arv_camera_set_chunk_mode 	(ArvCamera *camera, gboolean is_active);

--- a/src/arvchunkparser.c
+++ b/src/arvchunkparser.c
@@ -56,7 +56,7 @@ enum {
 	ARV_CHUNK_PARSER_PROPERTY_0,
 	ARV_CHUNK_PARSER_PROPERTY_GENICAM,
 	ARV_CHUNK_PARSER_PROPERTY_LAST
-} ArvStreamProperties;
+} ArvChunkParserProperties;
 
 static GObjectClass *parent_class = NULL;
 

--- a/src/arvenums.h
+++ b/src/arvenums.h
@@ -48,6 +48,12 @@ typedef enum {
 	ARV_GC_CACHABLE_WRITE_AROUND
 } ArvGcCachable;
 
+typedef enum {
+  ARV_UV_ENDPOINT_CONTROL,
+  ARV_UV_ENDPOINT_DATA
+} ArvUvEndpointType;
+
+
 /**
  * ArvAuto:
  * @ARV_AUTO_OFF: manual setting

--- a/src/arvfakecamera.c
+++ b/src/arvfakecamera.c
@@ -414,7 +414,7 @@ arv_get_fake_camera_genicam_xml (size_t *size)
 			filename = g_build_filename (ARAVIS_DATA_DIR, "arv-fake-camera.xml", NULL);
 		else
 			filename = g_strdup (arv_fake_camera_genicam_filename);
-
+		
 		genicam_file = g_mapped_file_new (filename, FALSE, NULL);
 
 		if (genicam_file != NULL) {
@@ -469,8 +469,7 @@ arv_fake_camera_new (const char *serial_number)
 	strcpy (((char *) memory) + ARV_GVBS_DEVICE_VERSION_OFFSET, PACKAGE_VERSION);
 	strcpy (((char *) memory) + ARV_GVBS_SERIAL_NUMBER_OFFSET, serial_number);
 
-	xml_url = g_strdup_printf ("Local:arv-fake-camera-%s.xml;%x;%x",
-				   PACKAGE_VERSION,
+	xml_url = g_strdup_printf ("Local:arv-fake-camera.xml;%x;%x",
 				   ARV_FAKE_CAMERA_MEMORY_SIZE,
 				   (unsigned int) fake_camera->priv->genicam_xml_size);
 	strcpy (((char *) memory) + ARV_GVBS_XML_URL_0_OFFSET, xml_url);

--- a/src/arvfakegvcamera.c
+++ b/src/arvfakegvcamera.c
@@ -208,6 +208,7 @@ arv_fake_gv_camera_new (const char *interface_name)
 	g_return_val_if_fail (interface_name != NULL, NULL);
 
 	gv_camera = g_new0 (ArvFakeGvCamera, 1);
+
 	gv_camera->camera = arv_fake_camera_new ("GV01");
 
 	return_value = getifaddrs (&ifap);
@@ -446,6 +447,7 @@ handle_control_packet (ArvFakeGvCamera *gv_camera, GSocket *socket,
 
 static char *arv_option_interface_name = "lo";
 static char *arv_option_debug_domains = NULL;
+static char *arv_option_genicam_file = "arv-fake-camera.xml";
 
 static const GOptionEntry arv_option_entries[] =
 {
@@ -453,6 +455,8 @@ static const GOptionEntry arv_option_entries[] =
 		&arv_option_interface_name,	"Listening interface name", "interface_id"},
 	{ "debug", 		'd', 0, G_OPTION_ARG_STRING,
 		&arv_option_debug_domains, 	NULL, "category[:level][,...]" },
+	{ "genicam",            'f', 0, G_OPTION_ARG_STRING,
+	        &arv_option_genicam_file, "Genicam file to use", "arv-fake-camera.xml"},
 	{ NULL }
 };
 
@@ -484,6 +488,10 @@ main (int argc, char **argv)
 
 	arv_debug_enable (arv_option_debug_domains);
 
+	//Set the genicam file to use (declared as a static global in arvfakecamera.c
+
+	arv_set_fake_camera_genicam_filename(arv_option_genicam_file);
+	
 	gv_camera = arv_fake_gv_camera_new (arv_option_interface_name);
 	if (gv_camera == NULL) {
 		g_print ("Can't instantiate a new fake camera.\n");

--- a/src/arvgvdevice.c
+++ b/src/arvgvdevice.c
@@ -36,12 +36,39 @@
 #include <arvenumtypes.h>
 #include <string.h>
 #include <stdlib.h>
+#ifndef __APPLE__
 #include <linux/ip.h>
+#endif
 #include <netinet/udp.h>
 
 static GObjectClass *parent_class = NULL;
 
 /* Shared data (main thread - heartbeat) */
+
+#ifdef __APPLE__
+struct iphdr
+  {
+#if __BYTE_ORDER == __LITTLE_ENDIAN
+    unsigned int ihl:4;
+    unsigned int version:4;
+#elif __BYTE_ORDER == __BIG_ENDIAN
+    unsigned int version:4;
+    unsigned int ihl:4;
+#else
+# error  "Please fix <bits/endian.h>"
+#endif
+    u_int8_t tos;
+    u_int16_t tot_len;
+    u_int16_t id;
+    u_int16_t frag_off;
+    u_int8_t ttl;
+    u_int8_t protocol;
+    u_int16_t check;
+    u_int32_t saddr;
+    u_int32_t daddr;
+    /*The options start here. */
+  };
+#endif
 
 typedef struct {
 #if GLIB_CHECK_VERSION(2,32,0)
@@ -629,7 +656,7 @@ arv_gv_device_auto_packet_size (ArvGvDevice *gv_device)
 				else
 					read_count = 0;
 			/* Discard late packets, read_count should be equal to packet size minus IP and UDP headers */
-			} while (n_events != 0 && read_count != (current_size - sizeof (struct iphdr) - sizeof (struct udphdr)));
+            } while (n_events != 0 && read_count != (current_size - sizeof (struct iphdr) - sizeof (struct udphdr)));
 
 			n_tries++;
 		} while (n_events == 0 && n_tries < 3);

--- a/src/arvuvcp.h
+++ b/src/arvuvcp.h
@@ -137,7 +137,7 @@ typedef struct ARAVIS_PACKED_STRUCTURE {
 
 typedef struct ARAVIS_PACKED_STRUCTURE {
 	guint64 address;
-	guint16 unknown;
+        guint16 unknown; //Listed as reserved, always 0
 	guint16 size;
 } ArvUvcpReadMemoryCmdInfos;
 
@@ -189,7 +189,10 @@ typedef struct ARAVIS_PACKED_STRUCTURE {
 } ArvUvcpPacket;
 
 typedef struct ARAVIS_PACKED_STRUCTURE {
-	guint64 unknown0;
+  guint16 file_version_subminor;
+  guint8 file_version_minor;
+  guint8 file_version_major;
+  guint32 schema;
 	guint64 address;
 	guint64 size;
 	guint64 unknown3;
@@ -199,6 +202,30 @@ typedef struct ARAVIS_PACKED_STRUCTURE {
 	guint64 unknown7;
 } ArvUvcpManifestEntry;
 
+//This is packed into the 32-bit schema type as bits 10-15
+typedef enum
+  {
+    ARV_UVCP_SCHEMA_RAW = 0x0,
+    ARV_UVCP_SCHEMA_ZIP = 0x1
+  }
+  ArvUvcpManifestSchemaType;
+
+static inline ArvUvcpManifestSchemaType arv_uvcp_packet_get_schema_type(guint32 schemaType)
+{
+  guint32 shifted = schemaType >> 10;
+  guint32 masked = shifted & 0x0000001f;
+
+  switch (masked)
+    {
+    case ARV_UVCP_SCHEMA_RAW:
+      return ARV_UVCP_SCHEMA_RAW;
+    case ARV_UVCP_SCHEMA_ZIP:
+      return ARV_UVCP_SCHEMA_ZIP;
+    default:
+      arv_debug_device("Unknown GenICam storage schema type: 0x%x", masked);
+      return 0;
+    }
+}
 #undef ARAVIS_PACKED_STRUCTURE
 
 void 			arv_uvcp_packet_free 			(ArvUvcpPacket *packet);

--- a/src/arvuvdevice.c
+++ b/src/arvuvdevice.c
@@ -51,13 +51,14 @@ struct _ArvUvDevicePrivate {
 
 	const char *genicam_xml;
 	size_t genicam_xml_size;
-
+  
 	guint16 packet_id;
 
 	guint timeout_ms;
 	guint cmd_packet_size_max;
 	guint ack_packet_size_max;
-
+        guint8 control_endpoint;
+        guint8 data_endpoint;
 	gboolean disconnected;
 };
 
@@ -66,7 +67,7 @@ struct _ArvUvDevicePrivate {
 /* ArvUvDevice implementation */
 
 gboolean
-arv_uv_device_bulk_transfer (ArvUvDevice *uv_device, unsigned char endpoint, void *data,
+arv_uv_device_bulk_transfer (ArvUvDevice *uv_device, ArvUvEndpointType endpoint_type, unsigned char endpoint_flags, void *data,
 			     size_t size, size_t *transferred_size, guint32 timeout_ms, GError **error)
 {
 	gboolean success;
@@ -83,8 +84,10 @@ arv_uv_device_bulk_transfer (ArvUvDevice *uv_device, unsigned char endpoint, voi
 		return FALSE;
 	}
 
-	//printf("Requesting %d bytes:", size);
-	result = libusb_bulk_transfer (uv_device->priv->usb_device, endpoint, data, size, &transferred,
+	
+	guint8 endpoint = ((endpoint_type == ARV_UV_ENDPOINT_CONTROL) ? uv_device->priv->control_endpoint : uv_device->priv->data_endpoint);
+	//printf("Requesting %d bytes on endpoint %d\n", size, endpoint);
+	result = libusb_bulk_transfer (uv_device->priv->usb_device, endpoint | endpoint_flags, data, size, &transferred,
 				       MAX (uv_device->priv->timeout_ms, timeout_ms));
 	//printf("Received %d bytes\n", transferred);
 	
@@ -152,14 +155,14 @@ _read_memory (ArvUvDevice *uv_device, guint32 address, guint32 size, void *buffe
 		arv_uvcp_packet_debug (packet, ARV_DEBUG_LEVEL_LOG);
 
 		success = TRUE;
-		success = success && arv_uv_device_bulk_transfer (uv_device, (0x02 | LIBUSB_ENDPOINT_OUT),
+		success = success && arv_uv_device_bulk_transfer (uv_device, ARV_UV_ENDPOINT_CONTROL, LIBUSB_ENDPOINT_OUT,
 								  packet, packet_size, NULL, 0, NULL);
 		if (success) {
 			gboolean expected_answer;
 
 			do {
 				success = TRUE;
-				success = success && arv_uv_device_bulk_transfer (uv_device, (0x82 | LIBUSB_ENDPOINT_IN),
+				success = success && arv_uv_device_bulk_transfer (uv_device, ARV_UV_ENDPOINT_CONTROL, LIBUSB_ENDPOINT_IN,
 										  read_packet, read_packet_size, &transferred,
 										  0, NULL);
 
@@ -267,14 +270,14 @@ _write_memory (ArvUvDevice *uv_device, guint32 address, guint32 size, void *buff
 		arv_uvcp_packet_debug (packet, ARV_DEBUG_LEVEL_LOG);
 
 		success = TRUE;
-		success = success && arv_uv_device_bulk_transfer (uv_device, (0x02 | LIBUSB_ENDPOINT_OUT),
+		success = success && arv_uv_device_bulk_transfer (uv_device, ARV_UV_ENDPOINT_CONTROL, LIBUSB_ENDPOINT_OUT,
 								  packet, packet_size, NULL, 0, NULL);
 		if (success ) {
 			gboolean expected_answer;
 
 			do {
 				success = TRUE;
-				success = success && arv_uv_device_bulk_transfer (uv_device, (0x82 | LIBUSB_ENDPOINT_IN),
+				success = success && arv_uv_device_bulk_transfer (uv_device, ARV_UV_ENDPOINT_CONTROL, LIBUSB_ENDPOINT_IN,
 										  read_packet, read_packet_size, &transferred,
 										  timeout_ms, NULL);
 
@@ -576,6 +579,27 @@ _open_usb_device (ArvUvDevice *uv_device)
 
 
 				uv_device->priv->usb_device = usb_device;
+				//Assign the endpoint while the libusb device handle is handy
+				struct libusb_config_descriptor *config;
+				libusb_get_active_config_descriptor(devices[i], &config);
+
+				
+				//Get the first endpoint of the first interface, strip the direction bits
+				//the control interface is bidirectional -> both IN and OUT endpoints
+				struct libusb_interface_descriptor interface = config->interface[0].altsetting[0];
+				struct libusb_endpoint_descriptor endpoint = interface.endpoint[0];
+
+				uv_device->priv->control_endpoint = endpoint.bEndpointAddress & 0x0f; //mask off reserved / direction
+
+
+				//Get the first endpoint of the second interface, strip the direction bits
+				//the data interface is one-way -> only an IN endpoint
+				interface = config->interface[1].altsetting[0];
+				endpoint = interface.endpoint[0];
+				
+				uv_device->priv->data_endpoint = 1; //endpoint.bEndpointAddress & 0x0f; //mask off reserved / direction
+				
+				libusb_free_config_descriptor(config);
 			} else
 				libusb_close (usb_device);
 
@@ -611,7 +635,9 @@ arv_uv_device_new (const char *vendor, const char *product, const char *serial_n
 	uv_device->priv->timeout_ms = 32;
 
 	_open_usb_device (uv_device);
-
+	arv_debug_device("[UvDevice::new] Using control endpoint %d", uv_device->priv->control_endpoint);
+	arv_debug_device("[UvDevice::new] Using data endpoint %d", uv_device->priv->data_endpoint);
+	
 	if (uv_device->priv->usb_device == NULL ||
 	    libusb_claim_interface (uv_device->priv->usb_device, 0) < 0) {
 		arv_warning_device ("[UvDevice::new] Failed to claim USB interface to '%s - #%s'", product, serial_nbr);

--- a/src/arvuvdevice.c
+++ b/src/arvuvdevice.c
@@ -83,9 +83,11 @@ arv_uv_device_bulk_transfer (ArvUvDevice *uv_device, unsigned char endpoint, voi
 		return FALSE;
 	}
 
-
+	//printf("Requesting %d bytes:", size);
 	result = libusb_bulk_transfer (uv_device->priv->usb_device, endpoint, data, size, &transferred,
 				       MAX (uv_device->priv->timeout_ms, timeout_ms));
+	//printf("Received %d bytes\n", transferred);
+	
 	success = (result >= 0);
 
 	if (!success)

--- a/src/arvuvdeviceprivate.h
+++ b/src/arvuvdeviceprivate.h
@@ -45,7 +45,7 @@ struct _ArvUvDeviceClass {
 	ArvDeviceClass parent_class;
 };
 
-gboolean 	arv_uv_device_bulk_transfer 		(ArvUvDevice *uv_device, unsigned char endpoint, void *data,
+gboolean 	arv_uv_device_bulk_transfer 		(ArvUvDevice *uv_device, ArvUvEndpointType endpoint_type, unsigned char endpoint_flags, void *data,
 							 size_t size, size_t *transferred_size,
 							 guint32 timeout_ms, GError **error);
 

--- a/src/arvuvsp.h
+++ b/src/arvuvsp.h
@@ -139,6 +139,16 @@ arv_uvsp_packet_get_region (ArvUvspPacket *packet, guint32 *width, guint32 *heig
 	*x_offset = GUINT32_FROM_LE (leader->infos.x_offset);
 	*y_offset = GUINT32_FROM_LE (leader->infos.y_offset);
 }
+static inline ArvPixelFormat arv_uvsp_packet_get_pixel_format(ArvUvspPacket *packet)
+{
+  ArvUvspLeader *leader;
+
+  if (packet == NULL)
+    return 0;
+
+  leader = (ArvUvspLeader *)packet;
+  return GUINT32_FROM_LE (leader->infos.pixel_format);
+}
 
 static inline guint64
 arv_uvsp_packet_get_timestamp (ArvUvspPacket *packet)

--- a/src/arvuvstream.c
+++ b/src/arvuvstream.c
@@ -107,7 +107,7 @@ arv_uv_stream_thread (void *data)
 			packet = incoming_buffer;
 
 		arv_debug_stream("Asking for %u bytes", size);		
-		arv_uv_device_bulk_transfer (thread_data->uv_device, (0x81 | LIBUSB_ENDPOINT_IN),
+		arv_uv_device_bulk_transfer (thread_data->uv_device,  ARV_UV_ENDPOINT_DATA, LIBUSB_ENDPOINT_IN,
 					     packet, size, &transferred, 0, NULL);
 
 	

--- a/src/arvuvstream.c
+++ b/src/arvuvstream.c
@@ -106,8 +106,7 @@ arv_uv_stream_thread (void *data)
 		else
 			packet = incoming_buffer;
 
-		//arv_debug_stream("Asking for %u bytes", size);
-		
+		arv_debug_stream("Asking for %u bytes", size);		
 		arv_uv_device_bulk_transfer (thread_data->uv_device, (0x81 | LIBUSB_ENDPOINT_IN),
 					     packet, size, &transferred, 0, NULL);
 

--- a/src/arvuvstream.c
+++ b/src/arvuvstream.c
@@ -58,7 +58,6 @@ typedef struct {
 	size_t trailer_size;
 
 	gboolean cancel;
-  gboolean paused;
 
 	/* Statistics */
 
@@ -86,13 +85,6 @@ arv_uv_stream_thread (void *data)
 
 	offset = 0;
 
-	//Wait for acquisition to actually start
-	/*
-	while (thread_data->paused)
-	  {
-	    g_thread_yield();
-	  }
-	*/
 	while (!thread_data->cancel) {
 		size_t size;
 		transferred = 0;
@@ -282,8 +274,7 @@ arv_uv_stream_new (ArvUvDevice *uv_device, ArvStreamCallback callback, void *use
 	thread_data->callback = callback;
 	thread_data->user_data = user_data;
 	thread_data->cancel = FALSE;
-	thread_data->paused = TRUE;
-	
+
 	thread_data->leader_size = si_req_leader_size;
 	thread_data->payload_size = si_payload_size;
 	thread_data->trailer_size = si_req_trailer_size;
@@ -314,16 +305,6 @@ arv_uv_stream_get_statistics (ArvStream *stream,
 	*n_completed_buffers = thread_data->n_completed_buffers;
 	*n_failures = thread_data->n_failures;
 	*n_underruns = thread_data->n_underruns;
-}
-
-void arv_uv_stream_unpause(GObject *object)
-{
-  ArvUvStream *uv_stream = ARV_UV_STREAM (object);
-  ArvUvStreamThreadData *thread_data;
-
-
-  thread_data = uv_stream->priv->thread_data;
-  thread_data->paused = FALSE;
 }
 
 static void

--- a/src/arvuvstreamprivate.h
+++ b/src/arvuvstreamprivate.h
@@ -47,7 +47,7 @@ struct _ArvUvStreamClass {
 };
 
 ArvStream * 	arv_uv_stream_new	(ArvUvDevice *uv_device, ArvStreamCallback callback, void *user_data);
-void arv_uv_stream_unpause(GObject *object);
+
 G_END_DECLS
 
 #endif

--- a/src/arvuvstreamprivate.h
+++ b/src/arvuvstreamprivate.h
@@ -47,7 +47,7 @@ struct _ArvUvStreamClass {
 };
 
 ArvStream * 	arv_uv_stream_new	(ArvUvDevice *uv_device, ArvStreamCallback callback, void *user_data);
-
+void arv_uv_stream_unpause(GObject *object);
 G_END_DECLS
 
 #endif

--- a/tests/arvcameratest.c
+++ b/tests/arvcameratest.c
@@ -355,8 +355,6 @@ main (int argc, char **argv)
 			}
 
 			arv_camera_start_acquisition (camera);
-			arv_uv_stream_unpause(stream);
- 
 			
 			g_signal_connect (stream, "new-buffer", G_CALLBACK (new_buffer_cb), &data);
 			arv_stream_set_emit_signals (stream, TRUE);

--- a/tests/arvcameratest.c
+++ b/tests/arvcameratest.c
@@ -340,7 +340,7 @@ main (int argc, char **argv)
 				arv_stream_push_buffer (stream, arv_buffer_new (payload, NULL));
 
 			arv_camera_set_acquisition_mode (camera, ARV_ACQUISITION_MODE_CONTINUOUS);
-
+			
 			if (arv_option_frequency > 0.0)
 				arv_camera_set_frame_rate (camera, arv_option_frequency);
 
@@ -355,7 +355,9 @@ main (int argc, char **argv)
 			}
 
 			arv_camera_start_acquisition (camera);
-
+			arv_uv_stream_unpause(stream);
+ 
+			
 			g_signal_connect (stream, "new-buffer", G_CALLBACK (new_buffer_cb), &data);
 			arv_stream_set_emit_signals (stream, TRUE);
 

--- a/tests/arvcameratest.c
+++ b/tests/arvcameratest.c
@@ -26,7 +26,8 @@ static gboolean arv_option_realtime = FALSE;
 static gboolean arv_option_high_priority = FALSE;
 static gboolean arv_option_no_packet_socket = FALSE;
 static char *arv_option_chunks = NULL;
-
+static unsigned int arv_option_bandwidth_limit = -1;
+  
 static const GOptionEntry arv_option_entries[] =
 {
 	{
@@ -120,6 +121,10 @@ static const GOptionEntry arv_option_entries[] =
 	{
 		"debug", 				'd', 0, G_OPTION_ARG_STRING,
 		&arv_option_debug_domains, 		"Debug domains", NULL
+	},
+	{
+		"bandwidth-limit",			'b', 0, G_OPTION_ARG_INT,
+		&arv_option_bandwidth_limit,		"Desired USB3 Vision device bandwidth limit", NULL
 	},
 	{ NULL }
 };
@@ -284,7 +289,10 @@ main (int argc, char **argv)
 		arv_camera_set_binning (camera, arv_option_horizontal_binning, arv_option_vertical_binning);
 		arv_camera_set_exposure_time (camera, arv_option_exposure_time_us);
 		arv_camera_set_gain (camera, arv_option_gain);
-
+		if (arv_camera_is_uv_device(camera))
+		  {
+		    arv_camera_uv_set_bandwidth(camera, arv_option_bandwidth_limit);
+		  }
 		if (arv_camera_is_gv_device (camera)) {
 			arv_camera_gv_select_stream_channel (camera, arv_option_gv_stream_channel);
 			arv_camera_gv_set_packet_delay (camera, arv_option_gv_packet_delay);
@@ -316,6 +324,12 @@ main (int argc, char **argv)
 			printf ("gv current channel    = %d\n", arv_camera_gv_get_current_stream_channel (camera));
 			printf ("gv packet delay       = %" G_GINT64_FORMAT " ns\n", arv_camera_gv_get_packet_delay (camera));
 			printf ("gv packet size        = %d bytes\n", arv_camera_gv_get_packet_size (camera));
+		}
+
+		if (arv_camera_is_uv_device(camera)) {
+		  guint min,max;
+		  arv_camera_uv_get_bandwidth_bounds(camera, &min, &max);
+		  printf("UV Bandwidth limit = %d, (%d,%d)\n", arv_camera_uv_get_bandwidth(camera), min, max);
 		}
 
 		stream = arv_camera_create_stream (camera, stream_cb, NULL);

--- a/tools/wireshark-snapshots/PtGrey-Flea3-USB-Properties.txt
+++ b/tools/wireshark-snapshots/PtGrey-Flea3-USB-Properties.txt
@@ -1,0 +1,136 @@
+
+Bus 006 Device 009: ID 1e10:3300 Point Grey Research, Inc. 
+Device Descriptor:
+  bLength                18
+  bDescriptorType         1
+  bcdUSB               3.00
+  bDeviceClass          239 Miscellaneous Device
+  bDeviceSubClass         2 
+  bDeviceProtocol         1 Interface Association
+  bMaxPacketSize0         9
+  idVendor           0x1e10 Point Grey Research, Inc.
+  idProduct          0x3300 
+  bcdDevice            0.00
+  iManufacturer           1 Point Grey Research
+  iProduct                2 Flea3 FL3-U3-13Y3M
+  iSerial                 3 00D9BC3D
+  bNumConfigurations      1
+  Configuration Descriptor:
+    bLength                 9
+    bDescriptorType         2
+    wTotalLength          116
+    bNumInterfaces          3
+    bConfigurationValue     1
+    iConfiguration          0 
+    bmAttributes         0x80
+      (Bus Powered)
+    MaxPower              224mA
+    Interface Association:
+      bLength                 8
+      bDescriptorType        11
+      bFirstInterface         0
+      bInterfaceCount         3
+      bFunctionClass        239 Miscellaneous Device
+      bFunctionSubClass       5 USB3 Vision
+      bFunctionProtocol       0 
+      iFunction               4 USB3 Vision Device
+    Interface Descriptor:
+      bLength                 9
+      bDescriptorType         4
+      bInterfaceNumber        0
+      bAlternateSetting       0
+      bNumEndpoints           2
+      bInterfaceClass       239 Miscellaneous Device
+      bInterfaceSubClass      5 USB3 Vision
+      bInterfaceProtocol      0 
+      iInterface              0 
+      ** UNRECOGNIZED:  14 24 01 00 00 01 00 00 00 01 00 05 06 07 08 09 0a 0b 0c 0c
+      Endpoint Descriptor:
+        bLength                 7
+        bDescriptorType         5
+        bEndpointAddress     0x02  EP 2 OUT
+        bmAttributes            2
+          Transfer Type            Bulk
+          Synch Type               None
+          Usage Type               Data
+        wMaxPacketSize     0x0400  1x 1024 bytes
+        bInterval               0
+        bMaxBurst               0
+      Endpoint Descriptor:
+        bLength                 7
+        bDescriptorType         5
+        bEndpointAddress     0x82  EP 2 IN
+        bmAttributes            2
+          Transfer Type            Bulk
+          Synch Type               None
+          Usage Type               Data
+        wMaxPacketSize     0x0400  1x 1024 bytes
+        bInterval               0
+        bMaxBurst               0
+    Interface Descriptor:
+      bLength                 9
+      bDescriptorType         4
+      bInterfaceNumber        1
+      bAlternateSetting       0
+      bNumEndpoints           1
+      bInterfaceClass       239 Miscellaneous Device
+      bInterfaceSubClass      5 USB3 Vision
+      bInterfaceProtocol      1 
+      iInterface              0 
+      Endpoint Descriptor:
+        bLength                 7
+        bDescriptorType         5
+        bEndpointAddress     0x83  EP 3 IN
+        bmAttributes            2
+          Transfer Type            Bulk
+          Synch Type               None
+          Usage Type               Data
+        wMaxPacketSize     0x0400  1x 1024 bytes
+        bInterval               0
+        bMaxBurst               0
+    Interface Descriptor:
+      bLength                 9
+      bDescriptorType         4
+      bInterfaceNumber        2
+      bAlternateSetting       0
+      bNumEndpoints           1
+      bInterfaceClass       239 Miscellaneous Device
+      bInterfaceSubClass      5 USB3 Vision
+      bInterfaceProtocol      2 
+      iInterface              0 
+      Endpoint Descriptor:
+        bLength                 7
+        bDescriptorType         5
+        bEndpointAddress     0x81  EP 1 IN
+        bmAttributes            2
+          Transfer Type            Bulk
+          Synch Type               None
+          Usage Type               Data
+        wMaxPacketSize     0x0400  1x 1024 bytes
+        bInterval               0
+        bMaxBurst              15
+Binary Object Store Descriptor:
+  bLength                 5
+  bDescriptorType        15
+  wTotalLength           22
+  bNumDeviceCaps          2
+  USB 2.0 Extension Device Capability:
+    bLength                 7
+    bDescriptorType        16
+    bDevCapabilityType      2
+    bmAttributes   0x00000002
+      HIRD Link Power Management (LPM) Supported
+  SuperSpeed USB Device Capability:
+    bLength                10
+    bDescriptorType        16
+    bDevCapabilityType      3
+    bmAttributes         0x00
+    wSpeedsSupported   0x000c
+      Device can operate at High Speed (480Mbps)
+      Device can operate at SuperSpeed (5Gbps)
+    bFunctionalitySupport   2
+      Lowest fully-functional device speed is High Speed (480Mbps)
+    bU1DevExitLat          10 micro seconds
+    bU2DevExitLat         512 micro seconds
+Device Status:     0x0000
+  (Bus Powered)

--- a/tools/wireshark-snapshots/Ximea-MQ013MG-ON-USB-Properties.txt
+++ b/tools/wireshark-snapshots/Ximea-MQ013MG-ON-USB-Properties.txt
@@ -1,0 +1,136 @@
+
+Bus 006 Device 008: ID 20f7:30b3 XIMEA Camera with CMOS sensor in Vision mode [MQ]
+Device Descriptor:
+  bLength                18
+  bDescriptorType         1
+  bcdUSB               3.10
+  bDeviceClass          239 Miscellaneous Device
+  bDeviceSubClass         2 
+  bDeviceProtocol         1 Interface Association
+  bMaxPacketSize0         9
+  idVendor           0x20f7 XIMEA
+  idProduct          0x30b3 Camera with CMOS sensor in Vision mode [MQ]
+  bcdDevice            0.00
+  iManufacturer           1 XIMEA
+  iProduct                2 xiQ
+  iSerial                10 39310250
+  bNumConfigurations      1
+  Configuration Descriptor:
+    bLength                 9
+    bDescriptorType         2
+    wTotalLength          116
+    bNumInterfaces          3
+    bConfigurationValue     1
+    iConfiguration          0 
+    bmAttributes         0x80
+      (Bus Powered)
+    MaxPower              100mA
+    Interface Association:
+      bLength                 8
+      bDescriptorType        11
+      bFirstInterface         0
+      bInterfaceCount         3
+      bFunctionClass        239 Miscellaneous Device
+      bFunctionSubClass       5 USB3 Vision
+      bFunctionProtocol       0 
+      iFunction               3 USB3 Vision Device
+    Interface Descriptor:
+      bLength                 9
+      bDescriptorType         4
+      bInterfaceNumber        0
+      bAlternateSetting       0
+      bNumEndpoints           2
+      bInterfaceClass       239 Miscellaneous Device
+      bInterfaceSubClass      5 USB3 Vision
+      bInterfaceProtocol      0 
+      iInterface              0 
+      ** UNRECOGNIZED:  14 24 01 00 00 01 00 00 00 01 00 04 05 06 07 08 09 0a 00 0c
+      Endpoint Descriptor:
+        bLength                 7
+        bDescriptorType         5
+        bEndpointAddress     0x02  EP 2 OUT
+        bmAttributes            2
+          Transfer Type            Bulk
+          Synch Type               None
+          Usage Type               Data
+        wMaxPacketSize     0x0400  1x 1024 bytes
+        bInterval               0
+        bMaxBurst               0
+      Endpoint Descriptor:
+        bLength                 7
+        bDescriptorType         5
+        bEndpointAddress     0x82  EP 2 IN
+        bmAttributes            2
+          Transfer Type            Bulk
+          Synch Type               None
+          Usage Type               Data
+        wMaxPacketSize     0x0400  1x 1024 bytes
+        bInterval               0
+        bMaxBurst               0
+    Interface Descriptor:
+      bLength                 9
+      bDescriptorType         4
+      bInterfaceNumber        1
+      bAlternateSetting       0
+      bNumEndpoints           1
+      bInterfaceClass       239 Miscellaneous Device
+      bInterfaceSubClass      5 USB3 Vision
+      bInterfaceProtocol      2 
+      iInterface              0 
+      Endpoint Descriptor:
+        bLength                 7
+        bDescriptorType         5
+        bEndpointAddress     0x81  EP 1 IN
+        bmAttributes            2
+          Transfer Type            Bulk
+          Synch Type               None
+          Usage Type               Data
+        wMaxPacketSize     0x0400  1x 1024 bytes
+        bInterval               0
+        bMaxBurst              15
+    Interface Descriptor:
+      bLength                 9
+      bDescriptorType         4
+      bInterfaceNumber        2
+      bAlternateSetting       0
+      bNumEndpoints           1
+      bInterfaceClass       239 Miscellaneous Device
+      bInterfaceSubClass      5 USB3 Vision
+      bInterfaceProtocol      1 
+      iInterface              0 
+      Endpoint Descriptor:
+        bLength                 7
+        bDescriptorType         5
+        bEndpointAddress     0x83  EP 3 IN
+        bmAttributes            2
+          Transfer Type            Bulk
+          Synch Type               None
+          Usage Type               Data
+        wMaxPacketSize     0x0400  1x 1024 bytes
+        bInterval               0
+        bMaxBurst               0
+Binary Object Store Descriptor:
+  bLength                 5
+  bDescriptorType        15
+  wTotalLength           22
+  bNumDeviceCaps          2
+  USB 2.0 Extension Device Capability:
+    bLength                 7
+    bDescriptorType        16
+    bDevCapabilityType      2
+    bmAttributes   0x00000002
+      HIRD Link Power Management (LPM) Supported
+  SuperSpeed USB Device Capability:
+    bLength                10
+    bDescriptorType        16
+    bDevCapabilityType      3
+    bmAttributes         0x00
+    wSpeedsSupported   0x000c
+      Device can operate at High Speed (480Mbps)
+      Device can operate at SuperSpeed (5Gbps)
+    bFunctionalitySupport   3
+      Lowest fully-functional device speed is SuperSpeed (5Gbps)
+    bU1DevExitLat           0 micro seconds
+    bU2DevExitLat           0 micro seconds
+Device Status:     0x0000
+  (Bus Powered)

--- a/viewer/arvviewer.c
+++ b/viewer/arvviewer.c
@@ -870,7 +870,7 @@ start_video (ArvViewer *viewer)
 	}
 
 	arv_camera_start_acquisition (viewer->camera);
-
+	arv_uv_stream_unpause(viewer->stream);
 	viewer->pipeline = gst_pipeline_new ("pipeline");
 
 	viewer->appsrc = gst_element_factory_make ("appsrc", NULL);

--- a/viewer/arvviewer.c
+++ b/viewer/arvviewer.c
@@ -870,7 +870,6 @@ start_video (ArvViewer *viewer)
 	}
 
 	arv_camera_start_acquisition (viewer->camera);
-	arv_uv_stream_unpause(viewer->stream);
 	viewer->pipeline = gst_pipeline_new ("pipeline");
 
 	viewer->appsrc = gst_element_factory_make ("appsrc", NULL);


### PR DESCRIPTION
Emmanuel, I have access to several Ximea cameras implementing USB3 Vision; I've added support to Aravis to support these cameras, without breaking the Basler support. The particular model I've developed on is part of the XiQ series, MQ013MG-ON. There are several areas of changes that this patch includes:

1. On Ximea cameras, the USB3 endpoint addresses are different than that on the Basler cameras. I've included an attempt at auto-detection for the correct USB endpoints.
2. On Ximea cameras, GenICam is stored as raw XML text, not a zip file. There is a header flag to indicate format that this patch supports.
3. Several of the GenICam features are named differently or have different datatypes; the vendor-specific quirks have been updated to support Ximea. 
4. Mac build support was added. 
5. Pixel format wasn't being reported for USB3 cameras

While this code is usable, there is at least one nagging problem I'm still investigating: the Ximea cameras appear to underrun approx 1% on my four-year old i5, while the underrun rate is much higher on a brand-new laptop, to the point where the camera is unusable. 

I also have a Point Grey Flea3 that I'm working with to make Aravis a more comprehensive solution - thank you for leading this project.
Cheers,
Steve McGuire
University of Colorado at Boulder
