### PR TITLE
gvstream: add API to free queue owned and packet receiver thread owne…

### DIFF
--- a/src/arvgvstream.c
+++ b/src/arvgvstream.c
@@ -755,9 +755,18 @@ _loop (ArvGvStreamThreadData *thread_data)
 			frame = NULL;
 
 		_check_frame_completion (thread_data, time_us, frame);
+
+		// signal state of owned buffers
+		if (thread_data->frames == NULL) {
+			arv_stream_receiver_buffers_freed (thread_data->stream, TRUE);
+		}
+		else {
+			arv_stream_receiver_buffers_freed (thread_data->stream, FALSE);
+		}
 	} while (!g_atomic_int_get (&thread_data->cancel));
 
 	g_free (packet);
+	arv_stream_receiver_buffers_freed (thread_data->stream, TRUE);
 
 }
 

--- a/src/arvstream.h
+++ b/src/arvstream.h
@@ -93,6 +93,8 @@ void		arv_stream_get_statistics		(ArvStream *stream,
 void 		arv_stream_set_emit_signals 		(ArvStream *stream, gboolean emit_signals);
 gboolean 	arv_stream_get_emit_signals 		(ArvStream *stream);
 
+gboolean	arv_stream_free_buffers				(ArvStream *stream);
+
 G_END_DECLS
 
 #endif

--- a/src/arvstreamprivate.h
+++ b/src/arvstreamprivate.h
@@ -33,7 +33,10 @@ G_BEGIN_DECLS
 
 ArvBuffer *	arv_stream_pop_input_buffer		(ArvStream *stream);
 void		arv_stream_push_output_buffer		(ArvStream *stream, ArvBuffer *buffer);
-void		arv_stream_receiver_buffers_freed	(ArvStream *stream, gboolean state);
+void		arv_stream_receiver_buffers_freed	(ArvStream *stream);
+void		arv_stream_receiver_thread_running	(ArvStream *stream, gboolean state);
+gboolean	arv_stream_free_buffers_requested	(ArvStream *stream);
+
 
 G_END_DECLS
 

--- a/src/arvstreamprivate.h
+++ b/src/arvstreamprivate.h
@@ -33,6 +33,7 @@ G_BEGIN_DECLS
 
 ArvBuffer *	arv_stream_pop_input_buffer		(ArvStream *stream);
 void		arv_stream_push_output_buffer		(ArvStream *stream, ArvBuffer *buffer);
+void		arv_stream_receiver_buffers_freed	(ArvStream *stream, gboolean state);
 
 G_END_DECLS
 


### PR DESCRIPTION
API function (for GigE cams) to free all the buffers, not only the one in the input and output queues, but also the one handled by the packet receiving htread.
Reason: In our current application we have to handle frequent changes of the read-out-region for a grab in a grab-preparation phase some time before the effective image aquisition starts. Some times it can happen that an already prepared snap is aborted before capture and in this case the buffers, which never will be grabbed in, have to be removed.