### PR TITLE
build: allow to build arv-viewer without optional libusb

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -26,7 +26,10 @@ usb_dep = dependency ('libusb-1.0', required: get_option ('usb'))
 libm = cc.find_library ('m', required: true)
 
 aravis_public_dependencies = [glib_dep, gobject_dep, gio_dep]
-aravis_dependencies = [aravis_public_dependencies, xml2_dep, libz_dep, libm, usb_dep]
+aravis_dependencies = [aravis_public_dependencies, xml2_dep, libz_dep, libm]
+if usb_dep.found()
+  aravis_dependencies += usb_dep
+endif
 
 has_if_packet = cc.has_header (join_paths ('linux','if_packet.h'))
 packet_socket_option = get_option('packet-socket')


### PR DESCRIPTION
Despite the fact that libusb is an optional dependency, it looks like the viewer is not built if libusb is not found. The proposed solution is to add usb to `aravis_dependencies` only if it was found. I'm not familiar with meson so it may not be the most elegant solution though.