### PR TITLE
Fix spelling available, Unknown, endianness

### DIFF
--- a/docs/arv-tool-0.8.1
+++ b/docs/arv-tool-0.8.1
@@ -27,7 +27,7 @@ genicam:
 dump the content of the Genicam xml data
 .TP
 features:
-list all availale features
+list all available features
 .TP
 description [<feature>] ...:
 show the full feature description

--- a/src/arvdomimplementation.c
+++ b/src/arvdomimplementation.c
@@ -67,7 +67,7 @@ arv_dom_implementation_create_document (const char *namespace_uri,
 
 	document_type = g_hash_table_lookup (document_types, qualified_name);
 	if (document_type == NULL) {
-		arv_debug_dom ("[ArvDomImplementation::create_document] Unknow document type (%s)",
+		arv_debug_dom ("[ArvDomImplementation::create_document] Unknown document type (%s)",
 			       qualified_name);
 		return NULL;
 	}

--- a/src/arvgcpropertynode.c
+++ b/src/arvgcpropertynode.c
@@ -202,7 +202,7 @@ arv_gc_property_node_set_attribute (ArvDomElement *self, const char *name, const
 		g_free (priv->name);
 		priv->name = g_strdup (value);
 	} else
-		arv_debug_dom ("[GcPropertyNode::set_attribute] Uknown attribute '%s'", name);
+		arv_debug_dom ("[GcPropertyNode::set_attribute] Unknown attribute '%s'", name);
 }
 
 static const char *
@@ -213,7 +213,7 @@ arv_gc_property_node_get_attribute (ArvDomElement *self, const char *name)
 	if (strcmp (name, "Name") == 0)
 		return priv->name;
 
-	arv_debug_dom ("[GcPropertyNode::set_attribute] Uknown attribute '%s'", name);
+	arv_debug_dom ("[GcPropertyNode::set_attribute] Unknown attribute '%s'", name);
 
 	return NULL;
 }

--- a/src/arvgcstructentrynode.c
+++ b/src/arvgcstructentrynode.c
@@ -271,7 +271,7 @@ arv_gc_struct_entry_node_get_min (ArvGcInteger *self, GError **error)
 	msb = arv_gc_property_node_get_msb (struct_entry->msb, 31);
 	signedness = arv_gc_property_node_get_sign (struct_entry->sign, ARV_GC_SIGNEDNESS_UNSIGNED);
 
-	/* TODO endianess */
+	/* TODO endianness */
 
 	if (signedness == ARV_GC_SIGNEDNESS_SIGNED) {
 		return -((1 << (msb - lsb  - 1)));
@@ -291,7 +291,7 @@ arv_gc_struct_entry_node_get_max (ArvGcInteger *self, GError **error)
 	msb = arv_gc_property_node_get_msb (struct_entry->msb, 31);
 	signedness = arv_gc_property_node_get_sign (struct_entry->sign, ARV_GC_SIGNEDNESS_UNSIGNED);
 
-	/* TODO endianess */
+	/* TODO endianness */
 
 	if (signedness == ARV_GC_SIGNEDNESS_SIGNED) {
 		return ((1 << (msb - lsb  - 1)) - 1);

--- a/src/arvgvdevice.c
+++ b/src/arvgvdevice.c
@@ -1290,7 +1290,7 @@ arv_gv_device_constructed (GObject *object)
 
 	document = ARV_DOM_DOCUMENT (priv->genicam);
 	register_description = ARV_GC_REGISTER_DESCRIPTION_NODE (arv_dom_document_get_document_element (document));
-	arv_debug_device ("[GvDevice::new] Legacy endianess handling = %s",
+	arv_debug_device ("[GvDevice::new] Legacy endianness handling = %s",
 			  arv_gc_register_description_node_compare_schema_version (register_description, 1, 1, 0) < 0 ?
 			  "yes" : "no");
 }

--- a/src/arvtool.c
+++ b/src/arvtool.c
@@ -364,7 +364,7 @@ arv_tool_execute_command (int argc, char **argv, ArvDevice *device, ArvRegisterC
 			g_strfreev (tokens);
 		}
 	} else {
-		printf ("Unkown command\n");
+		printf ("Unknown command\n");
 	}
 
 	if (arv_option_show_time)

--- a/src/arvuvstream.c
+++ b/src/arvuvstream.c
@@ -212,7 +212,7 @@ arv_uv_stream_thread (void *data)
 					}
 					break;
 				default:
-					arv_debug_stream_thread ("Unkown packet type");
+					arv_debug_stream_thread ("Unknown packet type");
 					break;
 			}
 		}


### PR DESCRIPTION
Debian linter highlighted some common misspellings in the binaries.
"endianess" still reads in the API, but this does not change API.