### PR TITLE
genicam: add 'Representation' and 'Unit' property node support for swiss knife

### DIFF
--- a/src/arvgcintswissknifenode.c
+++ b/src/arvgcintswissknifenode.c
@@ -51,6 +51,18 @@ arv_gc_int_swiss_knife_node_set_integer_value (ArvGcInteger *self, gint64 value,
 	g_set_error (error, ARV_GC_ERROR, ARV_GC_ERROR_READ_ONLY, "IntSwissKnife is read only");
 }
 
+static ArvGcRepresentation
+arv_gc_swiss_knife_node_get_integer_representation (ArvGcInteger *self, GError **error)
+{
+	return arv_gc_swiss_knife_get_representation (ARV_GC_SWISS_KNIFE (self), error);
+}
+
+static const char *
+arv_gc_swiss_knife_node_get_integer_unit (ArvGcInteger *self, GError **error)
+{
+	return arv_gc_swiss_knife_get_unit (ARV_GC_SWISS_KNIFE (self), error);
+}
+
 ArvGcNode *
 arv_gc_int_swiss_knife_node_new	(void)
 {
@@ -62,6 +74,8 @@ arv_gc_int_swiss_knife_node_integer_interface_init (ArvGcIntegerInterface *inter
 {
 	interface->get_value = arv_gc_int_swiss_knife_node_get_integer_value;
 	interface->set_value = arv_gc_int_swiss_knife_node_set_integer_value;
+	interface->get_representation = arv_gc_swiss_knife_node_get_integer_representation;
+	interface->get_unit = arv_gc_swiss_knife_node_get_integer_unit;
 }
 
 static void

--- a/src/arvgcswissknife.c
+++ b/src/arvgcswissknife.c
@@ -41,6 +41,8 @@ typedef struct {
 	GSList *expressions;	/* ArvGcVariableNode list */
 
 	ArvGcPropertyNode *formula_node;
+	ArvGcPropertyNode *unit;
+	ArvGcPropertyNode *representation;
 
 	ArvEvaluator *formula;
 } ArvGcSwissKnifePrivate;
@@ -63,6 +65,12 @@ arv_gc_swiss_knife_post_new_child (ArvDomNode *self, ArvDomNode *child)
 				break;
 			case ARV_GC_PROPERTY_NODE_TYPE_FORMULA:
 				priv->formula_node = property_node;
+				break;
+			case ARV_GC_PROPERTY_NODE_TYPE_UNIT:
+				priv->unit = property_node;
+				break;
+			case ARV_GC_PROPERTY_NODE_TYPE_REPRESENTATION:
+				priv->representation = property_node;
 				break;
 			case ARV_GC_PROPERTY_NODE_TYPE_EXPRESSION:
 				priv->expressions = g_slist_prepend (priv->expressions, property_node);
@@ -239,4 +247,30 @@ arv_gc_swiss_knife_get_float_value (ArvGcSwissKnife *self, GError **error)
 	}
 
 	return arv_evaluator_evaluate_as_double (priv->formula, NULL);
+}
+
+ArvGcRepresentation
+arv_gc_swiss_knife_get_representation (ArvGcSwissKnife *self, GError **error)
+{
+	ArvGcSwissKnifePrivate *priv = arv_gc_swiss_knife_get_instance_private (self);
+
+	g_return_val_if_fail (ARV_IS_GC_SWISS_KNIFE (self), ARV_GC_REPRESENTATION_UNDEFINED);
+
+	if (priv->representation == NULL)
+		return ARV_GC_REPRESENTATION_UNDEFINED;
+
+	return arv_gc_property_node_get_representation (ARV_GC_PROPERTY_NODE (priv->representation), ARV_GC_REPRESENTATION_UNDEFINED);
+}
+
+const char *
+arv_gc_swiss_knife_get_unit (ArvGcSwissKnife *self, GError **error)
+{
+	ArvGcSwissKnifePrivate *priv = arv_gc_swiss_knife_get_instance_private (self);
+
+	g_return_val_if_fail (ARV_IS_GC_SWISS_KNIFE (self), NULL);
+
+	if (priv->unit == NULL)
+		return NULL;
+
+	return arv_gc_property_node_get_string (ARV_GC_PROPERTY_NODE (priv->unit), error);
 }

--- a/src/arvgcswissknifenode.c
+++ b/src/arvgcswissknifenode.c
@@ -51,6 +51,18 @@ arv_gc_swiss_knife_node_set_float_value (ArvGcFloat *self, gdouble value, GError
 	g_set_error (error, ARV_GC_ERROR, ARV_GC_ERROR_READ_ONLY, "SwissKnife is read only");
 }
 
+static ArvGcRepresentation
+arv_gc_swiss_knife_node_get_float_representation (ArvGcFloat *self, GError **error)
+{
+	return arv_gc_swiss_knife_get_representation (ARV_GC_SWISS_KNIFE (self), error);
+}
+
+static const char *
+arv_gc_swiss_knife_node_get_float_unit (ArvGcFloat *self, GError **error)
+{
+	return arv_gc_swiss_knife_get_unit (ARV_GC_SWISS_KNIFE (self), error);
+}
+
 ArvGcNode *
 arv_gc_swiss_knife_node_new	(void)
 {
@@ -62,6 +74,8 @@ arv_gc_swiss_knife_node_float_interface_init (ArvGcFloatInterface *interface)
 {
 	interface->get_value = arv_gc_swiss_knife_node_get_float_value;
 	interface->set_value = arv_gc_swiss_knife_node_set_float_value;
+	interface->get_representation = arv_gc_swiss_knife_node_get_float_representation;
+	interface->get_unit = arv_gc_swiss_knife_node_get_float_unit;
 }
 
 static void

--- a/src/arvgcswissknifeprivate.h
+++ b/src/arvgcswissknifeprivate.h
@@ -25,7 +25,10 @@
 
 #include <arvgcswissknife.h>
 
-gint64		arv_gc_swiss_knife_get_integer_value		(ArvGcSwissKnife *self, GError **error);
-double 		arv_gc_swiss_knife_get_float_value 		(ArvGcSwissKnife *self, GError **error);
+ArvGcRepresentation	arv_gc_swiss_knife_get_representation	(ArvGcSwissKnife *self, GError **error);
+const char *		arv_gc_swiss_knife_get_unit		(ArvGcSwissKnife *self, GError **error);
+
+gint64			arv_gc_swiss_knife_get_integer_value	(ArvGcSwissKnife *self, GError **error);
+double			arv_gc_swiss_knife_get_float_value	(ArvGcSwissKnife *self, GError **error);
 
 #endif


### PR DESCRIPTION
This does not change public API, but interface functions are now able to get SwissKnife and IntSwissKnife Unit and Representation node info.