### PR TITLE
change order of operations in arv_camera_set_region 

### DIFF
--- a/src/arvcamera.c
+++ b/src/arvcamera.c
@@ -231,14 +231,14 @@ arv_camera_set_region (ArvCamera *camera, gint x, gint y, gint width, gint heigh
 {
 	g_return_if_fail (ARV_IS_CAMERA (camera));
 
-	if (x >= 0)
-		arv_device_set_integer_feature_value (camera->priv->device, "OffsetX", x);
-	if (y >= 0)
-		arv_device_set_integer_feature_value (camera->priv->device, "OffsetY", y);
 	if (width > 0)
 		arv_device_set_integer_feature_value (camera->priv->device, "Width", width);
 	if (height > 0)
 		arv_device_set_integer_feature_value (camera->priv->device, "Height", height);
+	if (x >= 0)
+		arv_device_set_integer_feature_value (camera->priv->device, "OffsetX", x);
+	if (y >= 0)
+		arv_device_set_integer_feature_value (camera->priv->device, "OffsetY", y);
 }
 
 /**

--- a/src/arvcamera.c
+++ b/src/arvcamera.c
@@ -231,6 +231,10 @@ arv_camera_set_region (ArvCamera *camera, gint x, gint y, gint width, gint heigh
 {
 	g_return_if_fail (ARV_IS_CAMERA (camera));
 
+	if (x >= 0)
+		arv_device_set_integer_feature_value (camera->priv->device, "OffsetX", 0);
+	if (y >= 0)
+		arv_device_set_integer_feature_value (camera->priv->device, "OffsetY", 0);
 	if (width > 0)
 		arv_device_set_integer_feature_value (camera->priv->device, "Width", width);
 	if (height > 0)


### PR DESCRIPTION
For example, if camera has Height==MAX_HEIGHT, we can not set OffsetY>0,
so we need set width and height first, and set offsets then.