### PR TITLE
Set SO_RCVBUF size to a larger value on discovery socket.

### DIFF
--- a/src/arvgvinterfaceprivate.h
+++ b/src/arvgvinterfaceprivate.h
@@ -34,6 +34,7 @@ G_BEGIN_DECLS
 
 #define ARV_GV_INTERFACE_DISCOVERY_TIMEOUT_MS	1000
 #define ARV_GV_INTERFACE_SOCKET_BUFFER_SIZE	1024
+#define ARV_GV_INTERFACE_DISCOVERY_SOCKET_BUFFER_SIZE	(256*1024)
 
 typedef struct _ArvGvInterfacePrivate ArvGvInterfacePrivate;
 typedef struct _ArvGvInterfaceClass ArvGvInterfaceClass;


### PR DESCRIPTION
This makes discovery work for all the GV devices on networks containing
moderately large numbers of them (in my testing, around 23-24 of them).