### PR TITLE
GStreamer Aravissrc plugin deadlocked

### DIFF
--- a/gst/gstaravis.c
+++ b/gst/gstaravis.c
@@ -768,7 +768,7 @@ gst_aravis_get_property (GObject * object, guint prop_id, GValue * value,
 				gst_aravis->gain_auto = arv_camera_get_gain_auto(gst_aravis->camera, NULL);
 			}
 			g_value_set_enum (value, gst_aravis->gain_auto);
-			GST_OBJECT_LOCK (gst_aravis);
+			GST_OBJECT_UNLOCK (gst_aravis);
 			break;
 		case PROP_EXPOSURE:
 			g_value_set_double (value, gst_aravis->exposure_time_us);

--- a/src/arvcamera.c
+++ b/src/arvcamera.c
@@ -2852,7 +2852,7 @@ ArvCamera *
 arv_camera_new (const char *name, GError **error)
 {
 	/* if you need to apply or test for fixups based on the camera model
-	   please do so in arv_camera_constructor and not here, as this breaks
+	   please do so in arv_camera_constructed and not here, as this breaks
 	   objects created with g_object_new, which includes but is not limited to
 	   introspection users */
 
@@ -2899,7 +2899,7 @@ arv_camera_constructed (GObject *object)
 						     "Device '%s' not found", priv->name);
 			else
 				error = g_error_new (ARV_DEVICE_ERROR, ARV_DEVICE_ERROR_NOT_FOUND,
-						     "No supported deice found");
+						     "No supported device found");
 		}
 
 		g_clear_error (&priv->init_error);
@@ -3056,4 +3056,3 @@ arv_camera_initable_iface_init (GInitableIface *iface)
 {
 	iface->init = arv_camera_initable_init;
 }
-


### PR DESCRIPTION
I found the aravissrc in deadlock. Unfortunately I was unable to capture the exact position where it had deadlocked and did not manage to reproduce it, but found some locking omissions through review.

I tried to see if the `gst_aravis_create` could be made to come out from the `arv_stream_timeout_pop_buffer` without delay, but I did not see an interface to tell the stream should stop now. This would be useful if there is need to stop fast. A look at it resulted in some minor cleanups that change no functionality.

I also found some spelling mistakes. Rather than put in own PR, I try if I can save some effort and offer them in this same PR. I'll split to separate PR if that is more convenient.