### PR TITLE
Fake camera controller privilege fixups

### DIFF
--- a/src/arvfakegvcamera.c
+++ b/src/arvfakegvcamera.c
@@ -359,7 +359,7 @@ handle_control_packet (ArvFakeGvCamera *gv_camera, GSocket *socket,
 			(time.tv_nsec - gv_camera->controller_time.tv_nsec) / 1000000;
 
 		if (elapsed_ms > arv_fake_camera_get_heartbeat_timeout (gv_camera->camera)) {
-			g_object_ref (gv_camera->controller_address);
+			g_object_unref (gv_camera->controller_address);
 			gv_camera->controller_address = NULL;
 			write_access = TRUE;
 			arv_warning_device ("[FakeGvCamera::handle_control_packet] Heartbeat timeout");

--- a/src/arvfakegvcamera.c
+++ b/src/arvfakegvcamera.c
@@ -446,7 +446,15 @@ handle_control_packet (ArvFakeGvCamera *gv_camera, GSocket *socket,
 	if (gv_camera->controller_address == NULL &&
 	    arv_fake_camera_get_control_channel_privilege (gv_camera->camera) != 0) {
 		g_object_ref (remote_address);
+		arv_debug_device("[FakeGvCamera::handle_control_packet] New controller");
 		gv_camera->controller_address = remote_address;
+		clock_gettime (CLOCK_MONOTONIC, &gv_camera->controller_time);
+	}
+	else if (gv_camera->controller_address != NULL &&
+	    arv_fake_camera_get_control_channel_privilege (gv_camera->camera) == 0) {
+		g_object_unref (gv_camera->controller_address);
+		gv_camera->controller_address = NULL;
+		arv_debug_device("[FakeGvCamera::handle_control_packet] Controller releases");
 		clock_gettime (CLOCK_MONOTONIC, &gv_camera->controller_time);
 	}
 }

--- a/src/arvfakegvcamera.c
+++ b/src/arvfakegvcamera.c
@@ -393,10 +393,13 @@ handle_control_packet (ArvFakeGvCamera *gv_camera, GSocket *socket,
 						     arv_gvcp_packet_get_read_memory_ack_data (ack_packet));
 			break;
 		case ARV_GVCP_COMMAND_WRITE_MEMORY_CMD:
-			if (!write_access)
-				break;
-
 			arv_gvcp_packet_get_write_memory_cmd_infos (packet, &block_address, &block_size);
+			if (!write_access) {
+				arv_warning_device("[FakeGvCamera::handle_control_packet] Ignore Write memory command %d (%d) not controller",
+					block_address, block_size);
+				break;
+			}
+
 			arv_debug_device ("[FakeGvCamera::handle_control_packet] Write memory command %d (%d)",
 					  block_address, block_size);
 			arv_fake_camera_write_memory (gv_camera->camera, block_address, block_size,
@@ -417,10 +420,13 @@ handle_control_packet (ArvFakeGvCamera *gv_camera, GSocket *socket,
 
 			break;
 		case ARV_GVCP_COMMAND_WRITE_REGISTER_CMD:
-			if (!write_access)
-				break;
-
 			arv_gvcp_packet_get_write_register_cmd_infos (packet, &register_address, &register_value);
+			if (!write_access) {
+				arv_warning_device("[FakeGvCamera::handle_control_packet] Ignore Write register command %d (%d) not controller",
+					register_address, register_value);
+				break;
+			}
+
 			arv_fake_camera_write_register (gv_camera->camera, register_address, register_value);
 			arv_debug_device ("[FakeGvCamera::handle_control_packet] Write register command %d -> %d",
 				   register_address, register_value);


### PR DESCRIPTION
Three changes related to handling of Control Channel Privilege register in the fake camera.

The main change is to correctly handle a client which explicitly relinquishes control privilege by writing CCP=0.  This needs to clear ```gv_camera->controller_address``` so the the write permission check works correctly.

I found this when writing some test code which needs to pass control between two clients: some setup code, and the code under test.  With these changes, this hand off works correctly.

I will note that when ```!write_access``` it would be better to return a permission denied error (I think involving ```ARV_GVCP_PACKET_TYPE_ERROR```).  However, I couldn't find an easy way to do this.