### PR TITLE
all: fix issues reported by Clang static analyzer

### DIFF
--- a/src/arvcamera.c
+++ b/src/arvcamera.c
@@ -1130,6 +1130,11 @@ arv_camera_get_frame_rate_bounds (ArvCamera *camera, double *min, double *max, G
 					return;
 				}
 
+				if (max != NULL)
+					*max = 0;
+				if (min != NULL)
+					*min = 0;
+
 				for (i = 0; i < n_values; i++) {
 					if (values[i] > 0) {
 						double s;

--- a/src/arvgvfakecamera.c
+++ b/src/arvgvfakecamera.c
@@ -265,13 +265,11 @@ _thread (void *user_data)
 
 	do {
 		guint64 next_timestamp_us;
-		guint64 sleep_time_us;
 
 		if (is_streaming) {
-			sleep_time_us = arv_fake_camera_get_sleep_time_for_next_frame (gv_fake_camera->priv->camera, &next_timestamp_us);
+			arv_fake_camera_get_sleep_time_for_next_frame (gv_fake_camera->priv->camera, &next_timestamp_us);
 		} else {
-			sleep_time_us = 100000;
-			next_timestamp_us = g_get_real_time () + sleep_time_us;
+			next_timestamp_us = g_get_real_time () + 100000;
 		}
 
 		do {

--- a/src/arvmisc.c
+++ b/src/arvmisc.c
@@ -345,11 +345,12 @@ arv_value_copy (ArvValue *to, const ArvValue *from)
 ArvValue *
 arv_value_duplicate (const ArvValue *from)
 {
-	ArvValue *value = g_new (ArvValue, 1);
+	ArvValue *value;
 
 	if (from == NULL)
 		return NULL;
 
+	value = g_new (ArvValue, 1);
 	*value = *from;
 
 	return value;

--- a/src/arvstream.c
+++ b/src/arvstream.c
@@ -480,8 +480,6 @@ arv_stream_init (ArvStream *stream)
 {
 	ArvStreamPrivate *priv = arv_stream_get_instance_private (stream);
 
-	priv = arv_stream_get_instance_private (stream);
-
 	priv->input_queue = g_async_queue_new ();
 	priv->output_queue = g_async_queue_new ();
 


### PR DESCRIPTION
Most of the reported issues are false-positives. The remaining ones
consist of dead code, uninitialized values and one memory leak.