### PR TITLE
Adds automake to list of brew install programs

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ On some platforms (like Ubuntu), you may have to configure the dynamic linker (l
 Using the GNU build system on Mac OS X is not directly supported, but can be mimicked by augmenting the install procedure above with some environment settings:
 
 ```
-brew install gettext intltool gtk-doc
+brew install gettext intltool gtk-doc automake
 brew link --force gettext
 aclocal
 autoconf


### PR DESCRIPTION
I found that after running `brew install gettext intltool gtk-doc` I was missing the `aclocal` command. Installing `automake` with brew solves this issue.