### PR TITLE
Feature/uv unpause

### DIFF
--- a/src/arvcamera.c
+++ b/src/arvcamera.c
@@ -650,6 +650,15 @@ arv_camera_start_acquisition (ArvCamera *camera)
 {
 	g_return_if_fail (ARV_IS_CAMERA (camera));
 	arv_device_execute_command (camera->priv->device, "AcquisitionStart");
+
+	if (ARV_IS_UV_DEVICE(camera->priv->device))
+	  {
+	    ArvUvDevice *uv_cam;
+	    uv_cam = ARV_UV_DEVICE(camera->priv->device);
+	    ArvUvStream *uv_stream;
+	    uv_stream = arv_uv_device_get_stream(uv_cam);
+	    arv_uv_stream_unpause(uv_stream);
+	  }
 }
 
 /**

--- a/src/arvcamera.c
+++ b/src/arvcamera.c
@@ -38,6 +38,7 @@
  * </example>
  */
 
+#include <arvconfig.h>
 #include <arvcamera.h>
 #include <arvsystem.h>
 #include <arvgvinterface.h>
@@ -52,6 +53,7 @@
 #include <arvgvdevice.h>
 #ifdef ARAVIS_BUILD_USB
 #include <arvuvdevice.h>
+#include <arvuvstream.h>
 #endif
 #include <arvenums.h>
 #include <arvstr.h>
@@ -650,15 +652,15 @@ arv_camera_start_acquisition (ArvCamera *camera)
 {
 	g_return_if_fail (ARV_IS_CAMERA (camera));
 	arv_device_execute_command (camera->priv->device, "AcquisitionStart");
-
-	if (ARV_IS_UV_DEVICE(camera->priv->device))
-	  {
-	    ArvUvDevice *uv_cam;
-	    uv_cam = ARV_UV_DEVICE(camera->priv->device);
-	    ArvUvStream *uv_stream;
-	    uv_stream = arv_uv_device_get_stream(uv_cam);
-	    arv_uv_stream_unpause(uv_stream);
-	  }
+#ifdef ARAVIS_BUILD_USB
+	if (ARV_IS_UV_DEVICE(camera->priv->device)) {
+	        ArvUvDevice *uv_cam;
+	        uv_cam = ARV_UV_DEVICE(camera->priv->device);
+		ArvUvStream *uv_stream;
+		uv_stream = arv_uv_device_get_stream(uv_cam);
+		arv_uv_stream_unpause(uv_stream);
+	}
+#endif
 }
 
 /**

--- a/src/arvuvdevice.c
+++ b/src/arvuvdevice.c
@@ -624,7 +624,7 @@ _open_usb_device (ArvUvDevice *uv_device)
 ArvUvStream*
 arv_uv_device_get_stream (ArvUvDevice* device)
 {
-  return device->priv->stream;
+        return device->priv->stream;
 }
 
 ArvDevice *

--- a/src/arvuvdevice.c
+++ b/src/arvuvdevice.c
@@ -61,6 +61,8 @@ struct _ArvUvDevicePrivate {
         guint8 control_endpoint;
         guint8 data_endpoint;
 	gboolean disconnected;
+  
+        ArvUvStream *stream;
 };
 
 /* ArvDevice implementation */
@@ -115,7 +117,7 @@ arv_uv_device_create_stream (ArvDevice *device, ArvStreamCallback callback, void
 	ArvStream *stream;
 
 	stream = arv_uv_stream_new (uv_device, callback, user_data);
-
+	uv_device->priv->stream = ARV_UV_STREAM(stream);
 	return stream;
 }
 
@@ -617,6 +619,12 @@ _open_usb_device (ArvUvDevice *uv_device)
 	}
 
 	libusb_free_device_list (devices, 1);
+}
+
+ArvUvStream*
+arv_uv_device_get_stream (ArvUvDevice* device)
+{
+  return device->priv->stream;
 }
 
 ArvDevice *

--- a/src/arvuvdevice.h
+++ b/src/arvuvdevice.h
@@ -41,7 +41,7 @@ G_BEGIN_DECLS
 GType arv_uv_device_get_type (void);
 
 ArvDevice * 	arv_uv_device_new 			(const char *vendor, const char *product, const char *serial_nbr);
-ArvUvStream*    arv_uv_device_get_stream (ArvUvDevice* device);
+ArvUvStream*    arv_uv_device_get_stream                (ArvUvDevice* device);
 
 G_END_DECLS
 

--- a/src/arvuvdevice.h
+++ b/src/arvuvdevice.h
@@ -41,6 +41,7 @@ G_BEGIN_DECLS
 GType arv_uv_device_get_type (void);
 
 ArvDevice * 	arv_uv_device_new 			(const char *vendor, const char *product, const char *serial_nbr);
+ArvUvStream*    arv_uv_device_get_stream (ArvUvDevice* device);
 
 G_END_DECLS
 

--- a/src/arvuvstream.c
+++ b/src/arvuvstream.c
@@ -58,7 +58,10 @@ typedef struct {
 	size_t trailer_size;
 
 	gboolean cancel;
-
+        gboolean can_start;
+        GCond *stream_condvar;
+        GMutex *stream_mutex;
+  
 	/* Statistics */
 
 	guint n_completed_buffers;
@@ -78,6 +81,12 @@ arv_uv_stream_thread (void *data)
 
 	arv_log_stream_thread ("Start USB3Vision stream thread");
 
+	thread_data->stream_condvar = g_cond_new();
+	g_cond_init(thread_data->stream_condvar);
+	thread_data->stream_mutex = g_mutex_new();
+	g_mutex_init(thread_data->stream_mutex);
+	thread_data->can_start = 0;
+	
 	incoming_buffer = g_malloc (MAXIMUM_TRANSFER_SIZE);
 
 	if (thread_data->callback != NULL)
@@ -85,6 +94,17 @@ arv_uv_stream_thread (void *data)
 
 	offset = 0;
 
+	/* Wait to start the thread loop until the condition variable is signalled by
+	   acquisition_start
+	*/
+	
+	g_mutex_lock(thread_data->stream_mutex);
+	while (!thread_data->can_start)
+	  g_cond_wait(thread_data->stream_condvar, thread_data->stream_mutex);
+	g_mutex_unlock(thread_data->stream_mutex);
+
+	arv_log_stream_thread("USB3Vision stream unpaused");
+	
 	while (!thread_data->cancel) {
 		size_t size;
 		transferred = 0;
@@ -353,6 +373,16 @@ arv_uv_stream_class_init (ArvUvStreamClass *uv_stream_class)
 	object_class->finalize = arv_uv_stream_finalize;
 
 	stream_class->get_statistics = arv_uv_stream_get_statistics;
+}
+
+void arv_uv_stream_unpause(ArvUvStream* stream)
+{
+  arv_log_stream_thread("Unpausing stream\n");
+  ArvUvStreamThreadData *thread_data = stream->priv->thread_data;
+  g_mutex_lock(thread_data->stream_mutex);
+  thread_data->can_start = 1;
+  g_cond_signal(thread_data->stream_condvar);
+  g_mutex_unlock(thread_data->stream_mutex);
 }
 
 G_DEFINE_TYPE (ArvUvStream, arv_uv_stream, ARV_TYPE_STREAM)

--- a/src/arvuvstream.h
+++ b/src/arvuvstream.h
@@ -38,6 +38,8 @@ G_BEGIN_DECLS
 #define ARV_IS_UV_STREAM_CLASS(klass)  (G_TYPE_CHECK_CLASS_TYPE ((klass), ARV_TYPE_UV_STREAM))
 #define ARV_UV_STREAM_GET_CLASS(obj)   (G_TYPE_INSTANCE_GET_CLASS((obj), ARV_TYPE_UV_STREAM, ArvUvStreamClass))
 
+void arv_uv_stream_unpause(ArvUvStream* stream);
+
 GType arv_uv_stream_get_type (void);
 
 G_END_DECLS

--- a/src/arvuvstream.h
+++ b/src/arvuvstream.h
@@ -38,7 +38,7 @@ G_BEGIN_DECLS
 #define ARV_IS_UV_STREAM_CLASS(klass)  (G_TYPE_CHECK_CLASS_TYPE ((klass), ARV_TYPE_UV_STREAM))
 #define ARV_UV_STREAM_GET_CLASS(obj)   (G_TYPE_INSTANCE_GET_CLASS((obj), ARV_TYPE_UV_STREAM, ArvUvStreamClass))
 
-void arv_uv_stream_unpause(ArvUvStream* stream);
+void arv_uv_stream_unpause             (ArvUvStream* stream);
 
 GType arv_uv_stream_get_type (void);
 


### PR DESCRIPTION
Add feature to start UV image acquisition in a paused state. On MacOS, issuing a libusb_bulk_transfer on a handle without data wedges libusb because of a timeout. Future reads fail even after data is available (i.e. after starting acquisition) - requiring the device to be unplugged and re-enumerated.

@EmmanuelP , regarding the add of device-specific code into arvcamera, my goal was to come up with a way to solve the problem of inadvertently reading from a pipe before acquisition was started (thereby wedging MacOS) while preserving device independence in higher-level code. I'm certainly open to a redesign to meet those goals.  