### PR TITLE
genicam: add 'DisplayNotation' and 'DisplayPrecision' property node support

### DIFF
--- a/docs/reference/aravis/aravis-sections.txt
+++ b/docs/reference/aravis/aravis-sections.txt
@@ -551,6 +551,10 @@ arv_gc_property_node_get_visibility
 arv_gc_property_node_new_visibility
 arv_gc_property_node_get_representation
 arv_gc_property_node_new_representation
+arv_gc_property_node_get_display_notation
+arv_gc_property_node_new_display_notation
+arv_gc_property_node_get_display_precision
+arv_gc_property_node_new_display_precision
 <SUBSECTION Standard>
 arv_gc_property_node_get_type
 ARV_GC_PROPERTY_NODE
@@ -905,6 +909,7 @@ ArvGc
 ArvRegisterCachePolicy
 ArvGcRepresentation
 ArvGcNameSpace
+ArvGcDisplayNotation
 arv_gc_new
 arv_gc_get_node
 arv_gc_get_device
@@ -1097,6 +1102,8 @@ arv_gc_float_get_max
 arv_gc_float_get_inc
 arv_gc_float_get_representation
 arv_gc_float_get_unit
+arv_gc_float_get_display_notation
+arv_gc_float_get_display_precision
 arv_gc_float_impose_min
 arv_gc_float_impose_max
 <SUBSECTION Standard>

--- a/src/arvgc.c
+++ b/src/arvgc.c
@@ -184,6 +184,10 @@ arv_gc_create_element (ArvDomDocument *document, const char *tag_name)
 		node = arv_gc_property_node_new_unit ();
 	else if (strcmp (tag_name, "Representation") == 0)
 		node = arv_gc_property_node_new_representation ();
+	else if (strcmp (tag_name, "DisplayNotation") == 0)
+		node = arv_gc_property_node_new_display_notation ();
+	else if (strcmp (tag_name, "DisplayPrecision") == 0)
+		node = arv_gc_property_node_new_display_precision ();
 	else if (strcmp (tag_name, "OnValue") == 0)
 		node = arv_gc_property_node_new_on_value ();
 	else if (strcmp (tag_name, "OffValue") == 0)

--- a/src/arvgcconverter.c
+++ b/src/arvgcconverter.c
@@ -30,6 +30,7 @@
 #include <arvevaluator.h>
 #include <arvgcinteger.h>
 #include <arvgcfloat.h>
+#include <arvgcdefaultsprivate.h>
 #include <arvgc.h>
 #include <arvdebug.h>
 #include <string.h>
@@ -556,12 +557,12 @@ arv_gc_converter_get_display_notation (ArvGcConverter *gc_converter, GError **er
 {
 	ArvGcConverterPrivate *priv = arv_gc_converter_get_instance_private (gc_converter);
 
-	g_return_val_if_fail (ARV_IS_GC_CONVERTER (gc_converter), ARV_GC_DISPLAY_NOTATION_AUTOMATIC);
+	g_return_val_if_fail (ARV_IS_GC_CONVERTER (gc_converter), ARV_GC_DISPLAY_NOTATION_DEFAULT);
 
 	if (priv->display_notation == NULL)
-		return ARV_GC_DISPLAY_NOTATION_AUTOMATIC;
+		return ARV_GC_DISPLAY_NOTATION_DEFAULT;
 
-	return arv_gc_property_node_get_display_notation (ARV_GC_PROPERTY_NODE (priv->display_notation), ARV_GC_DISPLAY_NOTATION_AUTOMATIC);
+	return arv_gc_property_node_get_display_notation (ARV_GC_PROPERTY_NODE (priv->display_notation), ARV_GC_DISPLAY_NOTATION_DEFAULT);
 }
 
 gint64
@@ -569,10 +570,10 @@ arv_gc_converter_get_display_precision (ArvGcConverter *gc_converter, GError **e
 {
 	ArvGcConverterPrivate *priv = arv_gc_converter_get_instance_private (gc_converter);
 
-	g_return_val_if_fail (ARV_IS_GC_CONVERTER (gc_converter), 6);
+	g_return_val_if_fail (ARV_IS_GC_CONVERTER (gc_converter), ARV_GC_DISPLAY_PRECISION_DEFAULT);
 
 	if (priv->display_precision == NULL)
-		return 6;
+		return ARV_GC_DISPLAY_PRECISION_DEFAULT;
 
-	return arv_gc_property_node_get_display_precision (ARV_GC_PROPERTY_NODE (priv->display_precision), 6);
+	return arv_gc_property_node_get_display_precision (ARV_GC_PROPERTY_NODE (priv->display_precision), ARV_GC_DISPLAY_PRECISION_DEFAULT);
 }

--- a/src/arvgcconverter.c
+++ b/src/arvgcconverter.c
@@ -44,6 +44,8 @@ typedef struct {
 	ArvGcPropertyNode *formula_from_node;
 	ArvGcPropertyNode *unit;
 	ArvGcPropertyNode *representation;
+	ArvGcPropertyNode *display_notation;
+	ArvGcPropertyNode *display_precision;
 	ArvGcPropertyNode *is_linear;
 	ArvGcPropertyNode *slope;
 
@@ -88,6 +90,12 @@ arv_gc_converter_post_new_child (ArvDomNode *self, ArvDomNode *child)
 				break;
 			case ARV_GC_PROPERTY_NODE_TYPE_REPRESENTATION:
 				priv->representation = property_node;
+				break;
+			case ARV_GC_PROPERTY_NODE_TYPE_DISPLAY_NOTATION:
+				priv->display_notation = property_node;
+				break;
+			case ARV_GC_PROPERTY_NODE_TYPE_DISPLAY_PRECISION:
+				priv->display_precision = property_node;
 				break;
 			case ARV_GC_PROPERTY_NODE_TYPE_IS_LINEAR:
 				priv->is_linear = property_node;
@@ -541,4 +549,30 @@ arv_gc_converter_get_unit (ArvGcConverter *gc_converter, GError **error)
 		return NULL;
 
 	return arv_gc_property_node_get_string (ARV_GC_PROPERTY_NODE (priv->unit), error);
+}
+
+ArvGcDisplayNotation
+arv_gc_converter_get_display_notation (ArvGcConverter *gc_converter, GError **error)
+{
+	ArvGcConverterPrivate *priv = arv_gc_converter_get_instance_private (gc_converter);
+
+	g_return_val_if_fail (ARV_IS_GC_CONVERTER (gc_converter), ARV_GC_DISPLAY_NOTATION_AUTOMATIC);
+
+	if (priv->display_notation == NULL)
+		return ARV_GC_DISPLAY_NOTATION_AUTOMATIC;
+
+	return arv_gc_property_node_get_display_notation (ARV_GC_PROPERTY_NODE (priv->display_notation), ARV_GC_DISPLAY_NOTATION_AUTOMATIC);
+}
+
+gint64
+arv_gc_converter_get_display_precision (ArvGcConverter *gc_converter, GError **error)
+{
+	ArvGcConverterPrivate *priv = arv_gc_converter_get_instance_private (gc_converter);
+
+	g_return_val_if_fail (ARV_IS_GC_CONVERTER (gc_converter), 6);
+
+	if (priv->display_precision == NULL)
+		return 6;
+
+	return arv_gc_property_node_get_display_precision (ARV_GC_PROPERTY_NODE (priv->display_precision), 6);
 }

--- a/src/arvgcconverternode.c
+++ b/src/arvgcconverternode.c
@@ -146,6 +146,18 @@ arv_gc_converter_get_float_unit (ArvGcFloat *gc_float, GError **error)
 	return arv_gc_converter_get_unit (ARV_GC_CONVERTER (gc_float), error);
 }
 
+static ArvGcDisplayNotation
+arv_gc_converter_get_float_display_notation (ArvGcFloat *gc_float, GError **error)
+{
+	return arv_gc_converter_get_display_notation (ARV_GC_CONVERTER (gc_float), error);
+}
+
+static gint64
+arv_gc_converter_get_float_display_precision (ArvGcFloat *gc_float, GError **error)
+{
+	return arv_gc_converter_get_display_precision (ARV_GC_CONVERTER (gc_float), error);
+}
+
 static void
 arv_gc_converter_set_float_value (ArvGcFloat *gc_float, double value, GError **error)
 {
@@ -162,6 +174,8 @@ arv_gc_converter_node_float_interface_init (ArvGcFloatInterface *interface)
 	interface->set_value = arv_gc_converter_set_float_value;
 	interface->get_representation = arv_gc_converter_get_float_representation;
 	interface->get_unit = arv_gc_converter_get_float_unit;
+	interface->get_display_notation = arv_gc_converter_get_float_display_notation;
+	interface->get_display_precision = arv_gc_converter_get_float_display_precision;
 }
 
 G_DEFINE_TYPE_WITH_CODE (ArvGcConverterNode, arv_gc_converter_node, ARV_TYPE_GC_CONVERTER,

--- a/src/arvgcconverterprivate.h
+++ b/src/arvgcconverterprivate.h
@@ -37,6 +37,8 @@ typedef enum {
 
 ArvGcRepresentation	arv_gc_converter_get_representation 	(ArvGcConverter *gc_converter, GError **error);
 const char * 		arv_gc_converter_get_unit	 	(ArvGcConverter *gc_converter, GError **error);
+ArvGcDisplayNotation	arv_gc_converter_get_display_notation	(ArvGcConverter *gc_converter, GError **error);
+gint64			arv_gc_converter_get_display_precision	(ArvGcConverter *gc_converter, GError **error);
 ArvGcIsLinear		arv_gc_converter_get_is_linear		(ArvGcConverter *gc_converter, GError **error);
 
 gint64 			arv_gc_converter_convert_to_int64 	(ArvGcConverter *gc_converter, ArvGcConverterNodeType node_type, GError **error);

--- a/src/arvgcdefaultsprivate.h
+++ b/src/arvgcdefaultsprivate.h
@@ -1,0 +1,65 @@
+/* Aravis - Digital camera library
+ *
+ * Copyright © 2009-2020 Emmanuel Pacaud
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General
+ * Public License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ *
+ * Author: Emmanuel Pacaud <emmanuel@gnome.org>
+ */
+
+#ifndef ARV_GC_DEFAULTS_PRIVATE_H
+#define ARV_GC_DEFAULTS_PRIVATE_H
+
+#if !defined (ARV_H_INSIDE) && !defined (ARAVIS_COMPILATION)
+#error "Only <arv.h> can be included directly."
+#endif
+
+#include <glib-object.h>
+#include <arvgcenums.h>
+
+G_BEGIN_DECLS
+
+/* Node default values */
+#define ARV_GC_OFF_VALUE_DEFAULT		0
+#define ARV_GC_ON_VALUE_DEFAULT			1
+/* TODO #define ARV_GC_STREAMABLE_DEFAULT	ARV_GC_STREAMABLE_NO */
+#define ARV_GC_DISPLAY_NOTATION_DEFAULT		ARV_GC_DISPLAY_NOTATION_AUTOMATIC
+#define ARV_GC_DISPLAY_PRECISION_DEFAULT	6
+#define ARV_GC_IS_LINEAR_DEFAULT		ARV_GC_IS_LINEAR_NO
+#define ARV_GC_REPRESENTATION_DEFAULT		ARV_GC_REPRESENTATION_PURE_NUMBER
+/* TODO #define ARV_GC_SLOPE_DEFAULT		ARV_GC_SLOPE_AUTOMATIC */
+#define ARV_GC_UNIT_DEFAULT			""
+/* TODO #define ARV_GC_IS_SELF_CLEARING_DEFAULT	ARV_GC_IS_SELF_CLEARING_NO */
+#define ARV_GC_CACHABLE_DEFAULT			ARV_GC_CACHABLE_WRITE_AROUND
+#define ARV_GC_SIGN_DEFAULT			ARV_GC_SIGNEDNESS_UNSIGNED
+/* TODO #define ARV_GC_IS_DEPRECATED_DEFAULT	ARV_GC_IS_DEPRECATED_NO */
+#define ARV_GC_IMPOSED_ACCESS_MODE_DEFAULT	ARV_GC_ACCESS_MODE_RW
+#define ARV_GC_VISIBILITY_DEFAULT		ARV_GC_VISIBILITY_BEGINNER
+/* TODO #define ARV_GC_CACHE_CHUNK_DATA		ARV_GC_CACHE_CHUNK_DATA_NO */
+/* TODO #define ARV_GC_SWAP_ENDIANNESS_DEFAULT	ARV_GC_SWAP_ENDIANNESS_NO */
+#define ARV_GC_FLOAT_MIN_DEFAULT		-G_MAXDOUBLE
+#define ARV_GC_FLOAT_MAX_DEFAULT		G_MAXDOUBLE
+#define ARV_GC_INTEGER_INC_DEFAULT		1
+#define ARV_GC_INTEGER_MIN_DEFAULT		G_MININT64
+#define ARV_GC_INTEGER_MAX_DEFAULT		G_MAXINT64
+
+/* Node attribute defaults */
+#define ARV_GC_NAME_SPACE_DEFAULT		ARV_GC_NAME_SPACE_CUSTOM
+#define ARV_GC_MERGE_PRIORITY_DEFAULT		0
+
+G_END_DECLS
+
+#endif

--- a/src/arvgcenums.h
+++ b/src/arvgcenums.h
@@ -114,6 +114,25 @@ typedef enum {
 	ARV_GC_REPRESENTATION_MAC_ADDRESS
 } ArvGcRepresentation;
 
+/**
+ * ArvGcDisplayNotation:
+ * @ARV_GC_DISPLAY_NOTATION_UNDEFINED: undefined number notation
+ * @ARV_GC_DISPLAY_NOTATION_AUTOMATIC: automatically detect whether to use fixed or scientific number notation
+ * @ARV_GC_DISPLAY_NOTATION_FIXED: used fixed (i.e. decimal) notation for displaying numbers
+ * @ARV_GC_DISPLAY_NOTATION_SCIENTIFIC: use scientific notation for displaying numbers
+ *
+ * Number display notations for showing numbers in user interfaces.
+ *
+ * Since: 0.8.0
+ */
+
+typedef enum {
+	ARV_GC_DISPLAY_NOTATION_UNDEFINED = -1,
+	ARV_GC_DISPLAY_NOTATION_AUTOMATIC,
+	ARV_GC_DISPLAY_NOTATION_FIXED,
+	ARV_GC_DISPLAY_NOTATION_SCIENTIFIC
+} ArvGcDisplayNotation;
+
 G_END_DECLS
 
 #endif

--- a/src/arvgcfloat.c
+++ b/src/arvgcfloat.c
@@ -157,6 +157,69 @@ arv_gc_float_get_unit	(ArvGcFloat *gc_float, GError **error)
 	return NULL;
 }
 
+/**
+ * arv_gc_float_get_display_notation:
+ * @gc_float: a #ArvGcFloat
+ * @error: return location for a GError, or NULL
+ *
+ * Get number display notation.
+ *
+ * Returns: Number display notation as #ArvGcDisplayNotation.
+ *
+ * Since: 0.8.0
+ */
+
+ArvGcDisplayNotation
+arv_gc_float_get_display_notation (ArvGcFloat *gc_float, GError **error)
+{
+	ArvGcFloatInterface *float_interface;
+
+	g_return_val_if_fail (ARV_IS_GC_FLOAT (gc_float), ARV_GC_DISPLAY_NOTATION_AUTOMATIC);
+	g_return_val_if_fail (error == NULL || *error == NULL, ARV_GC_DISPLAY_NOTATION_AUTOMATIC);
+
+	float_interface = ARV_GC_FLOAT_GET_IFACE (gc_float);
+
+	if (float_interface->get_display_notation != NULL)
+		return float_interface->get_display_notation (gc_float, error);
+
+	g_set_error (error, ARV_GC_ERROR, ARV_GC_ERROR_PROPERTY_NOT_DEFINED, "<DisplayNotation> node not found for '%s'",
+		     arv_gc_feature_node_get_name (ARV_GC_FEATURE_NODE (gc_float)));
+
+	return ARV_GC_DISPLAY_NOTATION_AUTOMATIC;
+}
+
+/**
+ * arv_gc_float_get_display_precision:
+ * @gc_float: a #ArvGcFloat
+ * @error: return location for a GError, or NULL
+ *
+ * Gets number of digits to show in user interface. This number should always be positive and represent
+ * total number of digits on left and right side of decimal.
+ *
+ * Returns: Number of digits to show.
+ *
+ * Since: 0.8.0
+ */
+
+gint64
+arv_gc_float_get_display_precision (ArvGcFloat *gc_float, GError **error)
+{
+	ArvGcFloatInterface *float_interface;
+
+	g_return_val_if_fail (ARV_IS_GC_FLOAT (gc_float), 6);
+	g_return_val_if_fail (error == NULL || *error == NULL, 6);
+
+	float_interface = ARV_GC_FLOAT_GET_IFACE (gc_float);
+
+	if (float_interface->get_display_precision != NULL)
+		return float_interface->get_display_precision (gc_float, error);
+
+	g_set_error (error, ARV_GC_ERROR, ARV_GC_ERROR_PROPERTY_NOT_DEFINED, "<DisplayPrecision> node not found for '%s'",
+		     arv_gc_feature_node_get_name (ARV_GC_FEATURE_NODE (gc_float)));
+
+	return 6;
+}
+
 void arv_gc_float_impose_min (ArvGcFloat *gc_float, double minimum, GError **error)
 {
 	ArvGcFloatInterface *float_interface;

--- a/src/arvgcfloat.c
+++ b/src/arvgcfloat.c
@@ -27,6 +27,7 @@
 
 #include <arvgcfloat.h>
 #include <arvgcfeaturenode.h>
+#include <arvgcdefaultsprivate.h>
 #include <arvgc.h>
 #include <arvmisc.h>
 
@@ -174,8 +175,8 @@ arv_gc_float_get_display_notation (ArvGcFloat *gc_float, GError **error)
 {
 	ArvGcFloatInterface *float_interface;
 
-	g_return_val_if_fail (ARV_IS_GC_FLOAT (gc_float), ARV_GC_DISPLAY_NOTATION_AUTOMATIC);
-	g_return_val_if_fail (error == NULL || *error == NULL, ARV_GC_DISPLAY_NOTATION_AUTOMATIC);
+	g_return_val_if_fail (ARV_IS_GC_FLOAT (gc_float), ARV_GC_DISPLAY_NOTATION_DEFAULT);
+	g_return_val_if_fail (error == NULL || *error == NULL, ARV_GC_DISPLAY_NOTATION_DEFAULT);
 
 	float_interface = ARV_GC_FLOAT_GET_IFACE (gc_float);
 
@@ -185,7 +186,7 @@ arv_gc_float_get_display_notation (ArvGcFloat *gc_float, GError **error)
 	g_set_error (error, ARV_GC_ERROR, ARV_GC_ERROR_PROPERTY_NOT_DEFINED, "<DisplayNotation> node not found for '%s'",
 		     arv_gc_feature_node_get_name (ARV_GC_FEATURE_NODE (gc_float)));
 
-	return ARV_GC_DISPLAY_NOTATION_AUTOMATIC;
+	return ARV_GC_DISPLAY_NOTATION_DEFAULT;
 }
 
 /**
@@ -206,8 +207,8 @@ arv_gc_float_get_display_precision (ArvGcFloat *gc_float, GError **error)
 {
 	ArvGcFloatInterface *float_interface;
 
-	g_return_val_if_fail (ARV_IS_GC_FLOAT (gc_float), 6);
-	g_return_val_if_fail (error == NULL || *error == NULL, 6);
+	g_return_val_if_fail (ARV_IS_GC_FLOAT (gc_float), ARV_GC_DISPLAY_PRECISION_DEFAULT);
+	g_return_val_if_fail (error == NULL || *error == NULL, ARV_GC_DISPLAY_PRECISION_DEFAULT);
 
 	float_interface = ARV_GC_FLOAT_GET_IFACE (gc_float);
 
@@ -217,7 +218,7 @@ arv_gc_float_get_display_precision (ArvGcFloat *gc_float, GError **error)
 	g_set_error (error, ARV_GC_ERROR, ARV_GC_ERROR_PROPERTY_NOT_DEFINED, "<DisplayPrecision> node not found for '%s'",
 		     arv_gc_feature_node_get_name (ARV_GC_FEATURE_NODE (gc_float)));
 
-	return 6;
+	return ARV_GC_DISPLAY_PRECISION_DEFAULT;
 }
 
 void arv_gc_float_impose_min (ArvGcFloat *gc_float, double minimum, GError **error)

--- a/src/arvgcfloat.h
+++ b/src/arvgcfloat.h
@@ -45,19 +45,23 @@ struct _ArvGcFloatInterface {
 	double			(*get_inc)		(ArvGcFloat *gc_float, GError **error);
 	ArvGcRepresentation	(*get_representation)	(ArvGcFloat *gc_float, GError **error);
 	const char *		(*get_unit)		(ArvGcFloat *gc_float, GError **error);
+	ArvGcDisplayNotation	(*get_display_notation) (ArvGcFloat *gc_float, GError **error);
+	gint64			(*get_display_precision)(ArvGcFloat *gc_float, GError **error);
 	void			(*impose_min)		(ArvGcFloat *gc_float, double minimum, GError **error);
 	void			(*impose_max)		(ArvGcFloat *gc_float, double maximum, GError **error);
 };
 
-double			arv_gc_float_get_value		(ArvGcFloat *gc_float, GError **error);
-void			arv_gc_float_set_value		(ArvGcFloat *gc_float, double value, GError **error);
-double			arv_gc_float_get_min		(ArvGcFloat *gc_float, GError **error);
-double			arv_gc_float_get_max		(ArvGcFloat *gc_float, GError **error);
-double			arv_gc_float_get_inc		(ArvGcFloat *gc_float, GError **error);
-ArvGcRepresentation	arv_gc_float_get_representation	(ArvGcFloat *gc_float, GError **error);
-const char *		arv_gc_float_get_unit		(ArvGcFloat *gc_float, GError **error);
-void			arv_gc_float_impose_min		(ArvGcFloat *gc_float, double minimum, GError **error);
-void			arv_gc_float_impose_max		(ArvGcFloat *gc_float, double maximum, GError **error);
+double			arv_gc_float_get_value			(ArvGcFloat *gc_float, GError **error);
+void			arv_gc_float_set_value			(ArvGcFloat *gc_float, double value, GError **error);
+double			arv_gc_float_get_min			(ArvGcFloat *gc_float, GError **error);
+double			arv_gc_float_get_max			(ArvGcFloat *gc_float, GError **error);
+double			arv_gc_float_get_inc			(ArvGcFloat *gc_float, GError **error);
+ArvGcRepresentation	arv_gc_float_get_representation		(ArvGcFloat *gc_float, GError **error);
+const char *		arv_gc_float_get_unit			(ArvGcFloat *gc_float, GError **error);
+ArvGcDisplayNotation	arv_gc_float_get_display_notation	(ArvGcFloat *gc_float, GError **error);
+gint64			arv_gc_float_get_display_precision	(ArvGcFloat *gc_float, GError **error);
+void			arv_gc_float_impose_min			(ArvGcFloat *gc_float, double minimum, GError **error);
+void			arv_gc_float_impose_max			(ArvGcFloat *gc_float, double maximum, GError **error);
 
 /* FIXME has_inc and get_inc are missing */
 

--- a/src/arvgcfloatnode.c
+++ b/src/arvgcfloatnode.c
@@ -44,6 +44,8 @@ struct _ArvGcFloatNode {
 	ArvGcPropertyNode *increment;
 	ArvGcPropertyNode *unit;
 	ArvGcPropertyNode *representation;
+	ArvGcPropertyNode *display_notation;
+	ArvGcPropertyNode *display_precision;
 
 	ArvGcPropertyNode *index;
 	GSList *value_indexed_nodes;
@@ -97,6 +99,12 @@ arv_gc_float_node_post_new_child (ArvDomNode *self, ArvDomNode *child)
 				break;
 			case ARV_GC_PROPERTY_NODE_TYPE_REPRESENTATION:
 				node->representation = property_node;
+				break;
+			case ARV_GC_PROPERTY_NODE_TYPE_DISPLAY_NOTATION:
+				node->display_notation = property_node;
+				break;
+			case ARV_GC_PROPERTY_NODE_TYPE_DISPLAY_PRECISION:
+				node->display_precision = property_node;
 				break;
 			case ARV_GC_PROPERTY_NODE_TYPE_P_INDEX:
 				node->index = property_node;
@@ -375,6 +383,28 @@ arv_gc_float_node_get_unit (ArvGcFloat *gc_float, GError **error)
 	return string;
 }
 
+static ArvGcDisplayNotation
+arv_gc_float_node_get_display_notation (ArvGcFloat *gc_float, GError **error)
+{
+	ArvGcFloatNode *gc_float_node = ARV_GC_FLOAT_NODE (gc_float);
+
+	if (gc_float_node->display_notation == NULL)
+		return ARV_GC_DISPLAY_NOTATION_AUTOMATIC;
+
+	return arv_gc_property_node_get_display_notation (ARV_GC_PROPERTY_NODE (gc_float_node->display_notation), ARV_GC_DISPLAY_NOTATION_AUTOMATIC);
+}
+
+static gint64
+arv_gc_float_node_get_display_precision (ArvGcFloat *gc_float, GError **error)
+{
+	ArvGcFloatNode *gc_float_node = ARV_GC_FLOAT_NODE (gc_float);
+
+	if (gc_float_node->display_precision == NULL)
+		return 6;
+
+	return arv_gc_property_node_get_display_precision (ARV_GC_PROPERTY_NODE (gc_float_node->display_precision), 6);
+}
+
 static void
 arv_gc_float_node_impose_min (ArvGcFloat *gc_float, double minimum, GError **error)
 {
@@ -415,6 +445,8 @@ arv_gc_float_node_float_interface_init (ArvGcFloatInterface *interface)
 	interface->get_inc = arv_gc_float_node_get_inc;
 	interface->get_representation = arv_gc_float_node_get_representation;
 	interface->get_unit = arv_gc_float_node_get_unit;
+	interface->get_display_notation = arv_gc_float_node_get_display_notation;
+	interface->get_display_precision = arv_gc_float_node_get_display_precision;
 	interface->impose_min = arv_gc_float_node_impose_min;
 	interface->impose_max = arv_gc_float_node_impose_max;
 }

--- a/src/arvgcfloatnode.c
+++ b/src/arvgcfloatnode.c
@@ -30,6 +30,7 @@
 #include <arvgcinteger.h>
 #include <arvgcvalueindexednode.h>
 #include <arvgcfeaturenodeprivate.h>
+#include <arvgcdefaultsprivate.h>
 #include <arvgc.h>
 #include <arvmisc.h>
 #include <arvstr.h>
@@ -389,9 +390,9 @@ arv_gc_float_node_get_display_notation (ArvGcFloat *gc_float, GError **error)
 	ArvGcFloatNode *gc_float_node = ARV_GC_FLOAT_NODE (gc_float);
 
 	if (gc_float_node->display_notation == NULL)
-		return ARV_GC_DISPLAY_NOTATION_AUTOMATIC;
+		return ARV_GC_DISPLAY_NOTATION_DEFAULT;
 
-	return arv_gc_property_node_get_display_notation (ARV_GC_PROPERTY_NODE (gc_float_node->display_notation), ARV_GC_DISPLAY_NOTATION_AUTOMATIC);
+	return arv_gc_property_node_get_display_notation (ARV_GC_PROPERTY_NODE (gc_float_node->display_notation), ARV_GC_DISPLAY_NOTATION_DEFAULT);
 }
 
 static gint64
@@ -400,9 +401,9 @@ arv_gc_float_node_get_display_precision (ArvGcFloat *gc_float, GError **error)
 	ArvGcFloatNode *gc_float_node = ARV_GC_FLOAT_NODE (gc_float);
 
 	if (gc_float_node->display_precision == NULL)
-		return 6;
+		return ARV_GC_DISPLAY_PRECISION_DEFAULT;
 
-	return arv_gc_property_node_get_display_precision (ARV_GC_PROPERTY_NODE (gc_float_node->display_precision), 6);
+	return arv_gc_property_node_get_display_precision (ARV_GC_PROPERTY_NODE (gc_float_node->display_precision), ARV_GC_DISPLAY_PRECISION_DEFAULT);
 }
 
 static void

--- a/src/arvgcfloatregnode.c
+++ b/src/arvgcfloatregnode.c
@@ -24,6 +24,7 @@
 #include <arvgcpropertynode.h>
 #include <arvgcfloat.h>
 #include <arvgcregister.h>
+#include <arvgcdefaultsprivate.h>
 #include <arvgc.h>
 #include <arvmisc.h>
 
@@ -238,9 +239,9 @@ arv_gc_float_reg_node_get_display_notation (ArvGcFloat *self, GError **error)
 	ArvGcFloatRegNodePrivate *priv = arv_gc_float_reg_node_get_instance_private (ARV_GC_FLOAT_REG_NODE (self));
 
 	if (priv->display_notation == NULL)
-		return ARV_GC_DISPLAY_NOTATION_AUTOMATIC;
+		return ARV_GC_DISPLAY_NOTATION_DEFAULT;
 
-	return arv_gc_property_node_get_display_notation (ARV_GC_PROPERTY_NODE (priv->display_notation), ARV_GC_DISPLAY_NOTATION_AUTOMATIC);
+	return arv_gc_property_node_get_display_notation (ARV_GC_PROPERTY_NODE (priv->display_notation), ARV_GC_DISPLAY_NOTATION_DEFAULT);
 }
 
 static gint64
@@ -249,9 +250,9 @@ arv_gc_float_reg_node_get_display_precision (ArvGcFloat *self, GError **error)
 	ArvGcFloatRegNodePrivate *priv = arv_gc_float_reg_node_get_instance_private (ARV_GC_FLOAT_REG_NODE (self));
 
 	if (priv->display_precision == NULL)
-		return 6;
+		return ARV_GC_DISPLAY_PRECISION_DEFAULT;
 
-	return arv_gc_property_node_get_display_precision (ARV_GC_PROPERTY_NODE (priv->display_precision), 6);
+	return arv_gc_property_node_get_display_precision (ARV_GC_PROPERTY_NODE (priv->display_precision), ARV_GC_DISPLAY_PRECISION_DEFAULT);
 }
 
 /**

--- a/src/arvgcfloatregnode.c
+++ b/src/arvgcfloatregnode.c
@@ -31,6 +31,8 @@ typedef struct {
 	ArvGcPropertyNode *endianness;
 	ArvGcPropertyNode *unit;
 	ArvGcPropertyNode *representation;
+	ArvGcPropertyNode *display_notation;
+	ArvGcPropertyNode *display_precision;
 
 	GSList *selecteds;
 } ArvGcFloatRegNodePrivate;
@@ -66,13 +68,15 @@ arv_gc_float_reg_node_post_new_child (ArvDomNode *self, ArvDomNode *child)
 			case ARV_GC_PROPERTY_NODE_TYPE_REPRESENTATION:
 				priv->representation = property_node;
 				break;
+			case ARV_GC_PROPERTY_NODE_TYPE_DISPLAY_NOTATION:
+				priv->display_notation = property_node;
+				break;
+			case ARV_GC_PROPERTY_NODE_TYPE_DISPLAY_PRECISION:
+				priv->display_precision = property_node;
+				break;
 			case ARV_GC_PROPERTY_NODE_TYPE_P_SELECTED:
 				priv->selecteds = g_slist_prepend (priv->selecteds, property_node);
 				break;
-
-				/* TODO DisplayNotation */
-				/* TODO DisplayPrecision */
-
 			default:
 				ARV_DOM_NODE_CLASS (arv_gc_float_reg_node_parent_class)->post_new_child (self, child);
 				break;
@@ -228,6 +232,28 @@ arv_gc_float_reg_node_get_unit (ArvGcFloat *self, GError **error)
 	return arv_gc_property_node_get_string (priv->unit, error);
 }
 
+static ArvGcDisplayNotation
+arv_gc_float_reg_node_get_display_notation (ArvGcFloat *self, GError **error)
+{
+	ArvGcFloatRegNodePrivate *priv = arv_gc_float_reg_node_get_instance_private (ARV_GC_FLOAT_REG_NODE (self));
+
+	if (priv->display_notation == NULL)
+		return ARV_GC_DISPLAY_NOTATION_AUTOMATIC;
+
+	return arv_gc_property_node_get_display_notation (ARV_GC_PROPERTY_NODE (priv->display_notation), ARV_GC_DISPLAY_NOTATION_AUTOMATIC);
+}
+
+static gint64
+arv_gc_float_reg_node_get_display_precision (ArvGcFloat *self, GError **error)
+{
+	ArvGcFloatRegNodePrivate *priv = arv_gc_float_reg_node_get_instance_private (ARV_GC_FLOAT_REG_NODE (self));
+
+	if (priv->display_precision == NULL)
+		return 6;
+
+	return arv_gc_property_node_get_display_precision (ARV_GC_PROPERTY_NODE (priv->display_precision), 6);
+}
+
 /**
  * arv_gc_float_reg_node_new:
  *
@@ -251,6 +277,8 @@ arv_gc_float_reg_node_float_interface_init (ArvGcFloatInterface *interface)
 	interface->get_max = arv_gc_float_reg_node_get_max;
 	interface->get_representation = arv_gc_float_reg_get_representation;
 	interface->get_unit = arv_gc_float_reg_node_get_unit;
+	interface->get_display_notation = arv_gc_float_reg_node_get_display_notation;
+	interface->get_display_precision = arv_gc_float_reg_node_get_display_precision;
 }
 
 static void

--- a/src/arvgcpropertynode.c
+++ b/src/arvgcpropertynode.c
@@ -682,6 +682,56 @@ arv_gc_property_node_get_representation (ArvGcPropertyNode *self, ArvGcRepresent
 }
 
 ArvGcNode *
+arv_gc_property_node_new_display_notation (void)
+{
+	return arv_gc_property_node_new (ARV_GC_PROPERTY_NODE_TYPE_DISPLAY_NOTATION);
+}
+
+ArvGcDisplayNotation
+arv_gc_property_node_get_display_notation (ArvGcPropertyNode *self, ArvGcDisplayNotation default_value)
+{
+	ArvGcPropertyNodePrivate *priv = arv_gc_property_node_get_instance_private (self);
+	const char *value;
+
+	if (self == NULL)
+		return default_value;
+
+	g_return_val_if_fail (ARV_IS_GC_PROPERTY_NODE (self), default_value);
+	g_return_val_if_fail (priv->type == ARV_GC_PROPERTY_NODE_TYPE_DISPLAY_NOTATION, default_value);
+
+	value = _get_value_data (self);
+
+	if (g_strcmp0 (value, "Automatic") == 0)
+		return ARV_GC_DISPLAY_NOTATION_AUTOMATIC;
+	else if (g_strcmp0 (value, "Fixed") == 0)
+		return ARV_GC_DISPLAY_NOTATION_FIXED;
+	else if (g_strcmp0 (value, "Scientific") == 0)
+		return ARV_GC_DISPLAY_NOTATION_SCIENTIFIC;
+
+	return default_value;
+}
+
+ArvGcNode *
+arv_gc_property_node_new_display_precision (void)
+{
+	return arv_gc_property_node_new (ARV_GC_PROPERTY_NODE_TYPE_DISPLAY_PRECISION);
+}
+
+gint64
+arv_gc_property_node_get_display_precision (ArvGcPropertyNode *self, gint64 default_value)
+{
+	ArvGcPropertyNodePrivate *priv = arv_gc_property_node_get_instance_private (self);
+
+	if (self == NULL)
+		return default_value;
+
+	g_return_val_if_fail (ARV_IS_GC_PROPERTY_NODE (self), default_value);
+	g_return_val_if_fail (priv->type == ARV_GC_PROPERTY_NODE_TYPE_DISPLAY_PRECISION, default_value);
+
+	return g_ascii_strtoll (_get_value_data (self), NULL, 0);
+}
+
+ArvGcNode *
 arv_gc_property_node_new_unit (void)
 {
 	return arv_gc_property_node_new (ARV_GC_PROPERTY_NODE_TYPE_UNIT);

--- a/src/arvgcpropertynode.h
+++ b/src/arvgcpropertynode.h
@@ -47,6 +47,8 @@ typedef enum {
 	ARV_GC_PROPERTY_NODE_TYPE_INCREMENT,
 	ARV_GC_PROPERTY_NODE_TYPE_IS_LINEAR,
 	ARV_GC_PROPERTY_NODE_TYPE_REPRESENTATION,
+	ARV_GC_PROPERTY_NODE_TYPE_DISPLAY_NOTATION,
+	ARV_GC_PROPERTY_NODE_TYPE_DISPLAY_PRECISION,
 	ARV_GC_PROPERTY_NODE_TYPE_UNIT,
 	ARV_GC_PROPERTY_NODE_TYPE_ON_VALUE,
 	ARV_GC_PROPERTY_NODE_TYPE_OFF_VALUE,
@@ -117,6 +119,8 @@ ArvGcNode * 	arv_gc_property_node_new_increment		(void);
 ArvGcNode * 	arv_gc_property_node_new_p_increment		(void);
 ArvGcNode * 	arv_gc_property_node_new_is_linear		(void);
 ArvGcNode * 	arv_gc_property_node_new_representation		(void);
+ArvGcNode * 	arv_gc_property_node_new_display_notation	(void);
+ArvGcNode * 	arv_gc_property_node_new_display_precision	(void);
 ArvGcNode * 	arv_gc_property_node_new_unit			(void);
 ArvGcNode * 	arv_gc_property_node_new_on_value 		(void);
 ArvGcNode * 	arv_gc_property_node_new_off_value 		(void);
@@ -149,26 +153,28 @@ ArvGcNode * 	arv_gc_property_node_new_event_id 		(void);
 ArvGcNode * 	arv_gc_property_node_new_value_default 		(void);
 ArvGcNode * 	arv_gc_property_node_new_p_value_default	(void);
 
-const char *		arv_gc_property_node_get_name		(ArvGcPropertyNode *node);
+const char *		arv_gc_property_node_get_name			(ArvGcPropertyNode *node);
 
-const char * 		arv_gc_property_node_get_string 	(ArvGcPropertyNode *node, GError **error);
-void	 		arv_gc_property_node_set_string 	(ArvGcPropertyNode *node, const char *string, GError **error);
-gint64			arv_gc_property_node_get_int64		(ArvGcPropertyNode *node, GError **error);
-void			arv_gc_property_node_set_int64		(ArvGcPropertyNode *node, gint64 v_int64, GError **error);
-double 			arv_gc_property_node_get_double 	(ArvGcPropertyNode *node, GError **error);
-void 			arv_gc_property_node_set_double 	(ArvGcPropertyNode *node, double v_double, GError **error);
+const char *		arv_gc_property_node_get_string			(ArvGcPropertyNode *node, GError **error);
+void			arv_gc_property_node_set_string			(ArvGcPropertyNode *node, const char *string, GError **error);
+gint64			arv_gc_property_node_get_int64			(ArvGcPropertyNode *node, GError **error);
+void			arv_gc_property_node_set_int64			(ArvGcPropertyNode *node, gint64 v_int64, GError **error);
+double			arv_gc_property_node_get_double			(ArvGcPropertyNode *node, GError **error);
+void			arv_gc_property_node_set_double			(ArvGcPropertyNode *node, double v_double, GError **error);
 
-guint	 		arv_gc_property_node_get_endianness	(ArvGcPropertyNode *self, guint default_value);
-ArvGcSignedness		arv_gc_property_node_get_sign 		(ArvGcPropertyNode *self, ArvGcSignedness default_value);
-guint	 		arv_gc_property_node_get_lsb		(ArvGcPropertyNode *self, guint default_value);
-guint	 		arv_gc_property_node_get_msb		(ArvGcPropertyNode *self, guint default_value);
-ArvGcCachable		arv_gc_property_node_get_cachable	(ArvGcPropertyNode *self, ArvGcCachable default_value);
-ArvGcAccessMode		arv_gc_property_node_get_access_mode	(ArvGcPropertyNode *self, ArvGcAccessMode default_value);
-ArvGcVisibility 	arv_gc_property_node_get_visibility 	(ArvGcPropertyNode *self, ArvGcVisibility default_value);
-ArvGcRepresentation 	arv_gc_property_node_get_representation (ArvGcPropertyNode *self, ArvGcRepresentation default_value);
+guint			arv_gc_property_node_get_endianness		(ArvGcPropertyNode *self, guint default_value);
+ArvGcSignedness		arv_gc_property_node_get_sign			(ArvGcPropertyNode *self, ArvGcSignedness default_value);
+guint			arv_gc_property_node_get_lsb			(ArvGcPropertyNode *self, guint default_value);
+guint			arv_gc_property_node_get_msb			(ArvGcPropertyNode *self, guint default_value);
+ArvGcCachable		arv_gc_property_node_get_cachable		(ArvGcPropertyNode *self, ArvGcCachable default_value);
+ArvGcAccessMode		arv_gc_property_node_get_access_mode		(ArvGcPropertyNode *self, ArvGcAccessMode default_value);
+ArvGcVisibility 	arv_gc_property_node_get_visibility		(ArvGcPropertyNode *self, ArvGcVisibility default_value);
+ArvGcRepresentation 	arv_gc_property_node_get_representation		(ArvGcPropertyNode *self, ArvGcRepresentation default_value);
+ArvGcDisplayNotation	arv_gc_property_node_get_display_notation	(ArvGcPropertyNode *self, ArvGcDisplayNotation default_value);
+gint64			arv_gc_property_node_get_display_precision	(ArvGcPropertyNode *self, gint64 default_value);
 
-ArvGcNode *		arv_gc_property_node_get_linked_node	(ArvGcPropertyNode *node);
-ArvGcPropertyNodeType	arv_gc_property_node_get_node_type	(ArvGcPropertyNode *node);
+ArvGcNode *		arv_gc_property_node_get_linked_node		(ArvGcPropertyNode *node);
+ArvGcPropertyNodeType	arv_gc_property_node_get_node_type		(ArvGcPropertyNode *node);
 
 G_END_DECLS
 

--- a/src/arvgcswissknifenode.c
+++ b/src/arvgcswissknifenode.c
@@ -27,16 +27,46 @@
 #include <arvgc.h>
 #include <arvmisc.h>
 
+typedef struct {
+	ArvGcPropertyNode *display_notation;
+	ArvGcPropertyNode *display_precision;
+} ArvGcSwissKnifeNodePrivate;
+
 static void arv_gc_swiss_knife_node_init (ArvGcSwissKnifeNode *self);
 static void arv_gc_swiss_knife_node_float_interface_init (ArvGcFloatInterface *interface);
 
 G_DEFINE_TYPE_WITH_CODE (ArvGcSwissKnifeNode, arv_gc_swiss_knife_node, ARV_TYPE_GC_SWISS_KNIFE,
+			 G_ADD_PRIVATE (ArvGcSwissKnifeNode)
 			 G_IMPLEMENT_INTERFACE (ARV_TYPE_GC_FLOAT, arv_gc_swiss_knife_node_float_interface_init))
 
 static const char *
 arv_gc_swiss_knife_node_get_node_name (ArvDomNode *node)
 {
 	return "SwissKnife";
+}
+
+static void
+arv_gc_swiss_knife_node_post_new_child (ArvDomNode *self, ArvDomNode *child)
+{
+	ArvGcSwissKnifeNodePrivate *priv = arv_gc_swiss_knife_node_get_instance_private (ARV_GC_SWISS_KNIFE_NODE (self));
+
+	if (ARV_IS_GC_PROPERTY_NODE (child)) {
+		ArvGcPropertyNode *property_node = ARV_GC_PROPERTY_NODE (child);
+
+		switch (arv_gc_property_node_get_node_type (property_node)) {
+			case ARV_GC_PROPERTY_NODE_TYPE_DISPLAY_NOTATION:
+				priv->display_notation = property_node;
+				break;
+			case ARV_GC_PROPERTY_NODE_TYPE_DISPLAY_PRECISION:
+				priv->display_precision = property_node;
+				break;
+			default:
+				ARV_DOM_NODE_CLASS (arv_gc_swiss_knife_node_parent_class)->post_new_child (self, child);
+				break;
+		}
+	} else {
+		ARV_DOM_NODE_CLASS (arv_gc_swiss_knife_node_parent_class)->post_new_child (self, child);
+	}
 }
 
 static gdouble
@@ -63,6 +93,28 @@ arv_gc_swiss_knife_node_get_float_unit (ArvGcFloat *self, GError **error)
 	return arv_gc_swiss_knife_get_unit (ARV_GC_SWISS_KNIFE (self), error);
 }
 
+static ArvGcDisplayNotation
+arv_gc_swiss_knife_node_get_display_notation (ArvGcFloat *self, GError **error)
+{
+	ArvGcSwissKnifeNodePrivate *priv = arv_gc_swiss_knife_node_get_instance_private (ARV_GC_SWISS_KNIFE_NODE (self));
+
+	if (priv->display_notation == NULL)
+		return ARV_GC_DISPLAY_NOTATION_AUTOMATIC;
+
+	return arv_gc_property_node_get_display_notation (ARV_GC_PROPERTY_NODE (priv->display_notation), ARV_GC_DISPLAY_NOTATION_AUTOMATIC);
+}
+
+static gint64
+arv_gc_swiss_knife_node_get_display_precision (ArvGcFloat *self, GError **error)
+{
+	ArvGcSwissKnifeNodePrivate *priv = arv_gc_swiss_knife_node_get_instance_private (ARV_GC_SWISS_KNIFE_NODE (self));
+
+	if (priv->display_precision == NULL)
+		return 6;
+
+	return arv_gc_property_node_get_display_precision (ARV_GC_PROPERTY_NODE (priv->display_precision), 6);
+}
+
 ArvGcNode *
 arv_gc_swiss_knife_node_new	(void)
 {
@@ -76,6 +128,8 @@ arv_gc_swiss_knife_node_float_interface_init (ArvGcFloatInterface *interface)
 	interface->set_value = arv_gc_swiss_knife_node_set_float_value;
 	interface->get_representation = arv_gc_swiss_knife_node_get_float_representation;
 	interface->get_unit = arv_gc_swiss_knife_node_get_float_unit;
+	interface->get_display_notation = arv_gc_swiss_knife_node_get_display_notation;
+	interface->get_display_precision = arv_gc_swiss_knife_node_get_display_precision;
 }
 
 static void
@@ -97,4 +151,5 @@ arv_gc_swiss_knife_node_class_init (ArvGcSwissKnifeNodeClass *this_class)
 
 	object_class->finalize = arv_gc_swiss_knife_node_finalize;
 	dom_node_class->get_node_name = arv_gc_swiss_knife_node_get_node_name;
+	dom_node_class->post_new_child = arv_gc_swiss_knife_node_post_new_child;
 }

--- a/src/arvgcswissknifenode.c
+++ b/src/arvgcswissknifenode.c
@@ -24,6 +24,7 @@
 #include <arvgcswissknifeprivate.h>
 #include <arvgcfloat.h>
 #include <arvgcregister.h>
+#include <arvgcdefaultsprivate.h>
 #include <arvgc.h>
 #include <arvmisc.h>
 
@@ -99,9 +100,9 @@ arv_gc_swiss_knife_node_get_display_notation (ArvGcFloat *self, GError **error)
 	ArvGcSwissKnifeNodePrivate *priv = arv_gc_swiss_knife_node_get_instance_private (ARV_GC_SWISS_KNIFE_NODE (self));
 
 	if (priv->display_notation == NULL)
-		return ARV_GC_DISPLAY_NOTATION_AUTOMATIC;
+		return ARV_GC_DISPLAY_NOTATION_DEFAULT;
 
-	return arv_gc_property_node_get_display_notation (ARV_GC_PROPERTY_NODE (priv->display_notation), ARV_GC_DISPLAY_NOTATION_AUTOMATIC);
+	return arv_gc_property_node_get_display_notation (ARV_GC_PROPERTY_NODE (priv->display_notation), ARV_GC_DISPLAY_NOTATION_DEFAULT);
 }
 
 static gint64
@@ -110,9 +111,9 @@ arv_gc_swiss_knife_node_get_display_precision (ArvGcFloat *self, GError **error)
 	ArvGcSwissKnifeNodePrivate *priv = arv_gc_swiss_knife_node_get_instance_private (ARV_GC_SWISS_KNIFE_NODE (self));
 
 	if (priv->display_precision == NULL)
-		return 6;
+		return ARV_GC_DISPLAY_PRECISION_DEFAULT;
 
-	return arv_gc_property_node_get_display_precision (ARV_GC_PROPERTY_NODE (priv->display_precision), 6);
+	return arv_gc_property_node_get_display_precision (ARV_GC_PROPERTY_NODE (priv->display_precision), ARV_GC_DISPLAY_PRECISION_DEFAULT);
 }
 
 ArvGcNode *

--- a/src/meson.build
+++ b/src/meson.build
@@ -163,6 +163,7 @@ library_private_headers = [
 	'arvfakeinterfaceprivate.h',
 	'arvfakestreamprivate.h',
 	'arvgcconverterprivate.h',
+	'arvgcdefaultsprivate.h',
 	'arvgcfeaturenodeprivate.h',
 	'arvgcregisternodeprivate.h',
 	'arvgcswissknifeprivate.h',


### PR DESCRIPTION
This patch adds many things related to 'DisplayNotation' and 'DisplayPrecision' nodes. Public API is expanded by `ArvGcDisplayNotation` enum, `*_get_display_notation`, `*_get_display_precision`, `arv_gc_property_node_new_display_notation` and `arv_gc_property_node_new_display_precision` functions.