### PR TITLE
Fixes for GVCP:

### DIFF
--- a/src/arvgvcp.c
+++ b/src/arvgvcp.c
@@ -348,7 +348,7 @@ arv_gvcp_packet_new_discovery_cmd (size_t *packet_size)
  */
 
 ArvGvcpPacket *
-arv_gvcp_packet_new_discovery_ack (size_t *packet_size)
+arv_gvcp_packet_new_discovery_ack (size_t *packet_size, int id)
 {
 	ArvGvcpPacket *packet;
 
@@ -361,7 +361,7 @@ arv_gvcp_packet_new_discovery_ack (size_t *packet_size)
 	packet->header.packet_type = g_htons (ARV_GVCP_PACKET_TYPE_ACK);
 	packet->header.command = g_htons (ARV_GVCP_COMMAND_DISCOVERY_ACK);
 	packet->header.size = g_htons (ARV_GVBS_DISCOVERY_DATA_SIZE);
-	packet->header.id = g_htons (0xffff);
+        packet->header.id = g_htons (id);
 
 	return packet;
 }

--- a/src/arvgvcp.h
+++ b/src/arvgvcp.h
@@ -266,7 +266,7 @@ ArvGvcpPacket * 	arv_gvcp_packet_new_write_register_cmd 	(guint32 address, guint
 ArvGvcpPacket * 	arv_gvcp_packet_new_write_register_ack 	(guint32 data_index,
 								 guint16 packet_id, size_t *packet_size);
 ArvGvcpPacket * 	arv_gvcp_packet_new_discovery_cmd 	(size_t *size);
-ArvGvcpPacket * 	arv_gvcp_packet_new_discovery_ack 	(size_t *packet_size);
+ArvGvcpPacket * 	arv_gvcp_packet_new_discovery_ack 	(size_t *packet_size, int id);
 ArvGvcpPacket * 	arv_gvcp_packet_new_packet_resend_cmd 	(guint32 frame_id,
 								 guint32 first_block, guint32 last_block,
 								 guint16 packet_id, size_t *packet_size);


### PR DESCRIPTION
  - ACK id must match discovery id
  - packet_type field may have additional flags indicating broadcast acknowledge
  - Remove discovery_socket, and bind GVCP socket to all interfaces
  - Add Netmask, Mac address, and version to discovery acknowledge

These were required to get the Aravis fake camera discoverable with the Pleora eBUS player. The last item about adding the netmask, mac address etc were possibly not essential, but added because the Player expected that information to be present in the GVCP discovery response packet.