### PR TITLE
Fixes setting framerate for FLIR Blackfly S cameras

### DIFF
--- a/src/arvcamera.c
+++ b/src/arvcamera.c
@@ -916,7 +916,7 @@ arv_camera_set_frame_rate (ArvCamera *camera, double frame_rate)
 			if (camera->priv->has_acquisition_frame_rate_enabled)
 				arv_device_set_integer_feature_value (camera->priv->device, "AcquisitionFrameRateEnabled", 1);
 			else
-				arv_device_set_integer_feature_value (camera->priv->device, "AcquisitionFrameRateEnable", 1);
+				arv_device_set_boolean_feature_value (camera->priv->device, "AcquisitionFrameRateEnable", 1);
 			arv_device_set_string_feature_value (camera->priv->device, "AcquisitionFrameRateAuto", "Off");
 			arv_device_set_float_feature_value (camera->priv->device, "AcquisitionFrameRate", frame_rate);
 			break;


### PR DESCRIPTION
For FLIR Blackfly-S cameras setting the framerate is not possible with the existing code because the boolean feature AcquisitionFrameRateEnable does not accept being set as an integer feature. This pull request fixes the issue.