### PR TITLE
gst: Add packet-delay property

### DIFF
--- a/gst/gstaravis.h
+++ b/gst/gstaravis.h
@@ -58,6 +58,7 @@ struct _GstAravis {
 	/* GigEVision parameters */
 	int packet_size;
 	gboolean auto_packet_size;
+	gint64 packet_delay;
         gboolean packet_resend;
 
 	gint payload;


### PR DESCRIPTION
The packet delay is reset on SVS-VISTEK eco424CVGE and exo304CGETR cameras
when GevCCP access is released. Must set it while holding the control
access.

This adds a property as the features property would be more difficult due to the scaling by GevTimestampTickFrequency.