### PR TITLE
gvdevice: make it possible to manually take or leave control access

### DIFF
--- a/src/arvgvdevice.c
+++ b/src/arvgvdevice.c
@@ -447,17 +447,30 @@ arv_gv_device_heartbeat_thread (void *data)
 
 /* ArvGvDevice implemenation */
 
-static gboolean
-arv_gv_device_take_control (ArvGvDevice *gv_device)
+/**
+ * arv_gv_device_take_control:
+ * @gv_device: a #ArvGvDevice
+ * @error: a #GError placeholder, %NULL to ignore
+ *
+ * Returns: whether the control was successfully acquired
+ *
+ * Since: 0.8.0
+ */
+
+gboolean
+arv_gv_device_take_control (ArvGvDevice *gv_device, GError **error)
 {
 	ArvGvDevicePrivate *priv = arv_gv_device_get_instance_private (gv_device);
-	gboolean success;
+	gboolean success = TRUE;
 
-	success = arv_device_write_register (ARV_DEVICE (gv_device),
-					     ARV_GVBS_CONTROL_CHANNEL_PRIVILEGE_OFFSET,
-					     ARV_GVBS_CONTROL_CHANNEL_PRIVILEGE_CONTROL, NULL);
+	if (!priv->io_data->is_controller) {
+		success = arv_device_write_register (ARV_DEVICE (gv_device),
+						     ARV_GVBS_CONTROL_CHANNEL_PRIVILEGE_OFFSET,
+						     ARV_GVBS_CONTROL_CHANNEL_PRIVILEGE_CONTROL,
+						     error);
 
-	priv->io_data->is_controller = success;
+		priv->io_data->is_controller = success;
+	}
 
 	if (!success)
 		arv_warning_device ("[GvDevice::take_control] Can't get control access");
@@ -465,16 +478,35 @@ arv_gv_device_take_control (ArvGvDevice *gv_device)
 	return success;
 }
 
-static gboolean
-arv_gv_device_leave_control (ArvGvDevice *gv_device)
+/**
+ * arv_gv_device_leave_control:
+ * @gv_device: a #ArvGvDevice
+ * @error: a #GError placeholder, %NULL to ignore
+ *
+ * Returns: whether the control was successfully relinquished
+ *
+ * Since: 0.8.0
+ */
+
+gboolean
+arv_gv_device_leave_control (ArvGvDevice *gv_device, GError **error)
 {
 	ArvGvDevicePrivate *priv = arv_gv_device_get_instance_private (gv_device);
-	gboolean success;
+	gboolean success = TRUE;
 
-	priv->io_data->is_controller = FALSE;
+	if (priv->io_data->is_controller) {
+		priv->io_data->is_controller = FALSE;
 
-	success = arv_device_write_register (ARV_DEVICE (gv_device),
-					    ARV_GVBS_CONTROL_CHANNEL_PRIVILEGE_OFFSET, 0, NULL);
+		success = arv_device_write_register (ARV_DEVICE (gv_device),
+						     ARV_GVBS_CONTROL_CHANNEL_PRIVILEGE_OFFSET,
+						     0,
+						     error);
+
+		priv->io_data->is_controller = !success;
+	}
+
+	if (!success)
+		arv_warning_device ("[GvDevice::leave_control] Can't relinquish control access");
 
 	return success;
 }
@@ -1288,7 +1320,7 @@ arv_gv_device_constructed (GObject *object)
 		return;
 	}
 
-	arv_gv_device_take_control (gv_device);
+	arv_gv_device_take_control (gv_device, NULL);
 
 	heartbeat_data = g_new (ArvGvDeviceHeartbeatData, 1);
 	heartbeat_data->gv_device = gv_device;
@@ -1345,7 +1377,7 @@ arv_gv_device_finalize (GObject *object)
 		priv->heartbeat_thread = NULL;
 	}
 
-	arv_gv_device_leave_control (gv_device);
+	arv_gv_device_leave_control (gv_device, NULL);
 
 	io_data = priv->io_data;
 	g_clear_object (&io_data->device_address);

--- a/src/arvgvdevice.h
+++ b/src/arvgvdevice.h
@@ -40,6 +40,9 @@ G_DECLARE_FINAL_TYPE (ArvGvDevice, arv_gv_device, ARV, GV_DEVICE, ArvDevice)
 ArvDevice * 		arv_gv_device_new 				(GInetAddress *interface_address, GInetAddress *device_address,
 									 GError **error);
 
+gboolean		arv_gv_device_take_control			(ArvGvDevice *gv_device, GError **error);
+gboolean		arv_gv_device_leave_control			(ArvGvDevice *gv_device, GError **error);
+
 guint64 		arv_gv_device_get_timestamp_tick_frequency	(ArvGvDevice *gv_device, GError **error);
 
 GSocketAddress *	arv_gv_device_get_interface_address  		(ArvGvDevice *device);


### PR DESCRIPTION
Hey! I've taken a stab at implementing a minimal version of #400. What do you think?

(commit message below)

The main changes are:
- Make `arv_gv_device_take_control` and `arv_gv_device_leave_control`
  public, adding documentation
- Add an `error` parameter for consistency with the current public API
- Adjust the few callers to this new parameter
- Add a warning message if we fail to relinquish the control access
- Update `is_controller` correctly if `leave_control` failed
- Wrap writing the register in a check that the register write will
  actually have an impact

I think this is correct and does not need touching the heartbeat
thread because:
- The heartbeat thread as defined in `arv_gv_device_heartbeat_thread`
  does not do anything when `is_controller` is set to `FALSE`
- Just setting `is_controller` to `FALSE` is already what will happen
  when losing the TCP control connection
- Having one heartbeat thread per alive `GvDevice` instance sounds
  like a reasonable price to pay, even though it would probably be
  more optimal to stop the heartbeat thread on control leave and
  resume it on control take

So, as future work that could be done to further improve the
situation, I see:
- Stop the heartbeat thread when leaving control and resume it when
  taking control
- Implement the rest of #400, ie. adding a “lazy” control access mode
  whereby control access is automatically acquired/relinquished when
  doing settings only