### PR TITLE
gst: Set pixel format before binning and region

### DIFF
--- a/gst/gstaravis.c
+++ b/gst/gstaravis.c
@@ -179,9 +179,9 @@ gst_aravis_set_caps (GstBaseSrc *src, GstCaps *caps)
 
 	pixel_format = arv_pixel_format_from_gst_caps (gst_structure_get_name (structure), format_string, bpp, depth);
 
-	arv_camera_set_region (gst_aravis->camera, gst_aravis->offset_x, gst_aravis->offset_y, width, height, NULL);
-	arv_camera_set_binning (gst_aravis->camera, gst_aravis->h_binning, gst_aravis->v_binning, NULL);
 	arv_camera_set_pixel_format (gst_aravis->camera, pixel_format, NULL);
+	arv_camera_set_binning (gst_aravis->camera, gst_aravis->h_binning, gst_aravis->v_binning, NULL);
+	arv_camera_set_region (gst_aravis->camera, gst_aravis->offset_x, gst_aravis->offset_y, width, height, NULL);
 
 	if (arv_camera_is_gv_device (gst_aravis->camera)) {
 		if (gst_aravis->packet_size > 0)


### PR DESCRIPTION
SVS-Vistek cameras reset Width and Height when PixelFormat is set. With the old initialization order the region was always max size regardless of width and height in caps.