### PR TITLE
meson: fix issues when used as a subproject

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -25,14 +25,12 @@ libz_dep = dependency ('zlib', required: true)
 
 libm = cc.find_library ('m', required: true)
 
-aravis_dependencies = [glib_dep, gobject_dep, gio_dep, xml2_dep, libz_dep, libm]
-aravis_dependency_str = 'glib-2.0 gobject-2.0 gio-2.0'
-aravis_private_dependency_str = 'libxml-2.0 zlib'
+aravis_public_dependencies = [glib_dep, gobject_dep, gio_dep]
+aravis_dependencies = [aravis_public_dependencies, xml2_dep, libz_dep, libm]
 
 enable_usb = get_option ('usb')
 if enable_usb
 	aravis_dependencies += dependency ('libusb-1.0', required: true)
-	aravis_private_dependency_str += ' libusb-1.0'
 endif
 
 subdir ('po')

--- a/src/meson.build
+++ b/src/meson.build
@@ -251,16 +251,15 @@ aravis_library = library ('aravis-@0@'.format (aravis_api_version),
 	install: true)
 
 aravis_library_dependencies = declare_dependency (dependencies: aravis_dependencies,
-						  link_with: aravis_library)
+						  link_with: aravis_library, include_directories: library_inc)
 
-pkg.generate (libraries: [aravis_library, libm],
+pkg.generate (aravis_library,
 	      filebase: 'aravis-@0@'.format (aravis_api_version),
 	      version: aravis_version,
 	      subdirs: 'aravis-@0@'.format (aravis_api_version),
 	      name: 'Aravis',
 	      description: 'Camera control and image acquisition library',
-	      requires: aravis_dependency_str,
-	      requires_private: aravis_private_dependency_str)
+	      requires: aravis_public_dependencies)
 
 progs = [[ 'arv-tool', 			'arvtool.c'],
 	 [ 'arv-fake-gv-camera', 	'arvfakegvcamera.c']]


### PR DESCRIPTION
- Add missing include dir to the declared dependency
- Clean up required libraries in pkgconfig generation since meson is  smart enough to do that for us.
  .pc diff (meson 0.54.0):
```diff
8,10c8,11
< Requires: glib-2.0 gobject-2.0 gio-2.0
< Requires.private: glib-2.0 >= 2.44, gobject-2.0, gio-2.0, libxml-2.0, zlib, libusb-1.0, libxml-2.0 zlib libusb-1.0
< Libs: -L${libdir} -laravis-0.8 -lm
---
> Requires: glib-2.0 >= 2.44, gobject-2.0, gio-2.0
> Requires.private: libxml-2.0, zlib, libusb-1.0
> Libs: -L${libdir} -laravis-0.8
> Libs.private: -lm
```
  This also fixes a deprecation warning:
```
subprojects/aravis/src/meson.build:256: DEPRECATION: Library aravis-0.8 was passed to the "libraries" keyword argument of a previous call to generate() method instead of first positional argument. Adding aravis-0.8 to "Requires" field, but this is a deprecated behaviour that will change in a future version of Meson. Please report the issue if this warning cannot be avoided in your case.
```