### PR TITLE
uvdevice: reset data endpoint in _open_usb_device

### DIFF
--- a/src/arvuvdevice.c
+++ b/src/arvuvdevice.c
@@ -620,6 +620,29 @@ arv_uv_device_get_genicam_xml (ArvDevice *device, size_t *size)
 }
 
 static void
+reset_endpoint (libusb_device_handle *usb_device, guint8 endpoint, guint8 endpoint_flags)
+{
+		// Set endpoint in halt condition
+		int errcode = libusb_control_transfer(usb_device,
+			LIBUSB_ENDPOINT_OUT|LIBUSB_REQUEST_TYPE_STANDARD|LIBUSB_RECIPIENT_ENDPOINT,
+			LIBUSB_REQUEST_SET_FEATURE,
+			0, /*wValue: 0=endpoint_halt*/
+			endpoint|endpoint_flags,
+			0, 0,
+			1000);
+		if (errcode < 0) {
+			arv_warning_device("Failed to set endpoint %x in halt condition: %s", endpoint|endpoint_flags, libusb_error_name(errcode));
+			return;
+		}
+		// Clear halt condtion on the endpoint, effectivelly resetting the pipe
+		errcode = libusb_clear_halt(usb_device, endpoint | endpoint_flags);
+		if (errcode < 0) {
+			arv_warning_device("Failed to clear halt contidion on endpoint: %s", libusb_error_name(errcode));
+			return;
+		}
+}
+
+static void
 _open_usb_device (ArvUvDevice *uv_device)
 {
 	libusb_device **devices;
@@ -749,6 +772,8 @@ arv_uv_device_new (const char *vendor, const char *product, const char *serial_n
 		g_object_unref (uv_device);
 		return NULL;
 	}
+
+	reset_endpoint(uv_device->priv->usb_device, uv_device->priv->data_endpoint, LIBUSB_ENDPOINT_IN);
 
 	return ARV_DEVICE (uv_device);
 }


### PR DESCRIPTION
Fixes #301 

With this PR I no longer have problems with replugging the camera.

I think that the main reason for that problem was that the camera has been in a halted state (see Figure 5-3:  Transmission States in [USB3 Vision Specification](https://www.visiononline.org/userAssets/aiaUploads/file/USB3_Vision_Specification_v1-0-1.pdf))

In order to return camera back to the idle state I'm setting data endpoint in a halted state and immediately clearing that state (this solution I picked up from [here](https://github.com/ni/usb3vision/blob/master/u3v_core.c#L1488) and from [here](https://github.com/signal11/m-stack/blob/master/host_test/feature.c#L97))