### PR TITLE
genicam: add 'Representation' property node support

### DIFF
--- a/docs/reference/aravis/aravis-sections.txt
+++ b/docs/reference/aravis/aravis-sections.txt
@@ -549,6 +549,8 @@ arv_gc_property_node_get_msb
 arv_gc_property_node_get_sign
 arv_gc_property_node_get_visibility
 arv_gc_property_node_new_visibility
+arv_gc_property_node_get_representation
+arv_gc_property_node_new_representation
 <SUBSECTION Standard>
 arv_gc_property_node_get_type
 ARV_GC_PROPERTY_NODE
@@ -759,6 +761,7 @@ arv_gc_integer_set_value
 arv_gc_integer_get_min
 arv_gc_integer_get_max
 arv_gc_integer_get_inc
+arv_gc_integer_get_representation
 arv_gc_integer_get_unit
 arv_gc_integer_impose_min
 arv_gc_integer_impose_max
@@ -899,6 +902,7 @@ ArvFakeDevicePrivate
 <TITLE>ArvGc</TITLE>
 ArvGc
 ArvRegisterCachePolicy
+ArvGcRepresentation
 arv_gc_new
 arv_gc_get_node
 arv_gc_get_device
@@ -1090,6 +1094,7 @@ arv_gc_float_set_value
 arv_gc_float_get_min
 arv_gc_float_get_max
 arv_gc_float_get_inc
+arv_gc_float_get_representation
 arv_gc_float_get_unit
 arv_gc_float_impose_min
 arv_gc_float_impose_max

--- a/src/arvgc.c
+++ b/src/arvgc.c
@@ -182,6 +182,8 @@ arv_gc_create_element (ArvDomDocument *document, const char *tag_name)
 		node = arv_gc_property_node_new_slope ();
 	else if (strcmp (tag_name, "Unit") == 0)
 		node = arv_gc_property_node_new_unit ();
+	else if (strcmp (tag_name, "Representation") == 0)
+		node = arv_gc_property_node_new_representation ();
 	else if (strcmp (tag_name, "OnValue") == 0)
 		node = arv_gc_property_node_new_on_value ();
 	else if (strcmp (tag_name, "OffValue") == 0)

--- a/src/arvgcconverter.c
+++ b/src/arvgcconverter.c
@@ -43,6 +43,7 @@ typedef struct {
 	ArvGcPropertyNode *formula_to_node;
 	ArvGcPropertyNode *formula_from_node;
 	ArvGcPropertyNode *unit;
+	ArvGcPropertyNode *representation;
 	ArvGcPropertyNode *is_linear;
 	ArvGcPropertyNode *slope;
 
@@ -84,6 +85,9 @@ arv_gc_converter_post_new_child (ArvDomNode *self, ArvDomNode *child)
 				break;
 			case ARV_GC_PROPERTY_NODE_TYPE_UNIT:
 				priv->unit = property_node;
+				break;
+			case ARV_GC_PROPERTY_NODE_TYPE_REPRESENTATION:
+				priv->representation = property_node;
 				break;
 			case ARV_GC_PROPERTY_NODE_TYPE_IS_LINEAR:
 				priv->is_linear = property_node;
@@ -511,6 +515,19 @@ arv_gc_converter_convert_from_int64 (ArvGcConverter *gc_converter, gint64 value,
 	arv_gc_feature_node_increment_change_count (ARV_GC_FEATURE_NODE (gc_converter));
 	arv_evaluator_set_int64_variable (priv->formula_to, "FROM", value);
 	arv_gc_converter_update_to_variables (gc_converter, error);
+}
+
+ArvGcRepresentation
+arv_gc_converter_get_representation (ArvGcConverter *gc_converter, GError **error)
+{
+	ArvGcConverterPrivate *priv = arv_gc_converter_get_instance_private (gc_converter);
+
+	g_return_val_if_fail (ARV_IS_GC_CONVERTER (gc_converter), ARV_GC_REPRESENTATION_UNDEFINED);
+
+	if (priv->representation == NULL)
+		return ARV_GC_REPRESENTATION_UNDEFINED;
+
+	return arv_gc_property_node_get_representation (ARV_GC_PROPERTY_NODE (priv->representation), ARV_GC_REPRESENTATION_UNDEFINED);
 }
 
 const char *

--- a/src/arvgcconverternode.c
+++ b/src/arvgcconverternode.c
@@ -134,6 +134,12 @@ _get_inc (ArvGcFloat *gc_float, GError **error)
 	return arv_gc_converter_convert_to_double (ARV_GC_CONVERTER (gc_float), ARV_GC_CONVERTER_NODE_TYPE_INC, &local_error);
 }
 
+static ArvGcRepresentation
+arv_gc_converter_get_float_representation (ArvGcFloat *gc_float, GError **error)
+{
+	return arv_gc_converter_get_representation (ARV_GC_CONVERTER (gc_float), error);
+}
+
 static const char *
 arv_gc_converter_get_float_unit (ArvGcFloat *gc_float, GError **error)
 {
@@ -154,6 +160,7 @@ arv_gc_converter_node_float_interface_init (ArvGcFloatInterface *interface)
 	interface->get_max = arv_gc_converter_get_float_max;
 	interface->get_inc = _get_inc;
 	interface->set_value = arv_gc_converter_set_float_value;
+	interface->get_representation = arv_gc_converter_get_float_representation;
 	interface->get_unit = arv_gc_converter_get_float_unit;
 }
 

--- a/src/arvgcconverterprivate.h
+++ b/src/arvgcconverterprivate.h
@@ -35,13 +35,14 @@ typedef enum {
 	ARV_GC_CONVERTER_NODE_TYPE_INC
 } ArvGcConverterNodeType;
 
-const char * 	arv_gc_converter_get_unit	 	(ArvGcConverter *gc_converter, GError **error);
-ArvGcIsLinear	arv_gc_converter_get_is_linear		(ArvGcConverter *gc_converter, GError **error);
+ArvGcRepresentation	arv_gc_converter_get_representation 	(ArvGcConverter *gc_converter, GError **error);
+const char * 		arv_gc_converter_get_unit	 	(ArvGcConverter *gc_converter, GError **error);
+ArvGcIsLinear		arv_gc_converter_get_is_linear		(ArvGcConverter *gc_converter, GError **error);
 
-gint64 		arv_gc_converter_convert_to_int64 	(ArvGcConverter *gc_converter, ArvGcConverterNodeType node_type, GError **error);
-double 		arv_gc_converter_convert_to_double 	(ArvGcConverter *gc_converter, ArvGcConverterNodeType node_type, GError **error);
-void 		arv_gc_converter_convert_from_int64 	(ArvGcConverter *gc_converter, gint64 value, GError **error);
-void		arv_gc_converter_convert_from_double 	(ArvGcConverter *gc_converter, double value, GError **error);
+gint64 			arv_gc_converter_convert_to_int64 	(ArvGcConverter *gc_converter, ArvGcConverterNodeType node_type, GError **error);
+double 			arv_gc_converter_convert_to_double 	(ArvGcConverter *gc_converter, ArvGcConverterNodeType node_type, GError **error);
+void 			arv_gc_converter_convert_from_int64 	(ArvGcConverter *gc_converter, gint64 value, GError **error);
+void			arv_gc_converter_convert_from_double 	(ArvGcConverter *gc_converter, double value, GError **error);
 
 G_END_DECLS
 

--- a/src/arvgcenums.h
+++ b/src/arvgcenums.h
@@ -78,6 +78,33 @@ typedef enum {
 	ARV_GC_VISIBILITY_BEGINNER
 } ArvGcVisibility;
 
+/**
+ * ArvGcRepresentation:
+ * @ARV_GC_REPRESENTATION_UNDEFINED: undefined representation
+ * @ARV_GC_REPRESENTATION_LINEAR: number presented on linear scale (e.g. on a linear slider)
+ * @ARV_GC_REPRESENTATION_LOGARITHMIC: number presented on logarithmic scale (e.g. on a logarithmic slider)
+ * @ARV_GC_REPRESENTATION_BOOLEAN: binary choice (e.g. a checkbox)
+ * @ARV_GC_REPRESENTATION_PURE_NUMBER: number presented in an editable field (e.g. a spinbox)
+ * @ARV_GC_REPRESENTATION_HEX_NUMBER: number presented in hexadecimal format
+ * @ARV_GC_REPRESENTATION_IPV4_ADDRESS: IPv4 address
+ * @ARV_GC_REPRESENTATION_MAC_ADDRESS: MAC address
+ *
+ * Number representation formats.
+ *
+ * Since: 0.8.0
+ */
+
+typedef enum {
+	ARV_GC_REPRESENTATION_UNDEFINED = -1,
+	ARV_GC_REPRESENTATION_LINEAR,
+	ARV_GC_REPRESENTATION_LOGARITHMIC,
+	ARV_GC_REPRESENTATION_BOOLEAN,
+	ARV_GC_REPRESENTATION_PURE_NUMBER,
+	ARV_GC_REPRESENTATION_HEX_NUMBER,
+	ARV_GC_REPRESENTATION_IPV4_ADDRESS,
+	ARV_GC_REPRESENTATION_MAC_ADDRESS
+} ArvGcRepresentation;
+
 G_END_DECLS
 
 #endif

--- a/src/arvgcfloat.c
+++ b/src/arvgcfloat.c
@@ -112,6 +112,32 @@ arv_gc_float_get_inc (ArvGcFloat *gc_float, GError **error)
 	return 1;
 }
 
+/**
+ * arv_gc_float_get_representation:
+ * @gc_float: a #ArvGcFloat
+ * @error: return location for a GError, or NULL
+ *
+ * Get number representation format.
+ *
+ * Returns: Number representation format as #ArvGcRepresentation.
+ */
+
+ArvGcRepresentation
+arv_gc_float_get_representation (ArvGcFloat *gc_float, GError **error)
+{
+	ArvGcFloatInterface *float_interface;
+
+	g_return_val_if_fail (ARV_IS_GC_FLOAT (gc_float), ARV_GC_REPRESENTATION_UNDEFINED);
+	g_return_val_if_fail (error == NULL || *error == NULL, ARV_GC_REPRESENTATION_UNDEFINED);
+
+	float_interface = ARV_GC_FLOAT_GET_IFACE (gc_float);
+
+	if (float_interface->get_representation != NULL)
+		return float_interface->get_representation (gc_float, error);
+
+	return ARV_GC_REPRESENTATION_UNDEFINED;
+}
+
 const char *
 arv_gc_float_get_unit	(ArvGcFloat *gc_float, GError **error)
 {

--- a/src/arvgcfloat.h
+++ b/src/arvgcfloat.h
@@ -28,6 +28,7 @@
 #endif
 
 #include <arvtypes.h>
+#include <arvgcenums.h>
 
 G_BEGIN_DECLS
 
@@ -37,26 +38,28 @@ G_DECLARE_INTERFACE (ArvGcFloat, arv_gc_float, ARV, GC_FLOAT, GObject)
 struct _ArvGcFloatInterface {
 	GTypeInterface parent;
 
-	double		(*get_value)		(ArvGcFloat *gc_float, GError **error);
-	void		(*set_value)		(ArvGcFloat *gc_float, double value, GError **error);
-	double		(*get_min)		(ArvGcFloat *gc_float, GError **error);
-	double		(*get_max)		(ArvGcFloat *gc_float, GError **error);
-	double		(*get_inc)		(ArvGcFloat *gc_float, GError **error);
-	const char *	(*get_unit)		(ArvGcFloat *gc_float, GError **error);
-	void		(*impose_min)		(ArvGcFloat *gc_float, double minimum, GError **error);
-	void		(*impose_max)		(ArvGcFloat *gc_float, double maximum, GError **error);
+	double			(*get_value)		(ArvGcFloat *gc_float, GError **error);
+	void			(*set_value)		(ArvGcFloat *gc_float, double value, GError **error);
+	double			(*get_min)		(ArvGcFloat *gc_float, GError **error);
+	double			(*get_max)		(ArvGcFloat *gc_float, GError **error);
+	double			(*get_inc)		(ArvGcFloat *gc_float, GError **error);
+	ArvGcRepresentation	(*get_representation)	(ArvGcFloat *gc_float, GError **error);
+	const char *		(*get_unit)		(ArvGcFloat *gc_float, GError **error);
+	void			(*impose_min)		(ArvGcFloat *gc_float, double minimum, GError **error);
+	void			(*impose_max)		(ArvGcFloat *gc_float, double maximum, GError **error);
 };
 
-double		arv_gc_float_get_value		(ArvGcFloat *gc_float, GError **error);
-void		arv_gc_float_set_value		(ArvGcFloat *gc_float, double value, GError **error);
-double		arv_gc_float_get_min		(ArvGcFloat *gc_float, GError **error);
-double		arv_gc_float_get_max		(ArvGcFloat *gc_float, GError **error);
-double		arv_gc_float_get_inc		(ArvGcFloat *gc_float, GError **error);
-const char *	arv_gc_float_get_unit		(ArvGcFloat *gc_float, GError **error);
-void		arv_gc_float_impose_min		(ArvGcFloat *gc_float, double minimum, GError **error);
-void		arv_gc_float_impose_max		(ArvGcFloat *gc_float, double maximum, GError **error);
+double			arv_gc_float_get_value		(ArvGcFloat *gc_float, GError **error);
+void			arv_gc_float_set_value		(ArvGcFloat *gc_float, double value, GError **error);
+double			arv_gc_float_get_min		(ArvGcFloat *gc_float, GError **error);
+double			arv_gc_float_get_max		(ArvGcFloat *gc_float, GError **error);
+double			arv_gc_float_get_inc		(ArvGcFloat *gc_float, GError **error);
+ArvGcRepresentation	arv_gc_float_get_representation	(ArvGcFloat *gc_float, GError **error);
+const char *		arv_gc_float_get_unit		(ArvGcFloat *gc_float, GError **error);
+void			arv_gc_float_impose_min		(ArvGcFloat *gc_float, double minimum, GError **error);
+void			arv_gc_float_impose_max		(ArvGcFloat *gc_float, double maximum, GError **error);
 
-/* FIXME get_representation, has_inc and get_inc are missing */
+/* FIXME has_inc and get_inc are missing */
 
 G_END_DECLS
 

--- a/src/arvgcfloatnode.c
+++ b/src/arvgcfloatnode.c
@@ -43,6 +43,7 @@ struct _ArvGcFloatNode {
 	ArvGcPropertyNode *maximum;
 	ArvGcPropertyNode *increment;
 	ArvGcPropertyNode *unit;
+	ArvGcPropertyNode *representation;
 
 	ArvGcPropertyNode *index;
 	GSList *value_indexed_nodes;
@@ -93,6 +94,9 @@ arv_gc_float_node_post_new_child (ArvDomNode *self, ArvDomNode *child)
 				break;
 			case ARV_GC_PROPERTY_NODE_TYPE_UNIT:
 				node->unit = property_node;
+				break;
+			case ARV_GC_PROPERTY_NODE_TYPE_REPRESENTATION:
+				node->representation = property_node;
 				break;
 			case ARV_GC_PROPERTY_NODE_TYPE_P_INDEX:
 				node->index = property_node;
@@ -340,6 +344,17 @@ arv_gc_float_node_get_inc (ArvGcFloat *gc_float, GError **error)
 	return value;
 }
 
+static ArvGcRepresentation
+arv_gc_float_node_get_representation (ArvGcFloat *gc_float, GError **error)
+{
+	ArvGcFloatNode *gc_float_node = ARV_GC_FLOAT_NODE (gc_float);
+
+	if (gc_float_node->representation == NULL)
+		return ARV_GC_REPRESENTATION_UNDEFINED;
+
+	return arv_gc_property_node_get_representation (ARV_GC_PROPERTY_NODE (gc_float_node->representation), ARV_GC_REPRESENTATION_UNDEFINED);
+}
+
 static const char *
 arv_gc_float_node_get_unit (ArvGcFloat *gc_float, GError **error)
 {
@@ -398,6 +413,7 @@ arv_gc_float_node_float_interface_init (ArvGcFloatInterface *interface)
 	interface->get_min = arv_gc_float_node_get_min;
 	interface->get_max = arv_gc_float_node_get_max;
 	interface->get_inc = arv_gc_float_node_get_inc;
+	interface->get_representation = arv_gc_float_node_get_representation;
 	interface->get_unit = arv_gc_float_node_get_unit;
 	interface->impose_min = arv_gc_float_node_impose_min;
 	interface->impose_max = arv_gc_float_node_impose_max;

--- a/src/arvgcfloatregnode.c
+++ b/src/arvgcfloatregnode.c
@@ -30,6 +30,7 @@
 typedef struct {
 	ArvGcPropertyNode *endianness;
 	ArvGcPropertyNode *unit;
+	ArvGcPropertyNode *representation;
 
 	GSList *selecteds;
 } ArvGcFloatRegNodePrivate;
@@ -62,11 +63,13 @@ arv_gc_float_reg_node_post_new_child (ArvDomNode *self, ArvDomNode *child)
 			case ARV_GC_PROPERTY_NODE_TYPE_UNIT:
 				priv->unit = property_node;
 				break;
+			case ARV_GC_PROPERTY_NODE_TYPE_REPRESENTATION:
+				priv->representation = property_node;
+				break;
 			case ARV_GC_PROPERTY_NODE_TYPE_P_SELECTED:
 				priv->selecteds = g_slist_prepend (priv->selecteds, property_node);
 				break;
 
-				/* TODO Representation */
 				/* TODO DisplayNotation */
 				/* TODO DisplayPrecision */
 
@@ -203,6 +206,17 @@ arv_gc_float_reg_node_get_max (ArvGcFloat *self, GError **error)
 	return G_MAXDOUBLE;
 }
 
+static ArvGcRepresentation
+arv_gc_float_reg_get_representation (ArvGcFloat *self, GError **error)
+{
+	ArvGcFloatRegNodePrivate *priv = arv_gc_float_reg_node_get_instance_private (ARV_GC_FLOAT_REG_NODE (self));
+
+	if (priv->representation == NULL)
+		return ARV_GC_REPRESENTATION_UNDEFINED;
+
+	return arv_gc_property_node_get_representation (priv->representation, ARV_GC_REPRESENTATION_UNDEFINED);
+}
+
 static const char *
 arv_gc_float_reg_node_get_unit (ArvGcFloat *self, GError **error)
 {
@@ -235,6 +249,7 @@ arv_gc_float_reg_node_float_interface_init (ArvGcFloatInterface *interface)
 	interface->set_value = arv_gc_float_reg_node_set_float_value;
 	interface->get_min = arv_gc_float_reg_node_get_min;
 	interface->get_max = arv_gc_float_reg_node_get_max;
+	interface->get_representation = arv_gc_float_reg_get_representation;
 	interface->get_unit = arv_gc_float_reg_node_get_unit;
 }
 

--- a/src/arvgcintconverternode.c
+++ b/src/arvgcintconverternode.c
@@ -131,6 +131,12 @@ arv_gc_converter_set_integer_value (ArvGcInteger *gc_integer, gint64 value, GErr
 	arv_gc_converter_convert_from_int64 (ARV_GC_CONVERTER (gc_integer), value, error);
 }
 
+static ArvGcRepresentation
+arv_gc_converter_get_integer_representation (ArvGcInteger *gc_integer, GError **error)
+{
+	return arv_gc_converter_get_representation (ARV_GC_CONVERTER (gc_integer), error);
+}
+
 static const char *
 arv_gc_converter_get_integer_unit (ArvGcInteger *gc_integer, GError **error)
 {
@@ -145,6 +151,7 @@ arv_gc_int_converter_node_integer_interface_init (ArvGcIntegerInterface *interfa
 	interface->get_max = arv_gc_converter_get_integer_max;
 	interface->get_inc = _get_inc;
 	interface->set_value = arv_gc_converter_set_integer_value;
+	interface->get_representation = arv_gc_converter_get_integer_representation;
 	interface->get_unit = arv_gc_converter_get_integer_unit;
 }
 

--- a/src/arvgcinteger.c
+++ b/src/arvgcinteger.c
@@ -112,6 +112,32 @@ arv_gc_integer_get_inc (ArvGcInteger *gc_integer, GError **error)
 	return 1;
 }
 
+/**
+ * arv_gc_integer_get_representation:
+ * @gc_integer: a #ArvGcInteger
+ * @error: return location for a GError, or NULL
+ *
+ * Get number representation format.
+ *
+ * Returns: Number representation format as #ArvGcRepresentation.
+ */
+
+ArvGcRepresentation
+arv_gc_integer_get_representation (ArvGcInteger *gc_integer, GError **error)
+{
+	ArvGcIntegerInterface *integer_interface;
+
+	g_return_val_if_fail (ARV_IS_GC_INTEGER (gc_integer), 0);
+	g_return_val_if_fail (error == NULL || *error == NULL, 0);
+
+	integer_interface = ARV_GC_INTEGER_GET_IFACE (gc_integer);
+
+	if (integer_interface->get_representation != NULL)
+		return integer_interface->get_representation (gc_integer, error);
+
+	return ARV_GC_REPRESENTATION_UNDEFINED;
+}
+
 const char *
 arv_gc_integer_get_unit	(ArvGcInteger *gc_integer, GError **error)
 {

--- a/src/arvgcinteger.h
+++ b/src/arvgcinteger.h
@@ -28,6 +28,7 @@
 #endif
 
 #include <arvtypes.h>
+#include <arvgcenums.h>
 
 G_BEGIN_DECLS
 
@@ -37,26 +38,26 @@ G_DECLARE_INTERFACE (ArvGcInteger, arv_gc_integer, ARV, GC_INTEGER, GObject)
 struct _ArvGcIntegerInterface {
 	GTypeInterface parent;
 
-	gint64		(*get_value)		(ArvGcInteger *gc_integer, GError **error);
-	void		(*set_value)		(ArvGcInteger *gc_integer, gint64 value, GError **error);
-	gint64		(*get_min)		(ArvGcInteger *gc_integer, GError **error);
-	gint64		(*get_max)		(ArvGcInteger *gc_integer, GError **error);
-	gint64		(*get_inc)		(ArvGcInteger *gc_integer, GError **error);
-	const char *	(*get_unit)		(ArvGcInteger *gc_integer, GError **error);
-	void		(*impose_min)		(ArvGcInteger *gc_integer, gint64 minimum, GError **error);
-	void		(*impose_max)		(ArvGcInteger *gc_integer, gint64 maximum, GError **error);
+	gint64			(*get_value)		(ArvGcInteger *gc_integer, GError **error);
+	void			(*set_value)		(ArvGcInteger *gc_integer, gint64 value, GError **error);
+	gint64			(*get_min)		(ArvGcInteger *gc_integer, GError **error);
+	gint64			(*get_max)		(ArvGcInteger *gc_integer, GError **error);
+	gint64			(*get_inc)		(ArvGcInteger *gc_integer, GError **error);
+	ArvGcRepresentation	(*get_representation)	(ArvGcInteger *gc_integer, GError **error);
+	const char *		(*get_unit)		(ArvGcInteger *gc_integer, GError **error);
+	void			(*impose_min)		(ArvGcInteger *gc_integer, gint64 minimum, GError **error);
+	void			(*impose_max)		(ArvGcInteger *gc_integer, gint64 maximum, GError **error);
 };
 
-gint64		arv_gc_integer_get_value	(ArvGcInteger *gc_integer, GError **error);
-void		arv_gc_integer_set_value	(ArvGcInteger *gc_integer, gint64 value, GError **error);
-gint64		arv_gc_integer_get_min		(ArvGcInteger *gc_integer, GError **error);
-gint64		arv_gc_integer_get_max		(ArvGcInteger *gc_integer, GError **error);
-gint64		arv_gc_integer_get_inc		(ArvGcInteger *gc_integer, GError **error);
-const char *	arv_gc_integer_get_unit		(ArvGcInteger *gc_integer, GError **error);
-void		arv_gc_integer_impose_min	(ArvGcInteger *gc_integer, gint64 minimum, GError **error);
-void		arv_gc_integer_impose_max	(ArvGcInteger *gc_integer, gint64 maximum, GError **error);
-
-/* FIXME get_representation is missing */
+gint64			arv_gc_integer_get_value		(ArvGcInteger *gc_integer, GError **error);
+void			arv_gc_integer_set_value		(ArvGcInteger *gc_integer, gint64 value, GError **error);
+gint64			arv_gc_integer_get_min			(ArvGcInteger *gc_integer, GError **error);
+gint64			arv_gc_integer_get_max			(ArvGcInteger *gc_integer, GError **error);
+gint64			arv_gc_integer_get_inc			(ArvGcInteger *gc_integer, GError **error);
+ArvGcRepresentation	arv_gc_integer_get_representation	(ArvGcInteger *gc_integer, GError **error);
+const char *		arv_gc_integer_get_unit			(ArvGcInteger *gc_integer, GError **error);
+void			arv_gc_integer_impose_min		(ArvGcInteger *gc_integer, gint64 minimum, GError **error);
+void			arv_gc_integer_impose_max		(ArvGcInteger *gc_integer, gint64 maximum, GError **error);
 
 G_END_DECLS
 

--- a/src/arvgcintegernode.c
+++ b/src/arvgcintegernode.c
@@ -44,6 +44,7 @@ struct _ArvGcIntegerNode {
 	ArvGcPropertyNode *maximum;
 	ArvGcPropertyNode *increment;
 	ArvGcPropertyNode *unit;
+	ArvGcPropertyNode *representation;
 
 	ArvGcPropertyNode *index;
 	GSList *value_indexed_nodes;
@@ -99,6 +100,9 @@ arv_gc_integer_node_post_new_child (ArvDomNode *self, ArvDomNode *child)
 				break;
 			case ARV_GC_PROPERTY_NODE_TYPE_UNIT:
 				node->unit = property_node;
+				break;
+			case ARV_GC_PROPERTY_NODE_TYPE_REPRESENTATION:
+				node->representation = property_node;
 				break;
 			case ARV_GC_PROPERTY_NODE_TYPE_P_INDEX:
 				node->index = property_node;
@@ -354,6 +358,17 @@ arv_gc_integer_node_get_inc (ArvGcInteger *gc_integer, GError **error)
 	return value;
 }
 
+static ArvGcRepresentation
+arv_gc_integer_node_get_representation (ArvGcInteger *gc_integer, GError **error)
+{
+	ArvGcIntegerNode *gc_integer_node = ARV_GC_INTEGER_NODE (gc_integer);
+
+	if (gc_integer_node->representation == NULL)
+		return ARV_GC_REPRESENTATION_UNDEFINED;
+
+	return arv_gc_property_node_get_representation (ARV_GC_PROPERTY_NODE (gc_integer_node->representation), ARV_GC_REPRESENTATION_UNDEFINED);
+}
+
 static const char *
 arv_gc_integer_node_get_unit (ArvGcInteger *gc_integer, GError **error)
 {
@@ -412,6 +427,7 @@ arv_gc_integer_node_integer_interface_init (ArvGcIntegerInterface *interface)
 	interface->get_min = arv_gc_integer_node_get_min;
 	interface->get_max = arv_gc_integer_node_get_max;
 	interface->get_inc = arv_gc_integer_node_get_inc;
+	interface->get_representation = arv_gc_integer_node_get_representation;
 	interface->get_unit = arv_gc_integer_node_get_unit;
 	interface->impose_min = arv_gc_integer_node_impose_min;
 	interface->impose_max = arv_gc_integer_node_impose_max;

--- a/src/arvgcintregnode.c
+++ b/src/arvgcintregnode.c
@@ -31,6 +31,7 @@ typedef struct {
 	ArvGcPropertyNode *sign;
 	ArvGcPropertyNode *endianness;
 	ArvGcPropertyNode *unit;
+	ArvGcPropertyNode *representation;
 
 	GSList *selecteds;
 	GSList *selected_features;
@@ -69,12 +70,12 @@ arv_gc_int_reg_node_post_new_child (ArvDomNode *self, ArvDomNode *child)
 			case ARV_GC_PROPERTY_NODE_TYPE_UNIT:
 				priv->unit = property_node;
 				break;
+			case ARV_GC_PROPERTY_NODE_TYPE_REPRESENTATION:
+				priv->representation = property_node;
+				break;
 			case ARV_GC_PROPERTY_NODE_TYPE_P_SELECTED:
 				priv->selecteds = g_slist_prepend (priv->selecteds, property_node);
 				break;
-
-				/* TODO Representation */
-
 			default:
 				ARV_DOM_NODE_CLASS (arv_gc_int_reg_node_parent_class)->post_new_child (self, child);
 				break;
@@ -180,6 +181,17 @@ arv_gc_int_reg_node_get_inc (ArvGcInteger *self, GError **error)
 	return 1;
 }
 
+static ArvGcRepresentation
+arv_gc_int_reg_node_get_representation (ArvGcInteger *self, GError **error)
+{
+	ArvGcIntRegNodePrivate *priv = arv_gc_int_reg_node_get_instance_private (ARV_GC_INT_REG_NODE (self));
+
+	if (priv->representation == NULL)
+		return ARV_GC_REPRESENTATION_UNDEFINED;
+
+	return arv_gc_property_node_get_representation (priv->representation, ARV_GC_REPRESENTATION_UNDEFINED);
+}
+
 static const char *
 arv_gc_int_reg_node_get_unit (ArvGcInteger *self, GError **error)
 {
@@ -213,6 +225,7 @@ arv_gc_int_reg_node_integer_interface_init (ArvGcIntegerInterface *interface)
 	interface->get_min = arv_gc_int_reg_node_get_min;
 	interface->get_max = arv_gc_int_reg_node_get_max;
 	interface->get_inc = arv_gc_int_reg_node_get_inc;
+	interface->get_representation = arv_gc_int_reg_node_get_representation;
 	interface->get_unit = arv_gc_int_reg_node_get_unit;
 }
 

--- a/src/arvgcmaskedintregnode.c
+++ b/src/arvgcmaskedintregnode.c
@@ -35,6 +35,7 @@ typedef struct {
 	ArvGcPropertyNode *sign;
 	ArvGcPropertyNode *endianness;
 	ArvGcPropertyNode *unit;
+	ArvGcPropertyNode *representation;
 
 	GSList *selecteds;
 	GSList *selected_features;
@@ -83,12 +84,12 @@ arv_gc_masked_int_reg_node_post_new_child (ArvDomNode *self, ArvDomNode *child)
 			case ARV_GC_PROPERTY_NODE_TYPE_UNIT:
 				priv->unit = property_node;
 				break;
+			case ARV_GC_PROPERTY_NODE_TYPE_REPRESENTATION:
+				priv->representation = property_node;
+				break;
 			case ARV_GC_PROPERTY_NODE_TYPE_P_SELECTED:
 				priv->selecteds = g_slist_prepend (priv->selecteds, property_node);
 				break;
-
-				/* TODO Representation */
-
 			default:
 				ARV_DOM_NODE_CLASS (arv_gc_masked_int_reg_node_parent_class)->post_new_child (self, child);
 				break;
@@ -174,6 +175,17 @@ arv_gc_masked_int_reg_node_get_max (ArvGcInteger *self, GError **error)
 	}
 }
 
+static ArvGcRepresentation
+arv_gc_masked_int_reg_node_get_representation (ArvGcInteger *self, GError **error)
+{
+	ArvGcMaskedIntRegNodePrivate *priv = arv_gc_masked_int_reg_node_get_instance_private (ARV_GC_MASKED_INT_REG_NODE (self));
+
+	if (priv->representation == NULL)
+		return ARV_GC_REPRESENTATION_UNDEFINED;
+
+	return arv_gc_property_node_get_representation (priv->representation, ARV_GC_REPRESENTATION_UNDEFINED);
+}
+
 static const char *
 arv_gc_masked_int_reg_node_get_unit (ArvGcInteger *self, GError **error)
 {
@@ -206,6 +218,7 @@ arv_gc_masked_int_reg_node_integer_interface_init (ArvGcIntegerInterface *interf
 	interface->set_value = arv_gc_masked_int_reg_node_set_integer_value;
 	interface->get_min = arv_gc_masked_int_reg_node_get_min;
 	interface->get_max = arv_gc_masked_int_reg_node_get_max;
+	interface->get_representation = arv_gc_masked_int_reg_node_get_representation;
 	interface->get_unit = arv_gc_masked_int_reg_node_get_unit;
 }
 

--- a/src/arvgcpropertynode.c
+++ b/src/arvgcpropertynode.c
@@ -88,6 +88,8 @@ arv_gc_property_node_get_node_name (ArvDomNode *node)
 			return "Inc";
 		case ARV_GC_PROPERTY_NODE_TYPE_IS_LINEAR:
 			return "IsLinear";
+		case ARV_GC_PROPERTY_NODE_TYPE_REPRESENTATION:
+			return "Representation";
 		case ARV_GC_PROPERTY_NODE_TYPE_UNIT:
 			return "Unit";
 		case ARV_GC_PROPERTY_NODE_TYPE_ON_VALUE:
@@ -639,6 +641,44 @@ ArvGcNode *
 arv_gc_property_node_new_is_linear (void)
 {
 	return arv_gc_property_node_new (ARV_GC_PROPERTY_NODE_TYPE_IS_LINEAR);
+}
+
+ArvGcNode *
+arv_gc_property_node_new_representation (void)
+{
+	return arv_gc_property_node_new (ARV_GC_PROPERTY_NODE_TYPE_REPRESENTATION);
+}
+
+ArvGcRepresentation
+arv_gc_property_node_get_representation (ArvGcPropertyNode *self, ArvGcRepresentation default_value)
+{
+	ArvGcPropertyNodePrivate *priv = arv_gc_property_node_get_instance_private (self);
+	const char *value;
+
+	if (self == NULL)
+		return default_value;
+
+	g_return_val_if_fail (ARV_IS_GC_PROPERTY_NODE (self), default_value);
+	g_return_val_if_fail (priv->type == ARV_GC_PROPERTY_NODE_TYPE_REPRESENTATION, default_value);
+
+	value = _get_value_data (self);
+
+	if (g_strcmp0 (value, "Linear") == 0)
+		return ARV_GC_REPRESENTATION_LINEAR;
+	else if (g_strcmp0 (value, "Logarithmic") == 0)
+		return ARV_GC_REPRESENTATION_LOGARITHMIC;
+	else if (g_strcmp0 (value, "Boolean") == 0)
+		return ARV_GC_REPRESENTATION_BOOLEAN;
+	else if (g_strcmp0 (value, "PureNumber") == 0)
+		return ARV_GC_REPRESENTATION_PURE_NUMBER;
+	else if (g_strcmp0 (value, "HexNumber") == 0)
+		return ARV_GC_REPRESENTATION_HEX_NUMBER;
+	else if (g_strcmp0 (value, "IPV4Address") == 0)
+		return ARV_GC_REPRESENTATION_IPV4_ADDRESS;
+	else if (g_strcmp0 (value, "MACAddress") == 0)
+		return ARV_GC_REPRESENTATION_MAC_ADDRESS;
+
+	return default_value;
 }
 
 ArvGcNode *

--- a/src/arvgcpropertynode.h
+++ b/src/arvgcpropertynode.h
@@ -46,6 +46,7 @@ typedef enum {
 	ARV_GC_PROPERTY_NODE_TYPE_SLOPE,
 	ARV_GC_PROPERTY_NODE_TYPE_INCREMENT,
 	ARV_GC_PROPERTY_NODE_TYPE_IS_LINEAR,
+	ARV_GC_PROPERTY_NODE_TYPE_REPRESENTATION,
 	ARV_GC_PROPERTY_NODE_TYPE_UNIT,
 	ARV_GC_PROPERTY_NODE_TYPE_ON_VALUE,
 	ARV_GC_PROPERTY_NODE_TYPE_OFF_VALUE,
@@ -115,6 +116,7 @@ ArvGcNode * 	arv_gc_property_node_new_slope			(void);
 ArvGcNode * 	arv_gc_property_node_new_increment		(void);
 ArvGcNode * 	arv_gc_property_node_new_p_increment		(void);
 ArvGcNode * 	arv_gc_property_node_new_is_linear		(void);
+ArvGcNode * 	arv_gc_property_node_new_representation		(void);
 ArvGcNode * 	arv_gc_property_node_new_unit			(void);
 ArvGcNode * 	arv_gc_property_node_new_on_value 		(void);
 ArvGcNode * 	arv_gc_property_node_new_off_value 		(void);
@@ -163,6 +165,7 @@ guint	 		arv_gc_property_node_get_msb		(ArvGcPropertyNode *self, guint default_v
 ArvGcCachable		arv_gc_property_node_get_cachable	(ArvGcPropertyNode *self, ArvGcCachable default_value);
 ArvGcAccessMode		arv_gc_property_node_get_access_mode	(ArvGcPropertyNode *self, ArvGcAccessMode default_value);
 ArvGcVisibility 	arv_gc_property_node_get_visibility 	(ArvGcPropertyNode *self, ArvGcVisibility default_value);
+ArvGcRepresentation 	arv_gc_property_node_get_representation (ArvGcPropertyNode *self, ArvGcRepresentation default_value);
 
 ArvGcNode *		arv_gc_property_node_get_linked_node	(ArvGcPropertyNode *node);
 ArvGcPropertyNodeType	arv_gc_property_node_get_node_type	(ArvGcPropertyNode *node);

--- a/src/arvgcstructentrynode.c
+++ b/src/arvgcstructentrynode.c
@@ -42,6 +42,7 @@ struct _ArvGcStructEntryNode {
 	ArvGcFeatureNode node;
 
 	ArvGcPropertyNode *sign;
+	ArvGcPropertyNode *representation;
 	ArvGcPropertyNode *lsb;
 	ArvGcPropertyNode *msb;
 	ArvGcPropertyNode *cachable;
@@ -79,6 +80,9 @@ arv_gc_struct_entry_node_post_new_child (ArvDomNode *self, ArvDomNode *child)
 		switch (arv_gc_property_node_get_node_type (property_node)) {
 			case ARV_GC_PROPERTY_NODE_TYPE_SIGN:
 				node->sign = property_node;
+				break;
+			case ARV_GC_PROPERTY_NODE_TYPE_REPRESENTATION:
+				node->representation = property_node;
 				break;
 			case ARV_GC_PROPERTY_NODE_TYPE_LSB:
 				node->lsb = property_node;
@@ -300,6 +304,17 @@ arv_gc_struct_entry_node_get_max (ArvGcInteger *self, GError **error)
 	}
 }
 
+static ArvGcRepresentation
+arv_gc_struct_entry_node_get_representation (ArvGcInteger *self, GError **error)
+{
+	ArvGcStructEntryNode *struct_entry = ARV_GC_STRUCT_ENTRY_NODE (self);
+
+	if (struct_entry->representation == NULL)
+		return ARV_GC_REPRESENTATION_UNDEFINED;
+
+	return arv_gc_property_node_get_representation (struct_entry->representation, ARV_GC_REPRESENTATION_UNDEFINED);
+}
+
 static void
 arv_gc_struct_entry_node_integer_interface_init (ArvGcIntegerInterface *interface)
 {
@@ -307,4 +322,5 @@ arv_gc_struct_entry_node_integer_interface_init (ArvGcIntegerInterface *interfac
 	interface->set_value = arv_gc_struct_entry_node_set_integer_value;
 	interface->get_min = arv_gc_struct_entry_node_get_min;
 	interface->get_max = arv_gc_struct_entry_node_get_max;
+	interface->get_representation = arv_gc_struct_entry_node_get_representation;
 }


### PR DESCRIPTION
This commit adds support for Representation property nodes which specify how integer and float values should be shown to user (e.g. as hex values).

From limited testing it seems that everything works, but testing/review would be much appreciated. Unit tests succeed, but I have not added extra tests for checking representation property.

I have used both `error` and `default_value` style functions. The `ArvGc*Interface` methods all have `error` parameters so I followed that with `get_representation` functions. However in `arv_gc_property_node_get_representation` I used `default_value` to match other property node functions. The result is that `get_representation` really never throws an error and silently returns `ARV_GC_REPRESENTATION_UNDEFINED` on errors. The default value for all nodes is actually `ARV_GC_REPRESENTATION_PURE_NUMBER`. Should we return this instead?