### PR TITLE
emit_signals synchronization

### DIFF
--- a/src/arvstream.c
+++ b/src/arvstream.c
@@ -53,9 +53,9 @@ struct _ArvStreamPrivate {
 	GAsyncQueue *input_queue;
 	GAsyncQueue *output_queue;
 #if GLIB_CHECK_VERSION(2,32,0)
-	GMutex mutex;
+	GRecMutex mutex;
 #else
-	GMutex *mutex;
+	GRecMutex *mutex;
 #endif
 
 	gboolean emit_signals;
@@ -189,18 +189,18 @@ arv_stream_push_output_buffer (ArvStream *stream, ArvBuffer *buffer)
 	g_async_queue_push (stream->priv->output_queue, buffer);
 
 #if GLIB_CHECK_VERSION(2,32,0)
-	g_mutex_lock (&stream->priv->mutex);
+	g_rec_mutex_lock (&stream->priv->mutex);
 #else
-	g_mutex_lock (stream->priv->mutex);
+	g_rec_mutex_lock (stream->priv->mutex);
 #endif
 
 	if (stream->priv->emit_signals)
 		g_signal_emit (stream, arv_stream_signals[ARV_STREAM_SIGNAL_NEW_BUFFER], 0);
 
 #if GLIB_CHECK_VERSION(2,32,0)
-	g_mutex_unlock (&stream->priv->mutex);
+	g_rec_mutex_unlock (&stream->priv->mutex);
 #else
-	g_mutex_unlock (stream->priv->mutex);
+	g_rec_mutex_unlock (stream->priv->mutex);
 #endif
 }
 
@@ -289,17 +289,17 @@ arv_stream_set_emit_signals (ArvStream *stream, gboolean emit_signals)
 	g_return_if_fail (ARV_IS_STREAM (stream));
 
 #if GLIB_CHECK_VERSION(2,32,0)
-	g_mutex_lock (&stream->priv->mutex);
+	g_rec_mutex_lock (&stream->priv->mutex);
 #else
-	g_mutex_lock (stream->priv->mutex);
+	g_rec_mutex_lock (stream->priv->mutex);
 #endif
 
 	stream->priv->emit_signals = emit_signals;
 
 #if GLIB_CHECK_VERSION(2,32,0)
-	g_mutex_unlock (&stream->priv->mutex);
+	g_rec_mutex_unlock (&stream->priv->mutex);
 #else
-	g_mutex_unlock (stream->priv->mutex);
+	g_rec_mutex_unlock (stream->priv->mutex);
 #endif
 }
 
@@ -321,17 +321,17 @@ arv_stream_get_emit_signals (ArvStream *stream)
 	g_return_val_if_fail (ARV_IS_STREAM (stream), FALSE);
 
 #if GLIB_CHECK_VERSION(2,32,0)
-	g_mutex_lock (&stream->priv->mutex);
+	g_rec_mutex_lock (&stream->priv->mutex);
 #else
-	g_mutex_lock (stream->priv->mutex);
+	g_rec_mutex_lock (stream->priv->mutex);
 #endif
 
 	ret = stream->priv->emit_signals;
 
 #if GLIB_CHECK_VERSION(2,32,0)
-	g_mutex_unlock (&stream->priv->mutex);
+	g_rec_mutex_unlock (&stream->priv->mutex);
 #else
-	g_mutex_unlock (stream->priv->mutex);
+	g_rec_mutex_unlock (stream->priv->mutex);
 #endif
 
 	return ret;
@@ -380,9 +380,9 @@ arv_stream_init (ArvStream *stream)
 	stream->priv->emit_signals = FALSE;
 
 #if GLIB_CHECK_VERSION(2,32,0)
-	g_mutex_init (&stream->priv->mutex);
+	g_rec_mutex_init (&stream->priv->mutex);
 #else
-	stream->priv->mutex = g_mutex_new ();
+	stream->priv->mutex = g_rec_mutex_new ();
 #endif
 }
 
@@ -418,9 +418,9 @@ arv_stream_finalize (GObject *object)
 	g_async_queue_unref (stream->priv->output_queue);
 
 #if GLIB_CHECK_VERSION(2,32,0)
-	g_mutex_clear (&stream->priv->mutex);
+	g_rec_mutex_clear (&stream->priv->mutex);
 #else
-	g_mutex_free (stream->priv->mutex);
+	g_rec_mutex_free (stream->priv->mutex);
 #endif
 
 	parent_class->finalize (object);

--- a/src/arvstream.c
+++ b/src/arvstream.c
@@ -397,6 +397,11 @@ arv_stream_finalize (GObject *object)
 	arv_debug_stream ("[Stream::finalize] Flush %d buffer[s] in output queue",
 			  g_async_queue_length (stream->priv->output_queue));
 
+	if (stream->priv->emit_signals) {
+		arv_warning_stream("[Stream::finalize] Stream finalized with emit_signals=true");
+		arv_warning_stream("[Stream::finalize] Disable signals before final unref avoids possible deadlock.");
+	}
+
 	do {
 		buffer = g_async_queue_try_pop (stream->priv->output_queue);
 		if (buffer != NULL)

--- a/src/arvstream.c
+++ b/src/arvstream.c
@@ -52,6 +52,11 @@ static GObjectClass *parent_class = NULL;
 struct _ArvStreamPrivate {
 	GAsyncQueue *input_queue;
 	GAsyncQueue *output_queue;
+#if GLIB_CHECK_VERSION(2,32,0)
+	GMutex mutex;
+#else
+	GMutex *mutex;
+#endif
 
 	gboolean emit_signals;
 };
@@ -183,8 +188,20 @@ arv_stream_push_output_buffer (ArvStream *stream, ArvBuffer *buffer)
 
 	g_async_queue_push (stream->priv->output_queue, buffer);
 
+#if GLIB_CHECK_VERSION(2,32,0)
+	g_mutex_lock (&stream->priv->mutex);
+#else
+	g_mutex_lock (stream->priv->mutex);
+#endif
+
 	if (stream->priv->emit_signals)
 		g_signal_emit (stream, arv_stream_signals[ARV_STREAM_SIGNAL_NEW_BUFFER], 0);
+
+#if GLIB_CHECK_VERSION(2,32,0)
+	g_mutex_unlock (&stream->priv->mutex);
+#else
+	g_mutex_unlock (stream->priv->mutex);
+#endif
 }
 
 /**
@@ -271,7 +288,19 @@ arv_stream_set_emit_signals (ArvStream *stream, gboolean emit_signals)
 {
 	g_return_if_fail (ARV_IS_STREAM (stream));
 
+#if GLIB_CHECK_VERSION(2,32,0)
+	g_mutex_lock (&stream->priv->mutex);
+#else
+	g_mutex_lock (stream->priv->mutex);
+#endif
+
 	stream->priv->emit_signals = emit_signals;
+
+#if GLIB_CHECK_VERSION(2,32,0)
+	g_mutex_unlock (&stream->priv->mutex);
+#else
+	g_mutex_unlock (stream->priv->mutex);
+#endif
 }
 
 /**
@@ -288,9 +317,24 @@ arv_stream_set_emit_signals (ArvStream *stream, gboolean emit_signals)
 gboolean
 arv_stream_get_emit_signals (ArvStream *stream)
 {
+	gboolean ret;
 	g_return_val_if_fail (ARV_IS_STREAM (stream), FALSE);
 
-	return stream->priv->emit_signals;
+#if GLIB_CHECK_VERSION(2,32,0)
+	g_mutex_lock (&stream->priv->mutex);
+#else
+	g_mutex_lock (stream->priv->mutex);
+#endif
+
+	ret = stream->priv->emit_signals;
+
+#if GLIB_CHECK_VERSION(2,32,0)
+	g_mutex_unlock (&stream->priv->mutex);
+#else
+	g_mutex_unlock (stream->priv->mutex);
+#endif
+
+	return ret;
 }
 
 static void
@@ -334,6 +378,12 @@ arv_stream_init (ArvStream *stream)
 	stream->priv->output_queue = g_async_queue_new ();
 
 	stream->priv->emit_signals = FALSE;
+
+#if GLIB_CHECK_VERSION(2,32,0)
+	g_mutex_init (&stream->priv->mutex);
+#else
+	stream->priv->mutex = g_mutex_new ();
+#endif
 }
 
 static void
@@ -361,6 +411,12 @@ arv_stream_finalize (GObject *object)
 
 	g_async_queue_unref (stream->priv->input_queue);
 	g_async_queue_unref (stream->priv->output_queue);
+
+#if GLIB_CHECK_VERSION(2,32,0)
+	g_mutex_clear (&stream->priv->mutex);
+#else
+	g_mutex_free (stream->priv->mutex);
+#endif
 
 	parent_class->finalize (object);
 }

--- a/tests/fakegv.c
+++ b/tests/fakegv.c
@@ -148,6 +148,10 @@ stream_test (void)
 		usleep (1000);
 
 	arv_camera_stop_acquisition (camera);
+	/* The following will block until the signal callback returns
+	 * which avoids a race and possible deadlock.
+	 */
+	arv_stream_set_emit_signals (stream, FALSE);
 
 	g_clear_object (&stream);
 	g_clear_object (&camera);


### PR DESCRIPTION
Attempt to fix #50.  Add a mutex to ```_ArvStreamPrivate``` which is locked in ```arv_stream_push_output_buffer()``` around the test of ```emit_signals``` and the call to ```g_signal_emit()```.  Also in ```arv_stream_set_emit_signals()``` when ```emit_signals``` is updated.

The stream shutdown sequence should include setting emit_signals=0, which by locking the mutex would ensure that ```g_signal_emit()``` isn't running after ```arv_stream_set_emit_signals()``` returns.

With some hesitation, print a warning if a stream is finalized w/ emit_signals=true.  Hopefully, this will give some hint about avoiding this a deadlock without being too annoying.

I've only tested the glib < 2.32 condition.