### PR TITLE
wip/genicam: implement 'AccessMode' and 'ImposedAccessMode' handling

### DIFF
--- a/docs/reference/aravis/aravis-sections.txt
+++ b/docs/reference/aravis/aravis-sections.txt
@@ -632,6 +632,8 @@ arv_gc_feature_node_is_available
 arv_gc_feature_node_is_implemented
 arv_gc_feature_node_is_locked
 arv_gc_feature_node_get_visibility
+arv_gc_feature_node_get_imposed_access_mode
+arv_gc_feature_node_get_actual_access_mode
 <SUBSECTION Standard>
 ARV_GC_FEATURE_NODE
 ARV_IS_GC_FEATURE_NODE

--- a/src/arvgcboolean.c
+++ b/src/arvgcboolean.c
@@ -213,6 +213,22 @@ arv_gc_boolean_set_value (ArvGcBoolean *gc_boolean, gboolean v_boolean, GError *
 		g_propagate_error (error, local_error);
 }
 
+static ArvGcFeatureNode *
+arv_gc_boolean_get_pointed_node (ArvGcFeatureNode *gc_feature_node)
+{
+	ArvGcBoolean *gc_boolean = ARV_GC_BOOLEAN (gc_feature_node);
+	ArvGcNode *pvalue_node = NULL;
+
+	if (gc_boolean->value == NULL)
+		return NULL;
+
+	pvalue_node = arv_gc_property_node_get_linked_node (gc_boolean->value);
+	if (ARV_IS_GC_FEATURE_NODE (pvalue_node))
+		return ARV_GC_FEATURE_NODE (pvalue_node);
+
+	return NULL;
+}
+
 ArvGcNode *
 arv_gc_boolean_new (void)
 {
@@ -239,6 +255,7 @@ arv_gc_boolean_class_init (ArvGcBooleanClass *this_class)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS (this_class);
 	ArvDomNodeClass *dom_node_class = ARV_DOM_NODE_CLASS (this_class);
+	ArvGcFeatureNodeClass *gc_feature_node_class = ARV_GC_FEATURE_NODE_CLASS (this_class);
 
 	parent_class = g_type_class_peek_parent (this_class);
 
@@ -246,4 +263,5 @@ arv_gc_boolean_class_init (ArvGcBooleanClass *this_class)
 	dom_node_class->get_node_name = arv_gc_boolean_get_node_name;
 	dom_node_class->post_new_child = arv_gc_boolean_post_new_child;
 	dom_node_class->pre_remove_child = arv_gc_boolean_pre_remove_child;
+	gc_feature_node_class->get_pointed_node = arv_gc_boolean_get_pointed_node;
 }

--- a/src/arvgccommand.c
+++ b/src/arvgccommand.c
@@ -124,6 +124,22 @@ arv_gc_command_execute (ArvGcCommand *gc_command, GError **error)
 			 command_value);
 }
 
+static ArvGcFeatureNode *
+arv_gc_command_get_pointed_node (ArvGcFeatureNode *gc_feature_node)
+{
+	ArvGcCommand *gc_command = ARV_GC_COMMAND (gc_feature_node);
+	ArvGcNode *pvalue_node = NULL;
+
+	if (gc_command->value == NULL)
+		return NULL;
+
+	pvalue_node = arv_gc_property_node_get_linked_node (gc_command->value);
+	if (ARV_IS_GC_FEATURE_NODE (pvalue_node))
+		return ARV_GC_FEATURE_NODE (pvalue_node);
+
+	return NULL;
+}
+
 ArvGcNode *
 arv_gc_command_new (void)
 {
@@ -150,9 +166,11 @@ arv_gc_command_class_init (ArvGcCommandClass *this_class)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS (this_class);
 	ArvDomNodeClass *dom_node_class = ARV_DOM_NODE_CLASS (this_class);
+	ArvGcFeatureNodeClass *gc_feature_node_class = ARV_GC_FEATURE_NODE_CLASS (this_class);
 
 	object_class->finalize = arv_gc_command_finalize;
 	dom_node_class->get_node_name = arv_gc_command_get_node_name;
 	dom_node_class->post_new_child = arv_gc_command_post_new_child;
 	dom_node_class->pre_remove_child = arv_gc_command_pre_remove_child;
+	gc_feature_node_class->get_pointed_node = arv_gc_command_get_pointed_node;
 }

--- a/src/arvgcconverter.c
+++ b/src/arvgcconverter.c
@@ -129,6 +129,22 @@ arv_gc_converter_init (ArvGcConverter *self)
 	priv->value = NULL;
 }
 
+static ArvGcFeatureNode *
+arv_gc_converter_get_pointed_node (ArvGcFeatureNode *gc_feature_node)
+{
+	ArvGcConverterPrivate *priv = arv_gc_converter_get_instance_private (ARV_GC_CONVERTER (gc_feature_node));
+	ArvGcNode *pvalue_node = NULL;
+
+	if (priv->value == NULL)
+		return NULL;
+
+	pvalue_node = arv_gc_property_node_get_linked_node (priv->value);
+	if (ARV_IS_GC_FEATURE_NODE (pvalue_node))
+		return ARV_GC_FEATURE_NODE (pvalue_node);
+
+	return NULL;
+}
+
 static void
 arv_gc_converter_finalize (GObject *object)
 {
@@ -149,10 +165,12 @@ arv_gc_converter_class_init (ArvGcConverterClass *this_class)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS (this_class);
 	ArvDomNodeClass *dom_node_class = ARV_DOM_NODE_CLASS (this_class);
+	ArvGcFeatureNodeClass *gc_feature_node_class = ARV_GC_FEATURE_NODE_CLASS (this_class);
 
 	object_class->finalize = arv_gc_converter_finalize;
 	dom_node_class->post_new_child = arv_gc_converter_post_new_child;
 	dom_node_class->pre_remove_child = arv_gc_converter_pre_remove_child;
+	gc_feature_node_class->get_pointed_node = arv_gc_converter_get_pointed_node;
 }
 
 /* ArvGcInteger interface implementation */

--- a/src/arvgcenumeration.c
+++ b/src/arvgcenumeration.c
@@ -514,6 +514,22 @@ arv_gc_enumeration_get_entries (ArvGcEnumeration *enumeration)
 	return enumeration->entries;
 }
 
+static ArvGcFeatureNode *
+arv_gc_enumeration_get_pointed_node (ArvGcFeatureNode *gc_feature_node)
+{
+	ArvGcEnumeration *gc_enumeration = ARV_GC_ENUMERATION (gc_feature_node);
+	ArvGcNode *pvalue_node = NULL;
+
+	if (gc_enumeration->value == NULL)
+		return NULL;
+
+	pvalue_node = arv_gc_property_node_get_linked_node (gc_enumeration->value);
+	if (ARV_IS_GC_FEATURE_NODE (pvalue_node))
+		return ARV_GC_FEATURE_NODE (pvalue_node);
+
+	return NULL;
+}
+
 ArvGcNode *
 arv_gc_enumeration_new (void)
 {
@@ -546,13 +562,14 @@ arv_gc_enumeration_class_init (ArvGcEnumerationClass *this_class)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS (this_class);
 	ArvDomNodeClass *dom_node_class = ARV_DOM_NODE_CLASS (this_class);
+	ArvGcFeatureNodeClass *gc_feature_node_class = ARV_GC_FEATURE_NODE_CLASS (this_class);
 
 	object_class->finalize = arv_gc_enumeration_finalize;
-
 	dom_node_class->get_node_name = arv_gc_enumeration_get_node_name;
 	dom_node_class->can_append_child = arv_gc_enumeration_can_append_child;
 	dom_node_class->post_new_child = arv_gc_enumeration_post_new_child;
 	dom_node_class->pre_remove_child = arv_gc_enumeration_pre_remove_child;
+	gc_feature_node_class->get_pointed_node = arv_gc_enumeration_get_pointed_node;
 }
 
 /* ArvGcInteger interface implementation */

--- a/src/arvgcfeaturenode.h
+++ b/src/arvgcfeaturenode.h
@@ -38,6 +38,9 @@ G_DECLARE_DERIVABLE_TYPE (ArvGcFeatureNode, arv_gc_feature_node, ARV, GC_FEATURE
 
 struct _ArvGcFeatureNodeClass {
 	ArvGcNodeClass parent_class;
+
+	ArvGcFeatureNode *	(*get_pointed_node)	(ArvGcFeatureNode *gc_feature_node);
+	ArvGcAccessMode		(*get_access_mode)	(ArvGcFeatureNode *gc_feature_node);
 };
 
 const char *		arv_gc_feature_node_get_name			(ArvGcFeatureNode *gc_feature_node);
@@ -51,6 +54,9 @@ ArvGcVisibility		arv_gc_feature_node_get_visibility		(ArvGcFeatureNode *gc_featu
 gboolean		arv_gc_feature_node_is_available		(ArvGcFeatureNode *gc_feature_node, GError **error);
 gboolean		arv_gc_feature_node_is_implemented		(ArvGcFeatureNode *gc_feature_node, GError **error);
 gboolean		arv_gc_feature_node_is_locked			(ArvGcFeatureNode *gc_feature_node, GError **error);
+
+ArvGcAccessMode		arv_gc_feature_node_get_imposed_access_mode	(ArvGcFeatureNode *gc_feature_node);
+ArvGcAccessMode		arv_gc_feature_node_get_actual_access_mode	(ArvGcFeatureNode *gc_feature_node);
 
 void			arv_gc_feature_node_set_value_from_string	(ArvGcFeatureNode *gc_feature_node, const char *string,
 									 GError **error);

--- a/src/arvgcfloatnode.c
+++ b/src/arvgcfloatnode.c
@@ -174,6 +174,22 @@ arv_gc_float_node_new (void)
 	return node;
 }
 
+static ArvGcFeatureNode *
+arv_gc_float_node_get_pointed_node (ArvGcFeatureNode *gc_feature_node)
+{
+	ArvGcFloatNode *gc_float_node = ARV_GC_FLOAT_NODE (gc_feature_node);
+	ArvGcNode *pvalue_node = NULL;
+
+	if (gc_float_node->value == NULL)
+		return NULL;
+
+	pvalue_node = arv_gc_property_node_get_linked_node (gc_float_node->value);
+	if (ARV_IS_GC_FEATURE_NODE (pvalue_node))
+		return ARV_GC_FEATURE_NODE (pvalue_node);
+
+	return NULL;
+}
+
 static void
 arv_gc_float_node_init (ArvGcFloatNode *gc_float_node)
 {
@@ -194,11 +210,13 @@ arv_gc_float_node_class_init (ArvGcFloatNodeClass *this_class)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS (this_class);
 	ArvDomNodeClass *dom_node_class = ARV_DOM_NODE_CLASS (this_class);
+	ArvGcFeatureNodeClass *gc_feature_node_class = ARV_GC_FEATURE_NODE_CLASS (this_class);
 
 	object_class->finalize = arv_gc_float_node_finalize;
 	dom_node_class->get_node_name = arv_gc_float_node_get_node_name;
 	dom_node_class->post_new_child = arv_gc_float_node_post_new_child;
 	dom_node_class->pre_remove_child = arv_gc_float_node_pre_remove_child;
+	gc_feature_node_class->get_pointed_node = arv_gc_float_node_get_pointed_node;
 }
 
 /* ArvGcFloat interface implementation */

--- a/src/arvgcintegernode.c
+++ b/src/arvgcintegernode.c
@@ -175,6 +175,22 @@ arv_gc_integer_node_new (void)
 	return node;
 }
 
+static ArvGcFeatureNode *
+arv_gc_integer_node_get_pointed_node (ArvGcFeatureNode *gc_feature_node)
+{
+	ArvGcIntegerNode *gc_integer_node = ARV_GC_INTEGER_NODE (gc_feature_node);
+	ArvGcNode *pvalue_node = NULL;
+
+	if (gc_integer_node->value == NULL)
+		return NULL;
+
+	pvalue_node = arv_gc_property_node_get_linked_node (gc_integer_node->value);
+	if (ARV_IS_GC_FEATURE_NODE (pvalue_node))
+		return ARV_GC_FEATURE_NODE (pvalue_node);
+
+	return NULL;
+}
+
 static void
 arv_gc_integer_node_init (ArvGcIntegerNode *gc_integer_node)
 {
@@ -197,11 +213,13 @@ arv_gc_integer_node_class_init (ArvGcIntegerNodeClass *this_class)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS (this_class);
 	ArvDomNodeClass *dom_node_class = ARV_DOM_NODE_CLASS (this_class);
+	ArvGcFeatureNodeClass *gc_feature_node_class = ARV_GC_FEATURE_NODE_CLASS (this_class);
 
 	object_class->finalize = arv_gc_integer_node_finalize;
 	dom_node_class->get_node_name = arv_gc_integer_node_get_node_name;
 	dom_node_class->post_new_child = arv_gc_integer_node_post_new_child;
 	dom_node_class->pre_remove_child = arv_gc_integer_node_pre_remove_child;
+	gc_feature_node_class->get_pointed_node = arv_gc_integer_node_get_pointed_node;
 }
 
 /* ArvGcInteger interface implementation */

--- a/src/arvgcpropertynode.c
+++ b/src/arvgcpropertynode.c
@@ -858,8 +858,10 @@ arv_gc_property_node_get_access_mode (ArvGcPropertyNode *self, ArvGcAccessMode d
 		return ARV_GC_ACCESS_MODE_RO;
 	else if (g_strcmp0 (value, "WO") == 0)
 		return ARV_GC_ACCESS_MODE_WO;
+	else if (g_strcmp0 (value, "RW") == 0)
+		return ARV_GC_ACCESS_MODE_RW;
 
-	return ARV_GC_ACCESS_MODE_RW;
+	return default_value;
 }
 
 ArvGcNode *

--- a/src/arvgcstructentrynode.c
+++ b/src/arvgcstructentrynode.c
@@ -45,6 +45,7 @@ struct _ArvGcStructEntryNode {
 	ArvGcPropertyNode *representation;
 	ArvGcPropertyNode *lsb;
 	ArvGcPropertyNode *msb;
+	ArvGcPropertyNode *access_mode;
 	ArvGcPropertyNode *cachable;
 
 	char v_string[G_ASCII_DTOSTR_BUF_SIZE];
@@ -94,6 +95,9 @@ arv_gc_struct_entry_node_post_new_child (ArvDomNode *self, ArvDomNode *child)
 				node->msb = property_node;
 				node->lsb = property_node;
 				break;
+			case ARV_GC_PROPERTY_NODE_TYPE_ACCESS_MODE:
+				node->access_mode = property_node;
+				break;
 			case ARV_GC_PROPERTY_NODE_TYPE_CACHABLE:
 				node->cachable = property_node;
 				break;
@@ -133,6 +137,17 @@ arv_gc_struct_entry_node_init (ArvGcStructEntryNode *gc_struct_entry_node)
 {
 }
 
+static ArvGcAccessMode
+arv_gc_struct_entry_node_get_access_mode (ArvGcFeatureNode *gc_feature_node)
+{
+	ArvGcStructEntryNode *self = ARV_GC_STRUCT_ENTRY_NODE(gc_feature_node);
+
+	if (self->access_mode == NULL)
+		return ARV_GC_ACCESS_MODE_RO;
+
+	return arv_gc_property_node_get_access_mode (self->access_mode, ARV_GC_ACCESS_MODE_RO);
+}
+
 static void
 arv_gc_struct_entry_node_finalize (GObject *object)
 {
@@ -144,11 +159,13 @@ arv_gc_struct_entry_node_class_init (ArvGcStructEntryNodeClass *this_class)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS (this_class);
 	ArvDomNodeClass *dom_node_class = ARV_DOM_NODE_CLASS (this_class);
+	ArvGcFeatureNodeClass *gc_feature_node_class = ARV_GC_FEATURE_NODE_CLASS (this_class);
 
 	object_class->finalize = arv_gc_struct_entry_node_finalize;
 	dom_node_class->get_node_name = arv_gc_struct_entry_node_get_node_name;
 	dom_node_class->post_new_child = arv_gc_struct_entry_node_post_new_child;
 	dom_node_class->pre_remove_child = arv_gc_struct_entry_node_pre_remove_child;
+	gc_feature_node_class->get_access_mode = arv_gc_struct_entry_node_get_access_mode;
 }
 
 /* ArvGcRegister interface implementation */

--- a/src/arvgcswissknife.c
+++ b/src/arvgcswissknife.c
@@ -101,6 +101,12 @@ arv_gc_swiss_knife_init (ArvGcSwissKnife *self)
 	priv->formula = arv_evaluator_new (NULL);
 }
 
+static ArvGcAccessMode
+arv_gc_swiss_knife_get_access_mode (ArvGcFeatureNode *gc_feature_node)
+{
+	return ARV_GC_ACCESS_MODE_RO;
+}
+
 static void
 arv_gc_swiss_knife_finalize (GObject *object)
 {
@@ -120,10 +126,12 @@ arv_gc_swiss_knife_class_init (ArvGcSwissKnifeClass *this_class)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS (this_class);
 	ArvDomNodeClass *dom_node_class = ARV_DOM_NODE_CLASS (this_class);
+	ArvGcFeatureNodeClass *gc_feature_node_class = ARV_GC_FEATURE_NODE_CLASS (this_class);
 
 	object_class->finalize = arv_gc_swiss_knife_finalize;
 	dom_node_class->post_new_child = arv_gc_swiss_knife_post_new_child;
 	dom_node_class->pre_remove_child = arv_gc_swiss_knife_pre_remove_child;
+	gc_feature_node_class->get_access_mode = arv_gc_swiss_knife_get_access_mode;
 }
 
 /* ArvGcInteger interface implementation */


### PR DESCRIPTION
This commit implements Genicam access mode retrieval for all important features except `StructEntry` nodes.

1. In case we have a register node we get the `access_mode` property and we are done.
2. If we have non-register feature node then `arv_gc_feature_node_get_access_mode` utilizes bunch of new private functions like `arv_gc_integer_node_get_access_mode`, `arv_gc_enumeration_get_access_mode` etc. to get the referenced `pValue` node which contains wanted access mode info.

The hackiest thing about this commit is probably `arv_gc_property_node_get_access_mode`. It can take both `AccessMode` and `pValue` properties.

The approach is quite experimental, but everything seems to work. Let me know what you think.

Edit: Forgot to mention that this topic was also discussed in #332 