### PR TITLE
genicam: add documentation related to ArvGcNameSpace

### DIFF
--- a/docs/reference/aravis/aravis-sections.txt
+++ b/docs/reference/aravis/aravis-sections.txt
@@ -620,6 +620,7 @@ ArvGcFeatureNode
 arv_gc_feature_node_get_value_as_string
 arv_gc_feature_node_set_value_from_string
 arv_gc_feature_node_get_name
+arv_gc_feature_node_get_name_space
 arv_gc_feature_node_get_display_name
 arv_gc_feature_node_get_tooltip
 arv_gc_feature_node_get_description
@@ -903,6 +904,7 @@ ArvFakeDevicePrivate
 ArvGc
 ArvRegisterCachePolicy
 ArvGcRepresentation
+ArvGcNameSpace
 arv_gc_new
 arv_gc_get_node
 arv_gc_get_device
@@ -921,7 +923,6 @@ ARV_GC_GET_CLASS
 <SUBSECTION Private>
 ArvGcPrivate
 ArvGcClass
-ArvGcNameSpace
 ArvGcAccessMode
 ArvGcCachable
 ArvGcSignedness

--- a/src/arvgcenums.h
+++ b/src/arvgcenums.h
@@ -31,6 +31,15 @@
 
 G_BEGIN_DECLS
 
+/**
+ * ArvGcNameSpace:
+ * @ARV_GC_NAME_SPACE_UNDEFINED: undefined name space
+ * @ARV_GC_NAME_SPACE_STANDARD: Genicam standardized name space
+ * @ARV_GC_NAME_SPACE_CUSTOM: non-standardized name space
+ *
+ * Name space types. Standardized name space features are documented in Genicam materials.
+ */
+
 typedef enum {
 	ARV_GC_NAME_SPACE_UNDEFINED = -1,
 	ARV_GC_NAME_SPACE_STANDARD,

--- a/src/arvgcfeaturenode.c
+++ b/src/arvgcfeaturenode.c
@@ -213,6 +213,17 @@ arv_gc_feature_node_get_name (ArvGcFeatureNode *node)
 	return priv->name;
 }
 
+/**
+ * arv_gc_feature_node_get_name_space:
+ * @gc_feature_node: a #ArvGcFeatureNode
+ *
+ * Get feature name space.
+ *
+ * Returns: Name space value as #ArvGcNameSpace.
+ *
+ * Since: 0.8.0
+ */
+
 ArvGcNameSpace
 arv_gc_feature_node_get_name_space (ArvGcFeatureNode *node)
 {


### PR DESCRIPTION
The `ArvGcNameSpace` enum and respective feature node function was added in PR #379. However, the documentation was missing which is now added in this patch.