### PR TITLE
viewer: Store appstream file in metainfo dir

### DIFF
--- a/viewer/meson.build
+++ b/viewer/meson.build
@@ -1,5 +1,5 @@
 aravis_desktop_dir = join_paths (get_option ('datadir'), 'applications')
-aravis_app_data_dir = join_paths (get_option ('datadir'), 'appdata')
+aravis_app_data_dir = join_paths (get_option ('datadir'), 'metainfo')
 aravis_icon_dir = join_paths (get_option ('datadir'), 'icons', 'hicolor')
 
 viewer_sources = [


### PR DESCRIPTION
"appdata" is the legacy path for AppStream files, and now such directory should be called "metainfo".

https://www.freedesktop.org/software/appstream/docs/chap-Quickstart.html#sect-Quickstart-DesktopApps