### PR TITLE
global discovery socket needs to be marked SO_REUSEPORT to allow

### DIFF
--- a/src/arvgvfakecamera.c
+++ b/src/arvgvfakecamera.c
@@ -494,7 +494,7 @@ arv_gv_fake_camera_start (ArvGvFakeCamera *gv_fake_camera)
 				gv_fake_camera->priv->discovery_socket = g_socket_new (G_SOCKET_FAMILY_IPV4,
 									    G_SOCKET_TYPE_DATAGRAM,
 									    G_SOCKET_PROTOCOL_UDP, NULL);
-				if (!g_socket_bind (gv_fake_camera->priv->discovery_socket, inet_socket_address, FALSE, NULL)) {
+				if (!g_socket_bind (gv_fake_camera->priv->discovery_socket, inet_socket_address, TRUE/*allow_reuse*/, NULL)) {
 					if (error != NULL) {
 						arv_warning_device ("Failed to bind global discovery socket: %s", error->message);
 						g_clear_error (&error);

--- a/src/arvgvfakecamera.c
+++ b/src/arvgvfakecamera.c
@@ -494,7 +494,7 @@ arv_gv_fake_camera_start (ArvGvFakeCamera *gv_fake_camera)
 				gv_fake_camera->priv->discovery_socket = g_socket_new (G_SOCKET_FAMILY_IPV4,
 									    G_SOCKET_TYPE_DATAGRAM,
 									    G_SOCKET_PROTOCOL_UDP, NULL);
-				if (!g_socket_bind (gv_fake_camera->priv->discovery_socket, inet_socket_address, TRUE/*allow_reuse*/, NULL)) {
+				if (!g_socket_bind (gv_fake_camera->priv->discovery_socket, inet_socket_address, TRUE /*allow_reuse*/, NULL)) {
 					if (error != NULL) {
 						arv_warning_device ("Failed to bind global discovery socket: %s", error->message);
 						g_clear_error (&error);


### PR DESCRIPTION
multiple fake cameras on the same system.

I have just marked the global discovery socket as reusable, which allows multiple cameras provided they are bound to different interfaces. IIUC correctly, Linux will shard the incoming UDP messages across processes - I tested this with arv_viewer, arv-fake-camera and another camera simulator I have written for my own purposes, and that works. Two instances of arv-fake-camera do not show up in the viewer because they both have the same serial number (GV01). Perhaps we can add the interface name somehow into the mix to distinguish them.