### PR TITLE
Feature subnet discovery port

### DIFF
--- a/src/arvgvfakecamera.c
+++ b/src/arvgvfakecamera.c
@@ -486,7 +486,6 @@ arv_gv_fake_camera_start (ArvGvFakeCamera *gv_fake_camera)
 			inet_address = g_inet_address_new_from_string ("255.255.255.255");
 			discovery_address_string = g_inet_address_to_string (inet_address);
 			arv_debug_device ("[GvFakeCamera::start] Discovery address = %s", discovery_address_string);
-			g_free (discovery_address_string);
 			inet_socket_address = g_inet_socket_address_new (inet_address, ARV_GVCP_PORT);
 			if (g_strcmp0 (gvcp_address_string, discovery_address_string) == 0)
 				gv_fake_camera->priv->discovery_socket = NULL;
@@ -498,6 +497,7 @@ arv_gv_fake_camera_start (ArvGvFakeCamera *gv_fake_camera)
 					binding_error = TRUE;
 				g_socket_set_blocking (gv_fake_camera->priv->discovery_socket, FALSE);
 			}
+			g_free (discovery_address_string);
 			g_clear_object (&inet_socket_address);
 			g_clear_object (&inet_address);
                         
@@ -507,7 +507,6 @@ arv_gv_fake_camera_start (ArvGvFakeCamera *gv_fake_camera)
                         inet_address = g_inet_socket_address_get_address (G_INET_SOCKET_ADDRESS (socket_address));
 			discovery_address_string = g_inet_address_to_string (inet_address);
 			arv_debug_device ("[GvFakeCamera::start] Discovery address = %s", discovery_address_string);
-			g_free (discovery_address_string);
 			inet_socket_address = g_inet_socket_address_new (inet_address, ARV_GVCP_PORT);
 			if (g_strcmp0 (gvcp_address_string, discovery_address_string) == 0)
 				gv_fake_camera->priv->subnet_discovery_socket = NULL;
@@ -519,10 +518,9 @@ arv_gv_fake_camera_start (ArvGvFakeCamera *gv_fake_camera)
 					binding_error = TRUE;
 				g_socket_set_blocking (gv_fake_camera->priv->subnet_discovery_socket, FALSE);
 			}
+			g_free (discovery_address_string);
 			g_clear_object (&socket_address);
 			g_clear_object (&inet_socket_address);
-			g_clear_object (&inet_address);
-                        
 
 			gv_fake_camera->priv->gvcp_fds[0].fd = g_socket_get_fd (gv_fake_camera->priv->gvcp_socket);
 			gv_fake_camera->priv->gvcp_fds[0].events = G_IO_IN;


### PR DESCRIPTION
Hi Emmanuel,
Here is my alternate implementation of the discovery port listener. This uses a second discovery socket attached to the subnet broadcast address, replicating the existing discovery_socket. This has the advantage of allowing (to the extent possible) multiple fake cameras on the one system, provided multiple interfaces are available.

The code is rather cargo cultish, and not very DRY, but I'm hamstrung by lack of C++ features like destructors :).

As mentioned, please choose either this PR, or PR #268, as both solve my problem. I'll rebase my working repo from yours when merged.