### PR TITLE
Add nullptr check to uv_device->priv->genicam.

### DIFF
--- a/src/arvuvdevice.c
+++ b/src/arvuvdevice.c
@@ -726,7 +726,8 @@ arv_uv_device_finalize (GObject *object)
 {
 	ArvUvDevice *uv_device = ARV_UV_DEVICE (object);
 
-	g_object_unref (uv_device->priv->genicam);
+	if (uv_device->priv->genicam)
+		g_object_unref(uv_device->priv->genicam);
 
 	g_clear_pointer (&uv_device->priv->vendor, g_free);
 	g_clear_pointer (&uv_device->priv->product, g_free);


### PR DESCRIPTION
This PR adds a nullptr check to uv_device->priv->genicam. This
pointer can be null if the device is already in use and aravis
cannot connect to the camera. Without this check a
'critical g_object_unref assertion 'g_is_object (object)' failed'
will be asserted.