### PR TITLE
Expose the raw ticks timestamp of packets.

### DIFF
--- a/docs/reference/aravis/aravis-sections.txt
+++ b/docs/reference/aravis/aravis-sections.txt
@@ -123,6 +123,7 @@ arv_buffer_get_user_data
 arv_buffer_get_data
 arv_buffer_get_chunk_data
 arv_buffer_get_timestamp
+arv_buffer_get_timestamp_ticks
 arv_buffer_set_timestamp
 arv_buffer_get_system_timestamp
 arv_buffer_set_system_timestamp
@@ -1752,6 +1753,7 @@ arv_gvsp_packet_get_packet_type
 arv_gvsp_packet_get_content_type
 arv_gvsp_packet_get_payload_type
 arv_gvsp_packet_get_pixel_format
+arv_gvsp_packet_get_timestamp_ticks
 arv_gvsp_packet_get_timestamp
 arv_gvsp_packet_get_width
 arv_gvsp_packet_get_x_offset

--- a/src/arvbuffer.c
+++ b/src/arvbuffer.c
@@ -299,6 +299,26 @@ arv_buffer_get_timestamp (ArvBuffer *buffer)
 	return buffer->priv->timestamp_ns;
 }
 
+
+/**
+ * arv_buffer_get_timestamp_ticks:
+ * @buffer: a #ArvBuffer
+ *
+ * Gets the buffer camera timestamp, expressed as ticks.
+ *
+ * Returns: buffer timestamp, in ticks.
+ *
+ * Since: 0.5.13
+ */
+
+guint64
+arv_buffer_get_timestamp_ticks (ArvBuffer *buffer)
+{
+       g_return_val_if_fail (ARV_IS_BUFFER (buffer), 0);
+
+       return buffer->priv->timestamp_ticks;
+}
+
 /**
  * arv_buffer_set_timestamp:
  * @buffer: a #ArvBuffer

--- a/src/arvbuffer.h
+++ b/src/arvbuffer.h
@@ -118,6 +118,7 @@ const void *		arv_buffer_get_user_data	(ArvBuffer *buffer);
 
 ArvBufferPayloadType	arv_buffer_get_payload_type	(ArvBuffer *buffer);
 guint64			arv_buffer_get_timestamp	(ArvBuffer *buffer);
+guint64			arv_buffer_get_timestamp_ticks	(ArvBuffer *buffer);
 void			arv_buffer_set_timestamp	(ArvBuffer *buffer, guint64 timestamp_ns);
 guint64			arv_buffer_get_system_timestamp	(ArvBuffer *buffer);
 void			arv_buffer_set_system_timestamp	(ArvBuffer *buffer, guint64 timestamp_ns);

--- a/src/arvbufferprivate.h
+++ b/src/arvbufferprivate.h
@@ -46,6 +46,7 @@ struct _ArvBufferPrivate {
 
 	guint32 frame_id;
 	guint64 timestamp_ns;
+       guint64 timestamp_ticks;
     guint64 system_timestamp_ns;
 
 	guint32 x_offset;

--- a/src/arvgvsp.h
+++ b/src/arvgvsp.h
@@ -253,9 +253,21 @@ arv_gvsp_packet_get_pixel_format (const ArvGvspPacket *packet)
 }
 
 static inline guint64
+arv_gvsp_packet_get_timestamp_ticks (const ArvGvspPacket *packet)
+{
+       ArvGvspDataLeader *leader;
+       guint64 timestamp;
+
+       leader = (ArvGvspDataLeader *) &packet->data;
+
+       timestamp = ( (guint64) g_ntohl (leader->timestamp_high) << 32) | g_ntohl (leader->timestamp_low);
+
+       return timestamp;
+}
+
+static inline guint64
 arv_gvsp_packet_get_timestamp (const ArvGvspPacket *packet, guint64 timestamp_tick_frequency)
 {
-	ArvGvspDataLeader *leader;
 	guint64 timestamp_s;
 	guint64 timestamp_ns;
 	guint64 timestamp;
@@ -263,9 +275,7 @@ arv_gvsp_packet_get_timestamp (const ArvGvspPacket *packet, guint64 timestamp_ti
 	if (timestamp_tick_frequency < 1)
 		return 0;
 
-	leader = (ArvGvspDataLeader *) &packet->data;
-
-	timestamp = ( (guint64) g_ntohl (leader->timestamp_high) << 32) | g_ntohl (leader->timestamp_low);
+       timestamp = arv_gvsp_packet_get_timestamp_ticks(packet);
 
 	timestamp_s = timestamp / timestamp_tick_frequency;
 	timestamp_ns = ((timestamp % timestamp_tick_frequency) * 1000000000) / timestamp_tick_frequency;

--- a/src/arvgvstream.c
+++ b/src/arvgvstream.c
@@ -244,6 +244,8 @@ _process_data_leader (ArvGvStreamThreadData *thread_data,
 	frame->buffer->priv->frame_id = arv_gvsp_packet_get_frame_id (packet);
 
 	frame->buffer->priv->system_timestamp_ns = g_get_real_time() * 1000LL;
+       frame->buffer->priv->timestamp_ticks = arv_gvsp_packet_get_timestamp_ticks (packet);
+
 	if (frame->buffer->priv->gvsp_payload_type != ARV_GVSP_PAYLOAD_TYPE_H264) {
 		if (G_LIKELY (thread_data->timestamp_tick_frequency != 0))
 			frame->buffer->priv->timestamp_ns = arv_gvsp_packet_get_timestamp (packet,


### PR DESCRIPTION
This commit exposes the raw ticks timestamp in ArvGvspPackets to ArvBuffers.

Background:

I'm trying to get the actual camera timestamp from a Prosilica GT camera that supports PTP time synchronization, but the ArvBuffer always seems to report system time.  

Looking into it, I found that the timestamp_tick_frequency is not successfully read in arv_gv_device_get_timestamp_tick_frequency, resulting in system time being used as a fallback.

This commit stores and exposes the raw ticks timestamp in the buffer object so that it is available even when the clock frequency is unknown or unavailable.

For this camera the frequency can be obtained by querying "GevTimestampTickFrequency" through arv_device_get_integer_feature_value, which I can use to convert the ticks timestamp to an actual time.