### PR TITLE
fix memory leak in GC feature node

### DIFF
--- a/src/arvgcfeaturenode.c
+++ b/src/arvgcfeaturenode.c
@@ -415,6 +415,10 @@ arv_gc_feature_node_init (ArvGcFeatureNode *gc_feature_node)
 static void
 arv_gc_feature_node_finalize (GObject *object)
 {
+	ArvGcFeatureNode *node = ARV_GC_FEATURE_NODE(object);
+
+	g_free (node->priv->name);
+
 	parent_class->finalize (object);
 }
 


### PR DESCRIPTION
valgrind flags a "definite" leak in arv_gc_feature_node_set_attribute() from g_strdup().  Free this string in feature node's finalize.