### PR TITLE
Add simple test/utility program for listing network interfaces

### DIFF
--- a/tests/arvnetworktest.c
+++ b/tests/arvnetworktest.c
@@ -1,0 +1,45 @@
+#include <arv.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include "../src/arvnetworkprivate.h"
+
+#define _ALEN 16
+#define _ALENS "16"
+#define _LINEFMT "%20s %10s %" _ALENS "s %" _ALENS "s %" _ALENS "s\n"
+
+int
+main (int argc, char **argv){
+	GList *ifaces;
+	GList *iface_iter;
+
+	ifaces = arv_enumerate_network_interfaces ();
+	if (!ifaces) {
+		fprintf (stderr,"No network interfaces found (or enumeration failed).");
+		return 1;
+	}
+	printf(_LINEFMT,"interface","proto","address","mask","broadcast");
+
+	for (iface_iter=ifaces; iface_iter!=NULL; iface_iter=iface_iter->next){
+		ArvNetworkInterface* ani = (ArvNetworkInterface*)iface_iter->data;
+		char addr[_ALEN];
+		char netmask[_ALEN];
+		char broadaddr[_ALEN];
+		int fam = arv_network_interface_get_addr(ani)->sa_family;
+		if (fam==AF_INET){
+			inet_ntop (fam, &((struct sockaddr_in*)arv_network_interface_get_addr(ani))->sin_addr, &addr[0], _ALEN);
+			inet_ntop (fam, &((struct sockaddr_in*)arv_network_interface_get_netmask(ani))->sin_addr, &netmask[0], _ALEN);
+			inet_ntop (fam, &((struct sockaddr_in*)arv_network_interface_get_addr(ani))->sin_addr, &broadaddr[0], _ALEN);
+			printf (_LINEFMT, arv_network_interface_get_name(ani), "IPv4", addr, netmask, broadaddr);
+		}
+		else if (fam==AF_INET6){
+			fprintf (stderr,"%s: IPv6 not yet reported correctly", arv_network_interface_get_name(ani));
+		}
+		else {
+			fprintf (stderr,"%s: unrecognized family %d", arv_network_interface_get_name(ani), fam);
+		}
+	}
+	g_list_free_full (ifaces, (GDestroyNotify) arv_network_interface_free);
+	return 0;
+}
+
+

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -54,6 +54,7 @@ if get_option('tests')
 	endif
 
 	examples = [
+		['arv-network-test',		'arvnetworktest.c'],
 		['arv-device-test',		'arvdevicetest.c'],
 		['arv-genicam-test',		'arvgenicamtest.c'],
 		['arv-evaluator-test',		'arvevaluatortest.c'],


### PR DESCRIPTION
A small utility for listing network interfaces. Sample output:
```
           interface      proto          address             mask        broadcast
                  lo       IPv4        127.0.0.1        255.0.0.0        127.0.0.1
                eth3       IPv4     169.254.64.1      255.255.0.0     169.254.64.1
                eth3       IPv4    192.168.100.1    255.255.255.0    192.168.100.1
                eth3       IPv4     192.168.2.12    255.255.255.0     192.168.2.12
              virbr0       IPv4    192.168.122.1    255.255.255.0    192.168.122.1
             docker0       IPv4       172.17.0.1      255.255.0.0       172.17.0.1
     br-23a99ce39657       IPv4       172.18.0.1      255.255.0.0       172.18.0.1
```