### PR TITLE
UV: bugfix for initial leader / trailer size of 0 for some Point Grey…

### DIFF
--- a/src/arvuvstream.c
+++ b/src/arvuvstream.c
@@ -90,12 +90,12 @@ arv_uv_stream_thread (void *data)
 		transferred = 0;
 
 		if (buffer == NULL)
-			size = thread_data->leader_size;
+			size = MAXIMUM_TRANSFER_SIZE;
 		else {
 			if (offset < buffer->priv->size)
 				size = MIN (thread_data->payload_size, buffer->priv->size - offset);
 			else
-				size = thread_data->trailer_size;
+				size = MAXIMUM_TRANSFER_SIZE;
 		}
 
 		/* Avoid unnecessary memory copy by transferring data directly to the image buffer */


### PR DESCRIPTION
Some Point Grey cameras seem to report a required leader and trailer size of 0 after plugging in. So the first attempt to access them after plugging in always fails. On the second attempt they report the correct size. I observed this with CM3-U3-13S2M-CS and BFLY-U3-05S2M-CS.

I increased the bulk transfers to the maximum transfer size for the leader and trailer, which seems to fix the problem.