### PR TITLE
Implements arv_gc_feature_node_get_name_space() function.

### DIFF
--- a/src/arvgcfeaturenode.c
+++ b/src/arvgcfeaturenode.c
@@ -213,6 +213,16 @@ arv_gc_feature_node_get_name (ArvGcFeatureNode *node)
 	return priv->name;
 }
 
+ArvGcNameSpace
+arv_gc_feature_node_get_name_space (ArvGcFeatureNode *node)
+{
+	ArvGcFeatureNodePrivate *priv = arv_gc_feature_node_get_instance_private (node);
+
+	g_return_val_if_fail (ARV_IS_GC_FEATURE_NODE (node), ARV_GC_NAME_SPACE_CUSTOM);
+
+	return priv->name_space;
+}
+
 const char *
 arv_gc_feature_node_get_tooltip (ArvGcFeatureNode *node)
 {

--- a/src/arvgcfeaturenode.h
+++ b/src/arvgcfeaturenode.h
@@ -41,6 +41,7 @@ struct _ArvGcFeatureNodeClass {
 };
 
 const char *		arv_gc_feature_node_get_name			(ArvGcFeatureNode *gc_feature_node);
+ArvGcNameSpace		arv_gc_feature_node_get_name_space		(ArvGcFeatureNode *gc_feature_node);
 
 const char *		arv_gc_feature_node_get_tooltip			(ArvGcFeatureNode *gc_feature_node);
 const char *		arv_gc_feature_node_get_description		(ArvGcFeatureNode *gc_feature_node);


### PR DESCRIPTION
This function is useful for retrieving feature node name space value.

In some cases camera manufacturers do not give detailed display text or description text for some standard feature nodes. By checking feature name and also if standard name space is used in particular feature, we can add our own display text. This is the basic use case.