### PR TITLE
arvgcenums: add more documentation for Genicam enums

### DIFF
--- a/docs/reference/aravis/aravis-sections.txt
+++ b/docs/reference/aravis/aravis-sections.txt
@@ -907,8 +907,13 @@ ArvFakeDevicePrivate
 <TITLE>ArvGc</TITLE>
 ArvGc
 ArvRegisterCachePolicy
-ArvGcRepresentation
 ArvGcNameSpace
+ArvGcAccessMode
+ArvGcCachable
+ArvGcSignedness
+ArvGcIsLinear
+ArvGcVisibility
+ArvGcRepresentation
 ArvGcDisplayNotation
 arv_gc_new
 arv_gc_get_node
@@ -928,11 +933,6 @@ ARV_GC_GET_CLASS
 <SUBSECTION Private>
 ArvGcPrivate
 ArvGcClass
-ArvGcAccessMode
-ArvGcCachable
-ArvGcSignedness
-ArvGcIsLinear
-ArvGcVisibility
 arv_gc_get_int64_from_value
 arv_gc_set_int64_to_value
 arv_gc_get_double_from_value

--- a/src/arvgcenums.h
+++ b/src/arvgcenums.h
@@ -37,7 +37,8 @@ G_BEGIN_DECLS
  * @ARV_GC_NAME_SPACE_STANDARD: Genicam standardized name space
  * @ARV_GC_NAME_SPACE_CUSTOM: non-standardized name space
  *
- * Name space types. Standardized name space features are documented in Genicam materials.
+ * Specifies feature node or register name space type. Standard name space features are listed in
+ * Genicam materials. Any other vendor-specific features should use custom name space type.
  */
 
 typedef enum {
@@ -46,6 +47,16 @@ typedef enum {
 	ARV_GC_NAME_SPACE_CUSTOM
 } ArvGcNameSpace;
 
+/**
+ * ArvGcAccessMode:
+ * @ARV_GC_ACCESS_MODE_UNDEFINED: undefined access mode
+ * @ARV_GC_ACCESS_MODE_RO: read-only access
+ * @ARV_GC_ACCESS_MODE_WO: write-only access
+ * @ARV_GC_ACCESS_MODE_RW: read and write access
+ *
+ * Specifies access mode for feature nodes and registers.
+ */
+
 typedef enum {
 	ARV_GC_ACCESS_MODE_UNDEFINED = -1,
 	ARV_GC_ACCESS_MODE_RO,
@@ -53,6 +64,15 @@ typedef enum {
 	ARV_GC_ACCESS_MODE_RW
 } ArvGcAccessMode;
 
+/**
+ * ArvGcCachable:
+ * @ARV_GC_CACHABLE_UNDEFINED: undefined cache mode
+ * @ARV_GC_CACHABLE_NO_CACHE: no value caching
+ * @ARV_GC_CACHABLE_WRITE_THROUGH: write-through cache mode
+ * @ARV_GC_CACHABLE_WRITE_AROUND: write-around cache mode
+ *
+ * Specifies caching mode for register values.
+ */
 typedef enum {
 	ARV_GC_CACHABLE_UNDEFINED = -1,
 	ARV_GC_CACHABLE_NO_CACHE,
@@ -61,10 +81,14 @@ typedef enum {
 } ArvGcCachable;
 
 /**
- * ArvGcSign:
+ * ArvGcSignedness:
  * @ARV_GC_SIGNEDNESS_UNDEFINED: undefined sign
  * @ARV_GC_SIGNEDNESS_SIGNED: signed integer
  * @ARV_GC_SIGNEDNESS_UNSIGNED: unsigned integer
+ *
+ * Specifies signedness of integer registers. Per standard Genicam internally uses signed 64-bit
+ * signed integers for representing all integer registers. Therefore unsigned 64-bit integers are
+ * not available.
  */
 
 typedef enum {
@@ -73,11 +97,31 @@ typedef enum {
 	ARV_GC_SIGNEDNESS_UNSIGNED
 } ArvGcSignedness;
 
+/**
+ * ArvGcIsLinear:
+ * @ARV_GC_IS_LINEAR_UNDEFINED: undefined relationship between variables
+ * @ARV_GC_IS_LINEAR_NO: non-linear relationship between variables
+ * @ARV_GC_IS_LINEAR_YES: linear relationship between variables
+ *
+ * Describes relationship between TO and FROM variables in Converter feature nodes.
+ */
+
 typedef enum {
 	ARV_GC_IS_LINEAR_UNDEFINED = -1,
 	ARV_GC_IS_LINEAR_NO,
 	ARV_GC_IS_LINEAR_YES
 } ArvGcIsLinear;
+
+/**
+ * ArvGcVisibility:
+ * @ARV_GC_VISIBILITY_UNDEFINED: undefined feature visibility level
+ * @ARV_GC_VISIBILITY_INVISIBLE: feature should be not be visible in user interface
+ * @ARV_GC_VISIBILITY_GURU: very advanced feature to be shown to very experienced users
+ * @ARV_GC_VISIBILITY_EXPERT: advanced feature to be shown to expert users
+ * @ARV_GC_VISIBILITY_BEGINNER: basic feature to be shown to all users
+ *
+ * Specifies feature node recommended visibility in user interfaces.
+ */
 
 typedef enum {
 	ARV_GC_VISIBILITY_UNDEFINED = -1,


### PR DESCRIPTION
Adds some documentation strings for Genicam enums and also fixes a bug by renaming `ArvGcSign` to `ArvGcSignedness`.