### PR TITLE
Save system time for each captured frame

### DIFF
--- a/m4/libtool.m4
+++ b/m4/libtool.m4
@@ -2867,9 +2867,6 @@ linux* | k*bsd*-gnu | kopensolaris*-gnu | gnu*)
   # before this can be enabled.
   hardcode_into_libs=yes
 
-  # Add ABI-specific directories to the system library path.
-  sys_lib_dlsearch_path_spec="/lib64 /usr/lib64 /lib /usr/lib"
-
   # Ideally, we could use ldconfig to report *all* directores which are
   # searched for libraries, however this is still not possible.  Aside from not
   # being certain /sbin/ldconfig is available, command
@@ -2878,7 +2875,7 @@ linux* | k*bsd*-gnu | kopensolaris*-gnu | gnu*)
   # appending ld.so.conf contents (and includes) to the search path.
   if test -f /etc/ld.so.conf; then
     lt_ld_extra=`awk '/^include / { system(sprintf("cd /etc; cat %s 2>/dev/null", \[$]2)); skip = 1; } { if (!skip) print \[$]0; skip = 0; }' < /etc/ld.so.conf | $SED -e 's/#.*//;/^[	 ]*hwcap[	 ]/d;s/[:,	]/ /g;s/=[^=]*$//;s/=[^= ]* / /g;s/"//g;/^$/d' | tr '\n' ' '`
-    sys_lib_dlsearch_path_spec="$sys_lib_dlsearch_path_spec $lt_ld_extra"
+    sys_lib_dlsearch_path_spec="/lib /usr/lib $lt_ld_extra"
   fi
 
   # We used to test for /lib/ld.so.1 and disable shared libraries on
@@ -2888,6 +2885,18 @@ linux* | k*bsd*-gnu | kopensolaris*-gnu | gnu*)
   # people can always --disable-shared, the test was removed, and we
   # assume the GNU/Linux dynamic linker is in use.
   dynamic_linker='GNU/Linux ld.so'
+  ;;
+
+netbsdelf*-gnu)
+  version_type=linux
+  need_lib_prefix=no
+  need_version=no
+  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major ${libname}${shared_ext}'
+  soname_spec='${libname}${release}${shared_ext}$major'
+  shlibpath_var=LD_LIBRARY_PATH
+  shlibpath_overrides_runpath=no
+  hardcode_into_libs=yes
+  dynamic_linker='NetBSD ld.elf_so'
   ;;
 
 netbsd*)
@@ -3549,7 +3558,7 @@ linux* | k*bsd*-gnu | kopensolaris*-gnu | gnu*)
   lt_cv_deplibs_check_method=pass_all
   ;;
 
-netbsd*)
+netbsd* | netbsdelf*-gnu)
   if echo __ELF__ | $CC -E - | $GREP __ELF__ > /dev/null; then
     lt_cv_deplibs_check_method='match_pattern /lib[[^/]]+(\.so\.[[0-9]]+\.[[0-9]]+|_pic\.a)$'
   else
@@ -4427,7 +4436,7 @@ m4_if([$1], [CXX], [
 	    ;;
 	esac
 	;;
-      netbsd*)
+      netbsd* | netbsdelf*-gnu)
 	;;
       *qnx* | *nto*)
         # QNX uses GNU C++, but need to define -shared option too, otherwise
@@ -4939,6 +4948,9 @@ m4_if([$1], [CXX], [
       ;;
     esac
     ;;
+  linux* | k*bsd*-gnu | gnu*)
+    _LT_TAGVAR(link_all_deplibs, $1)=no
+    ;;
   *)
     _LT_TAGVAR(export_symbols_cmds, $1)='$NM $libobjs $convenience | $global_symbol_pipe | $SED '\''s/.* //'\'' | sort | uniq > $export_symbols'
     ;;
@@ -5000,6 +5012,9 @@ dnl Note also adjust exclude_expsyms for C++ above.
     ;;
   openbsd* | bitrig*)
     with_gnu_ld=no
+    ;;
+  linux* | k*bsd*-gnu | gnu*)
+    _LT_TAGVAR(link_all_deplibs, $1)=no
     ;;
   esac
 
@@ -5255,7 +5270,7 @@ _LT_EOF
       fi
       ;;
 
-    netbsd*)
+    netbsd* | netbsdelf*-gnu)
       if echo __ELF__ | $CC -E - | $GREP __ELF__ >/dev/null; then
 	_LT_TAGVAR(archive_cmds, $1)='$LD -Bshareable $libobjs $deplibs $linker_flags -o $lib'
 	wlarc=
@@ -5776,6 +5791,7 @@ _LT_EOF
 	if test yes = "$lt_cv_irix_exported_symbol"; then
           _LT_TAGVAR(archive_expsym_cmds, $1)='$CC -shared $pic_flag $libobjs $deplibs $compiler_flags $wl-soname $wl$soname `test -n "$verstring" && func_echo_all "$wl-set_version $wl$verstring"` $wl-update_registry $wl$output_objdir/so_locations $wl-exports_file $wl$export_symbols -o $lib'
 	fi
+	_LT_TAGVAR(link_all_deplibs, $1)=no
       else
 	_LT_TAGVAR(archive_cmds, $1)='$CC -shared $libobjs $deplibs $compiler_flags -soname $soname `test -n "$verstring" && func_echo_all "-set_version $verstring"` -update_registry $output_objdir/so_locations -o $lib'
 	_LT_TAGVAR(archive_expsym_cmds, $1)='$CC -shared $libobjs $deplibs $compiler_flags -soname $soname `test -n "$verstring" && func_echo_all "-set_version $verstring"` -update_registry $output_objdir/so_locations -exports_file $export_symbols -o $lib'
@@ -5797,7 +5813,7 @@ _LT_EOF
       esac
       ;;
 
-    netbsd*)
+    netbsd* | netbsdelf*-gnu)
       if echo __ELF__ | $CC -E - | $GREP __ELF__ >/dev/null; then
 	_LT_TAGVAR(archive_cmds, $1)='$LD -Bshareable -o $lib $libobjs $deplibs $linker_flags'  # a.out
       else

--- a/m4/libtool.m4
+++ b/m4/libtool.m4
@@ -2867,6 +2867,9 @@ linux* | k*bsd*-gnu | kopensolaris*-gnu | gnu*)
   # before this can be enabled.
   hardcode_into_libs=yes
 
+  # Add ABI-specific directories to the system library path.
+  sys_lib_dlsearch_path_spec="/lib64 /usr/lib64 /lib /usr/lib"
+
   # Ideally, we could use ldconfig to report *all* directores which are
   # searched for libraries, however this is still not possible.  Aside from not
   # being certain /sbin/ldconfig is available, command
@@ -2875,7 +2878,7 @@ linux* | k*bsd*-gnu | kopensolaris*-gnu | gnu*)
   # appending ld.so.conf contents (and includes) to the search path.
   if test -f /etc/ld.so.conf; then
     lt_ld_extra=`awk '/^include / { system(sprintf("cd /etc; cat %s 2>/dev/null", \[$]2)); skip = 1; } { if (!skip) print \[$]0; skip = 0; }' < /etc/ld.so.conf | $SED -e 's/#.*//;/^[	 ]*hwcap[	 ]/d;s/[:,	]/ /g;s/=[^=]*$//;s/=[^= ]* / /g;s/"//g;/^$/d' | tr '\n' ' '`
-    sys_lib_dlsearch_path_spec="/lib /usr/lib $lt_ld_extra"
+    sys_lib_dlsearch_path_spec="$sys_lib_dlsearch_path_spec $lt_ld_extra"
   fi
 
   # We used to test for /lib/ld.so.1 and disable shared libraries on
@@ -2885,18 +2888,6 @@ linux* | k*bsd*-gnu | kopensolaris*-gnu | gnu*)
   # people can always --disable-shared, the test was removed, and we
   # assume the GNU/Linux dynamic linker is in use.
   dynamic_linker='GNU/Linux ld.so'
-  ;;
-
-netbsdelf*-gnu)
-  version_type=linux
-  need_lib_prefix=no
-  need_version=no
-  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major ${libname}${shared_ext}'
-  soname_spec='${libname}${release}${shared_ext}$major'
-  shlibpath_var=LD_LIBRARY_PATH
-  shlibpath_overrides_runpath=no
-  hardcode_into_libs=yes
-  dynamic_linker='NetBSD ld.elf_so'
   ;;
 
 netbsd*)
@@ -3558,7 +3549,7 @@ linux* | k*bsd*-gnu | kopensolaris*-gnu | gnu*)
   lt_cv_deplibs_check_method=pass_all
   ;;
 
-netbsd* | netbsdelf*-gnu)
+netbsd*)
   if echo __ELF__ | $CC -E - | $GREP __ELF__ > /dev/null; then
     lt_cv_deplibs_check_method='match_pattern /lib[[^/]]+(\.so\.[[0-9]]+\.[[0-9]]+|_pic\.a)$'
   else
@@ -4436,7 +4427,7 @@ m4_if([$1], [CXX], [
 	    ;;
 	esac
 	;;
-      netbsd* | netbsdelf*-gnu)
+      netbsd*)
 	;;
       *qnx* | *nto*)
         # QNX uses GNU C++, but need to define -shared option too, otherwise
@@ -4948,9 +4939,6 @@ m4_if([$1], [CXX], [
       ;;
     esac
     ;;
-  linux* | k*bsd*-gnu | gnu*)
-    _LT_TAGVAR(link_all_deplibs, $1)=no
-    ;;
   *)
     _LT_TAGVAR(export_symbols_cmds, $1)='$NM $libobjs $convenience | $global_symbol_pipe | $SED '\''s/.* //'\'' | sort | uniq > $export_symbols'
     ;;
@@ -5012,9 +5000,6 @@ dnl Note also adjust exclude_expsyms for C++ above.
     ;;
   openbsd* | bitrig*)
     with_gnu_ld=no
-    ;;
-  linux* | k*bsd*-gnu | gnu*)
-    _LT_TAGVAR(link_all_deplibs, $1)=no
     ;;
   esac
 
@@ -5270,7 +5255,7 @@ _LT_EOF
       fi
       ;;
 
-    netbsd* | netbsdelf*-gnu)
+    netbsd*)
       if echo __ELF__ | $CC -E - | $GREP __ELF__ >/dev/null; then
 	_LT_TAGVAR(archive_cmds, $1)='$LD -Bshareable $libobjs $deplibs $linker_flags -o $lib'
 	wlarc=
@@ -5791,7 +5776,6 @@ _LT_EOF
 	if test yes = "$lt_cv_irix_exported_symbol"; then
           _LT_TAGVAR(archive_expsym_cmds, $1)='$CC -shared $pic_flag $libobjs $deplibs $compiler_flags $wl-soname $wl$soname `test -n "$verstring" && func_echo_all "$wl-set_version $wl$verstring"` $wl-update_registry $wl$output_objdir/so_locations $wl-exports_file $wl$export_symbols -o $lib'
 	fi
-	_LT_TAGVAR(link_all_deplibs, $1)=no
       else
 	_LT_TAGVAR(archive_cmds, $1)='$CC -shared $libobjs $deplibs $compiler_flags -soname $soname `test -n "$verstring" && func_echo_all "-set_version $verstring"` -update_registry $output_objdir/so_locations -o $lib'
 	_LT_TAGVAR(archive_expsym_cmds, $1)='$CC -shared $libobjs $deplibs $compiler_flags -soname $soname `test -n "$verstring" && func_echo_all "-set_version $verstring"` -update_registry $output_objdir/so_locations -exports_file $export_symbols -o $lib'
@@ -5813,7 +5797,7 @@ _LT_EOF
       esac
       ;;
 
-    netbsd* | netbsdelf*-gnu)
+    netbsd*)
       if echo __ELF__ | $CC -E - | $GREP __ELF__ >/dev/null; then
 	_LT_TAGVAR(archive_cmds, $1)='$LD -Bshareable -o $lib $libobjs $deplibs $linker_flags'  # a.out
       else

--- a/src/arvbuffer.c
+++ b/src/arvbuffer.c
@@ -330,7 +330,7 @@ arv_buffer_set_timestamp (ArvBuffer *buffer, guint64 timestamp_ns)
  */
 
 guint64
-arv_buffer_get_system_time (ArvBuffer *buffer)
+arv_buffer_get_system_timestamp (ArvBuffer *buffer)
 {
 	g_return_val_if_fail (ARV_IS_BUFFER (buffer), 0);
 
@@ -349,7 +349,7 @@ arv_buffer_get_system_time (ArvBuffer *buffer)
  */
 
 void
-arv_buffer_set_system_time (ArvBuffer *buffer, guint64 timestamp_ns)
+arv_buffer_set_system_timestamp (ArvBuffer *buffer, guint64 timestamp_ns)
 {
 	g_return_if_fail (ARV_IS_BUFFER (buffer));
 

--- a/src/arvbuffer.c
+++ b/src/arvbuffer.c
@@ -334,7 +334,7 @@ arv_buffer_get_system_timestamp (ArvBuffer *buffer)
 {
 	g_return_val_if_fail (ARV_IS_BUFFER (buffer), 0);
 
-	return buffer->priv->systemtime_ns;
+	return buffer->priv->system_timestamp_ns;
 }
 
 /**
@@ -353,7 +353,7 @@ arv_buffer_set_system_timestamp (ArvBuffer *buffer, guint64 timestamp_ns)
 {
 	g_return_if_fail (ARV_IS_BUFFER (buffer));
 
-	buffer->priv->systemtime_ns = timestamp_ns;
+	buffer->priv->system_timestamp_ns = timestamp_ns;
 }
 
 

--- a/src/arvbuffer.c
+++ b/src/arvbuffer.c
@@ -318,6 +318,46 @@ arv_buffer_set_timestamp (ArvBuffer *buffer, guint64 timestamp_ns)
 }
 
 /**
+ * arv_buffer_get_system_time:
+ * @buffer: a #ArvBuffer
+ *
+ * Gets the system timestamp for when the frame was received. Expressed in
+ * microseconds.
+ *
+ * Returns: buffer timestamp, in microseconds.
+ *
+ * Since: 0.4.0
+ */
+
+guint64
+arv_buffer_get_system_time (ArvBuffer *buffer)
+{
+	g_return_val_if_fail (ARV_IS_BUFFER (buffer), 0);
+
+	return buffer->priv->systemtime_us;
+}
+
+/**
+ * arv_buffer_set_system_time:
+ * @buffer: a #ArvBuffer
+ * @timestamp_us: a timestamp, expressed as microseconds
+ *
+ * Sets the system timestamp for when the frame was received. Expressed in
+ * microseconds.
+ *
+ * Since: 0.4.0
+ */
+
+void
+arv_buffer_set_system_time (ArvBuffer *buffer, guint64 timestamp_us)
+{
+	g_return_if_fail (ARV_IS_BUFFER (buffer));
+
+	buffer->priv->systemtime_us = timestamp_us;
+}
+
+
+/**
  * arv_buffer_get_frame_id:
  * @buffer: a #ArvBuffer
  *

--- a/src/arvbuffer.c
+++ b/src/arvbuffer.c
@@ -324,7 +324,7 @@ arv_buffer_set_timestamp (ArvBuffer *buffer, guint64 timestamp_ns)
  * Gets the system timestamp for when the frame was received. Expressed in
  * microseconds.
  *
- * Returns: buffer timestamp, in microseconds.
+ * Returns: buffer timestamp, in nanoseconds.
  *
  * Since: 0.4.0
  */
@@ -334,13 +334,13 @@ arv_buffer_get_system_time (ArvBuffer *buffer)
 {
 	g_return_val_if_fail (ARV_IS_BUFFER (buffer), 0);
 
-	return buffer->priv->systemtime_us;
+	return buffer->priv->systemtime_ns;
 }
 
 /**
  * arv_buffer_set_system_time:
  * @buffer: a #ArvBuffer
- * @timestamp_us: a timestamp, expressed as microseconds
+ * @timestamp_ns: a timestamp, expressed as nanoseconds
  *
  * Sets the system timestamp for when the frame was received. Expressed in
  * microseconds.
@@ -349,11 +349,11 @@ arv_buffer_get_system_time (ArvBuffer *buffer)
  */
 
 void
-arv_buffer_set_system_time (ArvBuffer *buffer, guint64 timestamp_us)
+arv_buffer_set_system_time (ArvBuffer *buffer, guint64 timestamp_ns)
 {
 	g_return_if_fail (ARV_IS_BUFFER (buffer));
 
-	buffer->priv->systemtime_us = timestamp_us;
+	buffer->priv->systemtime_ns = timestamp_ns;
 }
 
 

--- a/src/arvbuffer.h
+++ b/src/arvbuffer.h
@@ -120,7 +120,7 @@ ArvBufferPayloadType	arv_buffer_get_payload_type	(ArvBuffer *buffer);
 guint64			arv_buffer_get_timestamp	(ArvBuffer *buffer);
 void			arv_buffer_set_timestamp	(ArvBuffer *buffer, guint64 timestamp_ns);
 guint64			arv_buffer_get_system_time	(ArvBuffer *buffer);
-void			arv_buffer_set_system_time	(ArvBuffer *buffer, guint64 timestamp_us);
+void			arv_buffer_set_system_time	(ArvBuffer *buffer, guint64 timestamp_ns);
 guint32 		arv_buffer_get_frame_id 	(ArvBuffer *buffer);
 const void *		arv_buffer_get_data		(ArvBuffer *buffer, size_t *size);
 

--- a/src/arvbuffer.h
+++ b/src/arvbuffer.h
@@ -119,8 +119,8 @@ const void *		arv_buffer_get_user_data	(ArvBuffer *buffer);
 ArvBufferPayloadType	arv_buffer_get_payload_type	(ArvBuffer *buffer);
 guint64			arv_buffer_get_timestamp	(ArvBuffer *buffer);
 void			arv_buffer_set_timestamp	(ArvBuffer *buffer, guint64 timestamp_ns);
-guint64			arv_buffer_get_system_time	(ArvBuffer *buffer);
-void			arv_buffer_set_system_time	(ArvBuffer *buffer, guint64 timestamp_ns);
+guint64			arv_buffer_get_system_timestamp	(ArvBuffer *buffer);
+void			arv_buffer_set_system_timestamp	(ArvBuffer *buffer, guint64 timestamp_ns);
 guint32 		arv_buffer_get_frame_id 	(ArvBuffer *buffer);
 const void *		arv_buffer_get_data		(ArvBuffer *buffer, size_t *size);
 

--- a/src/arvbuffer.h
+++ b/src/arvbuffer.h
@@ -119,6 +119,8 @@ const void *		arv_buffer_get_user_data	(ArvBuffer *buffer);
 ArvBufferPayloadType	arv_buffer_get_payload_type	(ArvBuffer *buffer);
 guint64			arv_buffer_get_timestamp	(ArvBuffer *buffer);
 void			arv_buffer_set_timestamp	(ArvBuffer *buffer, guint64 timestamp_ns);
+guint64			arv_buffer_get_system_time	(ArvBuffer *buffer);
+void			arv_buffer_set_system_time	(ArvBuffer *buffer, guint64 timestamp_us);
 guint32 		arv_buffer_get_frame_id 	(ArvBuffer *buffer);
 const void *		arv_buffer_get_data		(ArvBuffer *buffer, size_t *size);
 

--- a/src/arvbufferprivate.h
+++ b/src/arvbufferprivate.h
@@ -46,7 +46,7 @@ struct _ArvBufferPrivate {
 
 	guint32 frame_id;
 	guint64 timestamp_ns;
-    guint64 systemtime_us;
+    guint64 systemtime_ns;
 
 	guint32 x_offset;
 	guint32 y_offset;

--- a/src/arvbufferprivate.h
+++ b/src/arvbufferprivate.h
@@ -46,7 +46,7 @@ struct _ArvBufferPrivate {
 
 	guint32 frame_id;
 	guint64 timestamp_ns;
-    guint64 systemtime_ns;
+    guint64 system_timestamp_ns;
 
 	guint32 x_offset;
 	guint32 y_offset;

--- a/src/arvbufferprivate.h
+++ b/src/arvbufferprivate.h
@@ -46,6 +46,7 @@ struct _ArvBufferPrivate {
 
 	guint32 frame_id;
 	guint64 timestamp_ns;
+    guint64 systemtime_us;
 
 	guint32 x_offset;
 	guint32 y_offset;

--- a/src/arvfakecamera.c
+++ b/src/arvfakecamera.c
@@ -300,7 +300,7 @@ arv_fake_camera_fill_buffer (ArvFakeCamera *camera, ArvBuffer *buffer, guint32 *
 	buffer->priv->height = height;
 	buffer->priv->status = ARV_BUFFER_STATUS_SUCCESS;
 	buffer->priv->timestamp_ns = ((guint64) time.tv_sec) * 1000000000LL + time.tv_nsec;
-    buffer->priv->systemtime_ns = buffer->priv->timestamp_ns;
+	buffer->priv->system_timestamp_ns = buffer->priv->timestamp_ns;
 	buffer->priv->frame_id = camera->priv->frame_id++;
 	buffer->priv->pixel_format = _get_register (camera, ARV_FAKE_CAMERA_REGISTER_PIXEL_FORMAT);
 

--- a/src/arvfakecamera.c
+++ b/src/arvfakecamera.c
@@ -299,6 +299,7 @@ arv_fake_camera_fill_buffer (ArvFakeCamera *camera, ArvBuffer *buffer, guint32 *
 	buffer->priv->width = width;
 	buffer->priv->height = height;
 	buffer->priv->status = ARV_BUFFER_STATUS_SUCCESS;
+    buffer->priv->systemtime_us = ((guint64) time.tv_sec) * 1000000LL + time.tv_nsec/1000;
 	buffer->priv->timestamp_ns = ((guint64) time.tv_sec) * 1000000000LL + time.tv_nsec;
 	buffer->priv->frame_id = camera->priv->frame_id++;
 	buffer->priv->pixel_format = _get_register (camera, ARV_FAKE_CAMERA_REGISTER_PIXEL_FORMAT);
@@ -430,7 +431,7 @@ arv_get_fake_camera_genicam_xml (size_t *size)
 			filename = g_build_filename (ARAVIS_DATA_DIR, "arv-fake-camera.xml", NULL);
 		else
 			filename = g_strdup (arv_fake_camera_genicam_filename);
-		
+
 		genicam_file = g_mapped_file_new (filename, FALSE, NULL);
 
 		if (genicam_file != NULL) {

--- a/src/arvfakecamera.c
+++ b/src/arvfakecamera.c
@@ -299,8 +299,8 @@ arv_fake_camera_fill_buffer (ArvFakeCamera *camera, ArvBuffer *buffer, guint32 *
 	buffer->priv->width = width;
 	buffer->priv->height = height;
 	buffer->priv->status = ARV_BUFFER_STATUS_SUCCESS;
-    buffer->priv->systemtime_us = ((guint64) time.tv_sec) * 1000000LL + time.tv_nsec/1000;
 	buffer->priv->timestamp_ns = ((guint64) time.tv_sec) * 1000000000LL + time.tv_nsec;
+    buffer->priv->systemtime_ns = buffer->priv->timestamp_ns;
 	buffer->priv->frame_id = camera->priv->frame_id++;
 	buffer->priv->pixel_format = _get_register (camera, ARV_FAKE_CAMERA_REGISTER_PIXEL_FORMAT);
 

--- a/src/arvgvstream.c
+++ b/src/arvgvstream.c
@@ -240,16 +240,16 @@ _process_data_leader (ArvGvStreamThreadData *thread_data,
 	frame->buffer->priv->gvsp_payload_type = arv_gvsp_packet_get_payload_type (packet);
 	frame->buffer->priv->frame_id = arv_gvsp_packet_get_frame_id (packet);
 
-    frame->buffer->priv->systemtime_ns = g_get_real_time() * 1000LL;
+	frame->buffer->priv->system_timestamp_ns = g_get_real_time() * 1000LL;
 	if (frame->buffer->priv->gvsp_payload_type != ARV_GVSP_PAYLOAD_TYPE_H264) {
 		if (G_LIKELY (thread_data->timestamp_tick_frequency != 0))
 			frame->buffer->priv->timestamp_ns = arv_gvsp_packet_get_timestamp (packet,
 											   thread_data->timestamp_tick_frequency);
 		else {
-			frame->buffer->priv->timestamp_ns = frame->buffer->priv->systemtime_ns;
+			frame->buffer->priv->timestamp_ns = frame->buffer->priv->system_timestamp_ns;
 		}
 	} else
-		frame->buffer->priv->timestamp_ns = frame->buffer->priv->systemtime_ns;
+		frame->buffer->priv->timestamp_ns = frame->buffer->priv->system_timestamp_ns;
 
 	if (frame->buffer->priv->gvsp_payload_type == ARV_GVSP_PAYLOAD_TYPE_IMAGE) {
 		frame->buffer->priv->x_offset = arv_gvsp_packet_get_x_offset (packet);

--- a/src/arvgvstream.c
+++ b/src/arvgvstream.c
@@ -240,16 +240,16 @@ _process_data_leader (ArvGvStreamThreadData *thread_data,
 	frame->buffer->priv->gvsp_payload_type = arv_gvsp_packet_get_payload_type (packet);
 	frame->buffer->priv->frame_id = arv_gvsp_packet_get_frame_id (packet);
 
-    frame->buffer->priv->systemtime_us = g_get_real_time ();
+    frame->buffer->priv->systemtime_ns = g_get_real_time() * 1000LL;
 	if (frame->buffer->priv->gvsp_payload_type != ARV_GVSP_PAYLOAD_TYPE_H264) {
 		if (G_LIKELY (thread_data->timestamp_tick_frequency != 0))
 			frame->buffer->priv->timestamp_ns = arv_gvsp_packet_get_timestamp (packet,
 											   thread_data->timestamp_tick_frequency);
 		else {
-			frame->buffer->priv->timestamp_ns = frame->buffer->priv->systemtime_us * 1000LL;
+			frame->buffer->priv->timestamp_ns = frame->buffer->priv->systemtime_ns;
 		}
 	} else
-		frame->buffer->priv->timestamp_ns = frame->buffer->priv->systemtime_us * 1000LL;
+		frame->buffer->priv->timestamp_ns = frame->buffer->priv->systemtime_ns;
 
 	if (frame->buffer->priv->gvsp_payload_type == ARV_GVSP_PAYLOAD_TYPE_IMAGE) {
 		frame->buffer->priv->x_offset = arv_gvsp_packet_get_x_offset (packet);

--- a/src/arvgvstream.c
+++ b/src/arvgvstream.c
@@ -240,18 +240,16 @@ _process_data_leader (ArvGvStreamThreadData *thread_data,
 	frame->buffer->priv->gvsp_payload_type = arv_gvsp_packet_get_payload_type (packet);
 	frame->buffer->priv->frame_id = arv_gvsp_packet_get_frame_id (packet);
 
+    frame->buffer->priv->systemtime_us = g_get_real_time ();
 	if (frame->buffer->priv->gvsp_payload_type != ARV_GVSP_PAYLOAD_TYPE_H264) {
 		if (G_LIKELY (thread_data->timestamp_tick_frequency != 0))
 			frame->buffer->priv->timestamp_ns = arv_gvsp_packet_get_timestamp (packet,
 											   thread_data->timestamp_tick_frequency);
 		else {
-			GTimeVal time;
-
-			g_get_current_time (&time);
-			frame->buffer->priv->timestamp_ns = ((guint64) time.tv_sec * 1000000000LL) + ((guint64) time.tv_usec * 1000) ;
+			frame->buffer->priv->timestamp_ns = frame->buffer->priv->systemtime_us * 1000LL;
 		}
 	} else
-		frame->buffer->priv->timestamp_ns = g_get_real_time () * 1000LL;
+		frame->buffer->priv->timestamp_ns = frame->buffer->priv->systemtime_us * 1000LL;
 
 	if (frame->buffer->priv->gvsp_payload_type == ARV_GVSP_PAYLOAD_TYPE_IMAGE) {
 		frame->buffer->priv->x_offset = arv_gvsp_packet_get_x_offset (packet);

--- a/src/arvuvstream.c
+++ b/src/arvuvstream.c
@@ -128,7 +128,7 @@ arv_uv_stream_thread (void *data)
 					}
 					buffer = arv_stream_pop_input_buffer (thread_data->stream);
 					if (buffer != NULL) {
-						buffer->priv->systemtime_ns = g_get_real_time () * 1000LL;
+						buffer->priv->system_timestamp_ns = g_get_real_time () * 1000LL;
 						buffer->priv->status = ARV_BUFFER_STATUS_FILLING;
 						buffer->priv->gvsp_payload_type = ARV_GVSP_PAYLOAD_TYPE_IMAGE;
 						arv_uvsp_packet_get_region (packet,

--- a/src/arvuvstream.c
+++ b/src/arvuvstream.c
@@ -128,7 +128,7 @@ arv_uv_stream_thread (void *data)
 					}
 					buffer = arv_stream_pop_input_buffer (thread_data->stream);
 					if (buffer != NULL) {
-						buffer->priv->systemtime_us = g_get_real_time ();
+						buffer->priv->systemtime_ns = g_get_real_time () * 1000LL;
 						buffer->priv->status = ARV_BUFFER_STATUS_FILLING;
 						buffer->priv->gvsp_payload_type = ARV_GVSP_PAYLOAD_TYPE_IMAGE;
 						arv_uvsp_packet_get_region (packet,

--- a/src/arvuvstream.c
+++ b/src/arvuvstream.c
@@ -128,6 +128,7 @@ arv_uv_stream_thread (void *data)
 					}
 					buffer = arv_stream_pop_input_buffer (thread_data->stream);
 					if (buffer != NULL) {
+						buffer->priv->systemtime_us = g_get_real_time ();
 						buffer->priv->status = ARV_BUFFER_STATUS_FILLING;
 						buffer->priv->gvsp_payload_type = ARV_GVSP_PAYLOAD_TYPE_IMAGE;
 						arv_uvsp_packet_get_region (packet,


### PR DESCRIPTION
I have made an extension that saves the system time at which a frame was recorded, in addition to the already recorded camera time. The timestamp is saved to the buffer as soon as the leader is received, in order to minimize delays. There are two new functions for getting and setting the system timestamp:

`arv_buffer_get_system_time()`
`arv_buffer_set_system_time()`

The system time is saved in microseconds, which is unlike the camera timestamp that is saved in nanoseconds. This is because the used `g_get_real_time()` function only has microsecond resolution. If this makes the interface inconsistent, it could also be converted to nanoseconds.