### PR TITLE
fake_camera: detect zero frame period

### DIFF
--- a/src/arvfakecamera.c
+++ b/src/arvfakecamera.c
@@ -172,6 +172,11 @@ arv_fake_camera_wait_for_next_frame (ArvFakeCamera *camera)
 								ARV_FAKE_CAMERA_REGISTER_ACQUISITION_FRAME_PERIOD_US) *
 			1000L;
 
+	if (frame_period_time_ns == 0) {
+		arv_warning_misc("Invalid zero frame period, defaulting to 1 second");
+		frame_period_time_ns = 1000000000L;
+	}
+
 	clock_gettime (CLOCK_MONOTONIC, &time);
 	sleep_time_ns = frame_period_time_ns - (((guint64) time.tv_sec * 1000000000L +
 						 (guint64) time.tv_nsec) % frame_period_time_ns);


### PR DESCRIPTION
Otherwise results in SIGFPE if client configures with zero frame rate.

Since zero period isn't likely to be an intended condition (at least it wasn't for me) emit a warning and fallback to 1Hz.
