### PR TITLE
travis: fix ci failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install ninja intltool; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew link --force gettext ; fi
   - sudo pip3 install --upgrade pip
-  - sudo pip3 install setuptools
+  - sudo pip3 install 'setuptools==49.6.0'
   - sudo pip3 install 'meson==0.47'
 
 script:


### PR DESCRIPTION
Force setuptools to be 49.6.0, as 50.0.3 makes meson fail with the
following error:

```
$ meson build

Traceback (most recent call last):

  File "/usr/bin/meson", line 26, in <module>

    from mesonbuild import mesonmain

ImportError: No module named 'mesonbuild'
```