### PR TITLE
arvfakecamera: implement Bayer pixel formats

### DIFF
--- a/src/arv-fake-camera.xml
+++ b/src/arv-fake-camera.xml
@@ -219,6 +219,18 @@
 
 	<Enumeration Name="PixelFormat" NameSpace="Standard">
 		<DisplayName>Pixel format</DisplayName>
+		<EnumEntry Name="BayerBG8" NameSpace="Standard">
+			<Value>17301515</Value>
+		</EnumEntry>
+		<EnumEntry Name="BayerGB8" NameSpace="Standard">
+			<Value>17301514</Value>
+		</EnumEntry>
+		<EnumEntry Name="BayerGR8" NameSpace="Standard">
+			<Value>17301512</Value>
+		</EnumEntry>
+		<EnumEntry Name="BayerRG8" NameSpace="Standard">
+			<Value>17301513</Value>
+		</EnumEntry>
 		<EnumEntry Name="Mono8" NameSpace="Standard">
 			<Value>17301505</Value>
 		</EnumEntry>
@@ -530,4 +542,3 @@
 	</Port>
 
 </RegisterDescription>
-

--- a/src/arvfakecamera.c
+++ b/src/arvfakecamera.c
@@ -541,6 +541,106 @@ arv_fake_camera_diagonal_ramp (ArvBuffer *buffer, void *fill_pattern_data,
 				}
 			break;
 
+        case ARV_PIXEL_FORMAT_BAYER_BG_8:
+            for (y = 0; y < height; y++)
+                for (x = 0; x < width; x++) {
+                    unsigned int index;
+					pixel_value = (x + buffer->priv->frame_id + y) % 255;
+					pixel_value *= scale;
+					index = CLAMP (pixel_value, 0, 255);
+
+                    // BG
+                    // GR
+                    unsigned char *pixel = &buffer->priv->data [y * width + x];
+                    if (x & 1) {
+                        if (y & 1)
+                            *pixel = jet_colormap [index].b;
+                        else
+                            *pixel = jet_colormap [index].g;
+                    } else {
+                        if (y & 1)
+                            *pixel = jet_colormap [index].g;
+                        else
+                            *pixel = jet_colormap [index].r;
+                    }
+                }
+            break;
+
+        case ARV_PIXEL_FORMAT_BAYER_GB_8:
+            for (y = 0; y < height; y++)
+                for (x = 0; x < width; x++) {
+                    unsigned int index;
+					pixel_value = (x + buffer->priv->frame_id + y) % 255;
+					pixel_value *= scale;
+					index = CLAMP (pixel_value, 0, 255);
+
+                    // GB
+                    // RG
+                    unsigned char *pixel = &buffer->priv->data [y * width + x];
+                    if (x & 1) {
+                        if (y & 1)
+                            *pixel = jet_colormap [index].g;
+                        else
+                            *pixel = jet_colormap [index].b;
+                    } else {
+                        if (y & 1)
+                            *pixel = jet_colormap [index].r;
+                        else
+                            *pixel = jet_colormap [index].g;
+                    }
+                }
+            break;
+
+        case ARV_PIXEL_FORMAT_BAYER_GR_8:
+            for (y = 0; y < height; y++)
+                for (x = 0; x < width; x++) {
+					unsigned int index;
+					pixel_value = (x + buffer->priv->frame_id + y) % 255;
+					pixel_value *= scale;
+					index = CLAMP (pixel_value, 0, 255);
+
+                    // GR
+                    // BG
+                    unsigned char *pixel = &buffer->priv->data [y * width + x];
+                    if (x & 1) {
+                        if (y & 1)
+                            *pixel = jet_colormap [index].g;
+                        else
+                            *pixel = jet_colormap [index].r;
+                    } else {
+                        if (y & 1)
+                            *pixel = jet_colormap [index].b;
+                        else
+                            *pixel = jet_colormap [index].g;
+                    }
+                }
+            break;
+
+        case ARV_PIXEL_FORMAT_BAYER_RG_8:
+            for (y = 0; y < height; y++)
+                for (x = 0; x < width; x++) {
+					unsigned int index;
+					pixel_value = (x + buffer->priv->frame_id + y) % 255;
+					pixel_value *= scale;
+					index = CLAMP (pixel_value, 0, 255);
+
+                    // RG
+                    // GB
+                    unsigned char *pixel = &buffer->priv->data [y * width + x];
+                    if (x & 1) {
+                        if (y & 1)
+                            *pixel = jet_colormap [index].r;
+                        else
+                            *pixel = jet_colormap [index].g;
+                    } else {
+                        if (y & 1)
+                            *pixel = jet_colormap [index].g;
+                        else
+                            *pixel = jet_colormap [index].b;
+                    }
+                }
+            break;
+
 		case ARV_PIXEL_FORMAT_RGB_8_PACKED:
 			for (y = 0; y < height; y++)
 				for (x = 0; x < width; x++) {

--- a/tests/fake.c
+++ b/tests/fake.c
@@ -403,6 +403,46 @@ camera_api_test (void)
 	g_assert (error == NULL);
 	g_assert_cmpstr (string, ==, "RGB8");
 
+	arv_camera_set_pixel_format (camera, ARV_PIXEL_FORMAT_BAYER_BG_8, &error);
+	g_assert (error == NULL);
+	pixel_format = arv_camera_get_pixel_format (camera, &error);
+	g_assert (error == NULL);
+	g_assert_cmpint (pixel_format, ==, ARV_PIXEL_FORMAT_BAYER_BG_8);
+
+	string = arv_camera_get_pixel_format_as_string (camera, &error);
+	g_assert (error == NULL);
+	g_assert_cmpstr (string, ==, "BayerBG8");
+
+	arv_camera_set_pixel_format (camera, ARV_PIXEL_FORMAT_BAYER_GB_8, &error);
+	g_assert (error == NULL);
+	pixel_format = arv_camera_get_pixel_format (camera, &error);
+	g_assert (error == NULL);
+	g_assert_cmpint (pixel_format, ==, ARV_PIXEL_FORMAT_BAYER_GB_8);
+
+	string = arv_camera_get_pixel_format_as_string (camera, &error);
+	g_assert (error == NULL);
+	g_assert_cmpstr (string, ==, "BayerGB8");
+
+	arv_camera_set_pixel_format (camera, ARV_PIXEL_FORMAT_BAYER_GR_8, &error);
+	g_assert (error == NULL);
+	pixel_format = arv_camera_get_pixel_format (camera, &error);
+	g_assert (error == NULL);
+	g_assert_cmpint (pixel_format, ==, ARV_PIXEL_FORMAT_BAYER_GR_8);
+
+	string = arv_camera_get_pixel_format_as_string (camera, &error);
+	g_assert (error == NULL);
+	g_assert_cmpstr (string, ==, "BayerGR8");
+
+	arv_camera_set_pixel_format (camera, ARV_PIXEL_FORMAT_BAYER_RG_8, &error);
+	g_assert (error == NULL);
+	pixel_format = arv_camera_get_pixel_format (camera, &error);
+	g_assert (error == NULL);
+	g_assert_cmpint (pixel_format, ==, ARV_PIXEL_FORMAT_BAYER_RG_8);
+
+	string = arv_camera_get_pixel_format_as_string (camera, &error);
+	g_assert (error == NULL);
+	g_assert_cmpstr (string, ==, "BayerRG8");
+
 	arv_camera_set_pixel_format_from_string (camera, "Mono8", &error);
 	g_assert (error == NULL);
 	pixel_format = arv_camera_get_pixel_format (camera, &error);
@@ -412,19 +452,19 @@ camera_api_test (void)
 	ptr = arv_camera_dup_available_pixel_formats (camera, &n, &error);
 	g_assert (error == NULL);
 	g_assert (ptr != NULL);
-	g_assert_cmpint (n, ==, 2);
+	g_assert_cmpint (n, ==, 6);
 	g_clear_pointer (&ptr, g_free);
 
 	ptr = arv_camera_dup_available_pixel_formats_as_strings (camera, &n, &error);
 	g_assert (error == NULL);
 	g_assert (ptr != NULL);
-	g_assert_cmpint (n, ==, 2);
+	g_assert_cmpint (n, ==, 6);
 	g_clear_pointer (&ptr, g_free);
 
 	ptr = arv_camera_dup_available_pixel_formats_as_display_names (camera, &n, &error);
 	g_assert (error == NULL);
 	g_assert (ptr != NULL);
-	g_assert_cmpint (n, ==, 2);
+	g_assert_cmpint (n, ==, 6);
 	g_clear_pointer (&ptr, g_free);
 
 	b = arv_camera_is_frame_rate_available (camera, &error);


### PR DESCRIPTION
Adds support for all Bayer formats to the `arv-fake-gv-camera` utility.

Closes #354