### PR TITLE
Ignore duplicate packets in ArvGvStream

### DIFF
--- a/src/arvgvstream.c
+++ b/src/arvgvstream.c
@@ -683,13 +683,14 @@ _process_packet (ArvGvStreamThreadData *thread_data, const ArvGvspPacket *packet
 			frame->error_packet_received = TRUE;
 
 			thread_data->n_error_packets++;
+		} else if (packet_id < frame->n_packets &&
+		           frame->packet_data[packet_id].received) {
+			/* Ignore duplicate packet */
+			thread_data->n_duplicated_packets++;
+			arv_gvsp_packet_debug (packet, packet_size, ARV_DEBUG_LEVEL_LOG);
 		} else {
-			/* Check for duplicated packets */
 			if (packet_id < frame->n_packets) {
-				if (frame->packet_data[packet_id].received)
-					thread_data->n_duplicated_packets++;
-				else
-					frame->packet_data[packet_id].received = TRUE;
+				frame->packet_data[packet_id].received = TRUE;
 			}
 
 			/* Keep track of last packet of a continuous block starting from packet 0 */


### PR DESCRIPTION
With this change, ArvGvStream will discard duplicate packets
for packet_ids already received. The previous behaviour was
to use the payload from the duplicate packet, replacing the
previously received data.

Discarding duplicate packets acts as a workaround for an
issue with PtGrey BlackFly cameras which sometimes send
duplicate packets with incorrect data.

See issue #311