### PR TITLE
introspection: workaround binding issue of boolean returning functions

### DIFF
--- a/docs/reference/aravis/aravis-sections.txt
+++ b/docs/reference/aravis/aravis-sections.txt
@@ -130,6 +130,7 @@ ARV_CAMERA_GET_CLASS
 <SUBSECTION Private>
 ArvCameraPrivate
 ArvCameraClass
+arv_camera_get_boolean_gi
 </SECTION>
 
 <SECTION>
@@ -1046,6 +1047,7 @@ ARV_IS_GC_BOOLEAN_CLASS
 ARV_GC_BOOLEAN_GET_CLASS
 <SUBSECTION Private>
 ArvGcBooleanClass
+arv_gc_boolean_get_value_gi
 </SECTION>
 
 <SECTION>

--- a/src/arvcamera.c
+++ b/src/arvcamera.c
@@ -1905,6 +1905,24 @@ arv_camera_get_boolean (ArvCamera *camera, const char *feature, GError **error)
 }
 
 /**
+ * arv_camera_get_boolean_gi: (rename-to arv_camera_get_boolean)
+ * @camera: a #ArvCamera
+ * @feature: feature name
+ * @value: (out): output value
+ * @error: a #GError placeholder, %NULL to ignore
+ *
+ * Since: 0.8.0
+ */
+
+void
+arv_camera_get_boolean_gi (ArvCamera *camera, const char *feature, gboolean *value, GError **error)
+{
+	g_return_if_fail (value != NULL);
+
+	*value = arv_camera_get_boolean (camera, feature, error);
+}
+
+/**
  * arv_camera_set_string:
  * @camera: a #ArvCamera
  * @feature: feature name

--- a/src/arvcamera.h
+++ b/src/arvcamera.h
@@ -139,6 +139,7 @@ void 		arv_camera_execute_command 		(ArvCamera *camera, const char *feature, GEr
 
 void		arv_camera_set_boolean			(ArvCamera *camera, const char *feature, gboolean value, GError **error);
 gboolean	arv_camera_get_boolean			(ArvCamera *camera, const char *feature, GError **error);
+void		arv_camera_get_boolean_gi		(ArvCamera *camera, const char *feature, gboolean *value, GError **error);
 
 void		arv_camera_set_string			(ArvCamera *camera, const char *feature, const char *value, GError **error);
 const char *	arv_camera_get_string			(ArvCamera *camera, const char *feature, GError **error);

--- a/src/arvgcboolean.c
+++ b/src/arvgcboolean.c
@@ -128,6 +128,16 @@ arv_gc_boolean_get_off_value (ArvGcBoolean *gc_boolean, GError **error)
 	return off_value;
 }
 
+/**
+ * arv_gc_boolean_get_value:
+ * @gc_boolean: a #ArvGcBoolean
+ * @error: a #GError placeholder, %NULL to ignore
+ *
+ * Returns: the feature value.
+ *
+ * Since: 0.8.0
+ */
+
 gboolean
 arv_gc_boolean_get_value (ArvGcBoolean *gc_boolean, GError **error)
 {
@@ -156,6 +166,25 @@ arv_gc_boolean_get_value (ArvGcBoolean *gc_boolean, GError **error)
 	}
 
 	return value == on_value;
+}
+
+/**
+ * arv_gc_boolean_get_value_gi: (rename-to arv_gc_boolean_get_value)
+ * @gc_boolean: a #ArvGcBoolean
+ * @value: (out): feature value
+ * @error: a #GError placeholder, %NULL to ignore
+ *
+ * Get the feature value.
+ *
+ * Since: 0.8.0
+ */
+
+void
+arv_gc_boolean_get_value_gi (ArvGcBoolean *gc_boolean, gboolean *value, GError **error)
+{
+	g_return_if_fail (value != NULL);
+
+	*value = arv_gc_boolean_get_value (gc_boolean, error);
 }
 
 void

--- a/src/arvgcboolean.h
+++ b/src/arvgcboolean.h
@@ -39,6 +39,7 @@ G_DECLARE_FINAL_TYPE (ArvGcBoolean, arv_gc_boolean, ARV, GC_BOOLEAN, ArvGcFeatur
 ArvGcNode * 	arv_gc_boolean_new 		(void);
 
 gboolean 	arv_gc_boolean_get_value 	(ArvGcBoolean *gc_boolean, GError **error);
+void	 	arv_gc_boolean_get_value_gi 	(ArvGcBoolean *gc_boolean, gboolean *value, GError **error);
 void 		arv_gc_boolean_set_value 	(ArvGcBoolean *gc_boolean, gboolean v_boolean, GError **error);
 
 G_END_DECLS

--- a/tests/exception.py
+++ b/tests/exception.py
@@ -48,3 +48,12 @@ try:
 
 except GLib.Error as err:
     assert err.matches (Aravis.device_error_quark(), Aravis.DeviceError.FEATURE_NOT_FOUND)
+
+value = camera.get_boolean ("TestBoolean")
+
+assert value == False
+
+camera.set_boolean ("TestBoolean", True)
+value = camera.get_boolean ("TestBoolean")
+
+assert value == True


### PR DESCRIPTION
The function gc_boolean_get_value take a GError ** and it returns a
boolean, but the return value doesn't indicate if the function call
failed. The result is that the automatically generated bindings assume
there is no data in the return value. In Rust, that translates to a
Result with no value.

Fix the binding by implementing functions taking an ouput parameter, and
using rename-to annotation to replace the functions designed for C use.