### PR TITLE
usb3vision: use libusb async API

### DIFF
--- a/src/arvuvdevice.c
+++ b/src/arvuvdevice.c
@@ -80,6 +80,19 @@ G_DEFINE_TYPE_WITH_CODE (ArvUvDevice, arv_uv_device, ARV_TYPE_DEVICE, G_ADD_PRIV
 
 /* ArvUvDevice implementation */
 
+void arv_uv_device_fill_bulk_transfer (struct libusb_transfer* transfer, ArvUvDevice *uv_device,
+				ArvUvEndpointType endpoint_type, unsigned char endpoint_flags,
+				void *data, size_t size,
+				libusb_transfer_cb_fn callback, void* callback_data,
+				unsigned int timeout)
+{
+	guint8 endpoint;
+
+	endpoint = (endpoint_type == ARV_UV_ENDPOINT_CONTROL) ? uv_device->priv->control_endpoint : uv_device->priv->data_endpoint;
+
+	libusb_fill_bulk_transfer( transfer, uv_device->priv->usb_device, endpoint | endpoint_flags, data, size, callback, callback_data, timeout );
+}
+
 gboolean
 arv_uv_device_bulk_transfer (ArvUvDevice *uv_device, ArvUvEndpointType endpoint_type, unsigned char endpoint_flags, void *data,
 			     size_t size, size_t *transferred_size, guint32 timeout_ms, GError **error)
@@ -729,6 +742,22 @@ _open_usb_device (ArvUvDevice *uv_device)
 	libusb_free_device_list (devices, 1);
 }
 
+static int event_thread_run = 1;
+static GThread* event_thread = NULL;
+
+static gpointer
+event_thread_func(void *ctx)
+{
+	struct timeval tv = { 0, 100 };
+
+    while (event_thread_run)
+	{
+        libusb_handle_events_timeout(ctx, &tv);
+	}
+
+    return NULL;
+}
+
 ArvDevice *
 arv_uv_device_new (const char *vendor, const char *product, const char *serial_nbr)
 {
@@ -778,7 +807,12 @@ arv_uv_device_new (const char *vendor, const char *product, const char *serial_n
 		return NULL;
 	}
 
-	reset_endpoint (uv_device->priv->usb_device, uv_device->priv->data_endpoint, LIBUSB_ENDPOINT_IN);
+	// FIXME: Async mode dosn't work with reset_endpoint
+	if (mode_sync)
+		reset_endpoint (uv_device->priv->usb_device, uv_device->priv->data_endpoint, LIBUSB_ENDPOINT_IN);
+
+	event_thread_run = 1;
+	event_thread = g_thread_new( "libusb events", event_thread_func, uv_device->priv->usb );
 
 	return ARV_DEVICE (uv_device);
 }
@@ -797,6 +831,9 @@ static void
 arv_uv_device_finalize (GObject *object)
 {
 	ArvUvDevice *uv_device = ARV_UV_DEVICE (object);
+
+	event_thread_run = 0;
+	g_thread_join( event_thread );
 
 	g_clear_object (&uv_device->priv->genicam);
 

--- a/src/arvuvdeviceprivate.h
+++ b/src/arvuvdeviceprivate.h
@@ -29,6 +29,7 @@
 
 #include <arvuvdevice.h>
 #include <arvdeviceprivate.h>
+#include <libusb.h>
 
 G_BEGIN_DECLS
 
@@ -41,6 +42,12 @@ gboolean 	arv_uv_device_bulk_transfer 		(ArvUvDevice *uv_device,
 							 ArvUvEndpointType endpoint_type, unsigned char endpoint_flags,
 							 void *data, size_t size, size_t *transferred_size,
 							 guint32 timeout_ms, GError **error);
+
+void arv_uv_device_fill_bulk_transfer (struct libusb_transfer* transfer, ArvUvDevice *uv_device,
+				ArvUvEndpointType endpoint_type, unsigned char endpoint_flags,
+				void *data, size_t size,
+				libusb_transfer_cb_fn callback, void* callback_data,
+				unsigned int timeout);
 
 G_END_DECLS
 

--- a/src/arvuvstreamprivate.h
+++ b/src/arvuvstreamprivate.h
@@ -35,6 +35,8 @@ G_BEGIN_DECLS
 
 ArvStream * 	arv_uv_stream_new	(ArvUvDevice *uv_device, ArvStreamCallback callback, void *user_data);
 
+extern int mode_sync;
+
 G_END_DECLS
 
 #endif


### PR DESCRIPTION
This working release of aync usb on master. I found that async usb doesn't work with reset_endpoint. So I disabled reset_endpoint when working in async mode. To switch to previous sync mode with reset_endpoint assign mode_sync=1 and recompile. Sync mode could be used for debugging and analysis. 

Upstreamed by Constantine Shulyupin <constantine.shulyupin@gmail.com>

    Added:
    event_thread_func
    arv_uv_stream_buffer_context_wait_transfer_completed
    arv_uv_stream_buffer_context_notify_transfer_completed
    arv_uv_stream_buffer_context_new
    arv_uv_stream_buffer_context_cancel
    arv_uv_stream_buffer_context_free
    arv_uv_stream_submit_transfer
    arv_uv_stream_thread_async
    arv_uv_stream_thread_sync (was arv_uv_stream_thread)