### PR TITLE
Fix _send_cmd_and_receive_ack timeout race

### DIFF
--- a/src/arvgvdevice.c
+++ b/src/arvgvdevice.c
@@ -228,7 +228,9 @@ _send_cmd_and_receive_ack (ArvGvDeviceIOData *io_data, ArvGvcpCommand command,
 			do {
 				pending_ack = FALSE;
 
-				timeout_ms = MAX (0, timeout_stop_ms - g_get_monotonic_time () / 1000);
+				timeout_ms = timeout_stop_ms - g_get_monotonic_time () / 1000;
+				if (timeout_ms < 0)
+					timeout_ms = 0;
 
 				success = TRUE;
 				success = success && g_poll (&io_data->poll_in_event, 1, timeout_ms) > 0;


### PR DESCRIPTION
Using MAX macro with g_get_monotonic_time() as one of parameters may
cause (and causes) a race because this is evaluated twice.
It lead to g_poll timeout being set to -1 causing infinite wait on
disconnected camera.

Very hard to reproduce. I use FAST-HEARTBEAT to make my software react for camera being plugged/unplugged faster.
After camera is lost the system polls for it once in a while in a separated thread.
I realized that arv_camera_new(camera_id) takes very long if the camera does not exists (but did exist previously). So what I am actually doing (after control-lost) is calling some read command (arv_camera_get_gain) and only once it succeeds I proceed with full re-initialization. This works fine but once in say 3 - 6 hours (!!!) with an attempt every 5 seconds the library freezes. I have compiled in in release with debug symbols and finally managed to find the spot:

`timeout_ms = MAX (0, timeout_stop_ms - g_get_monotonic_time () / 1000);`
`...`
`success = success && g_poll (&io_data->poll_in_event, 1, timeout_ms) > 0;`

gets me to the state where the timeout_ms is -1 which means "wait forever".
See the debuger (qt-creator) output.

![aravis-MAX-macro-race](https://user-images.githubusercontent.com/67421944/94036459-dacc0b00-fdb3-11ea-9b27-387d924ae050.png)

I scratched my head how is it possible that macro MAX(0, whatever) may return -1 but finally figured it out: double evaluation.
I believe this may have been a reason for other rare/hard-to-reporduce error. 

I have checked the remaining code and found the macro to by used correctly (without function calls as parameters) everywhere else but here:
arvgvdevice.c: 573:  inc = MAX (1, arv_device_get_integer_feature_increment (device, "GevSCPSPacketSize", NULL));

I'm not sure if the above shouldn't be fixed as well. 

