### PR TITLE
Wip/packet size check

### DIFF
--- a/src/arvcamera.c
+++ b/src/arvcamera.c
@@ -2540,6 +2540,26 @@ arv_camera_gv_set_stream_options (ArvCamera *camera, ArvGvStreamOption options)
 }
 
 /**
+ * arv_camera_gv_set_packet_size_adjustement:
+ * @camera: a #ArvCamera
+ * @adjustement: a #ArvGvPacketSizeAdjustement option
+ *
+ * Sets the option for packet size adjustement that happens at stream object creation.
+ *
+ * Since: 0.8.3
+ */
+
+void
+arv_camera_gv_set_packet_size_adjustement (ArvCamera *camera, ArvGvPacketSizeAdjustement adjustement)
+{
+	ArvCameraPrivate *priv = arv_camera_get_instance_private (camera);
+
+	g_return_if_fail (arv_camera_is_gv_device (camera));
+
+	arv_gv_device_set_packet_size_adjustement (ARV_GV_DEVICE (priv->device), adjustement);
+}
+
+/**
  * arv_camera_is_uv_device:
  * @camera: a #ArvCamera
  *

--- a/src/arvcamera.h
+++ b/src/arvcamera.h
@@ -30,6 +30,7 @@
 #include <arvtypes.h>
 #include <arvstream.h>
 #include <arvgvstream.h>
+#include <arvgvdevice.h>
 
 G_BEGIN_DECLS
 
@@ -175,6 +176,8 @@ gint64 		arv_camera_gv_get_packet_delay 		(ArvCamera *camera, GError **error);
 void 		arv_camera_gv_set_packet_size 		(ArvCamera *camera, gint packet_size, GError **error);
 guint		arv_camera_gv_get_packet_size		(ArvCamera *camera, GError **error);
 guint		arv_camera_gv_auto_packet_size		(ArvCamera *camera, GError **error);
+void		arv_camera_gv_set_packet_size_adjustement 	(ArvCamera *camera,
+								 ArvGvPacketSizeAdjustement adjustement);
 
 void 		arv_camera_gv_set_stream_options 	(ArvCamera *camera, ArvGvStreamOption options);
 

--- a/src/arvgvdevice.c
+++ b/src/arvgvdevice.c
@@ -526,23 +526,43 @@ arv_gv_device_set_packet_size (ArvGvDevice *gv_device, gint packet_size, GError 
 	arv_device_set_integer_feature_value (ARV_DEVICE (gv_device), "GevSCPSPacketSize", packet_size, error);
 }
 
-/**
- * arv_gv_device_auto_packet_size:
- * @gv_device: a #ArvGvDevice
- * @error: a #GError placeholder, %NULL to ignore
- *
- * Automatically determine the biggest packet size that can be used data
- * streaming, and set GevSCPSPacketSize value accordingly. This function relies
- * on the GevSCPSFireTestPacket feature. If this feature is not available, the
- * packet size will be set to a default value (1500 bytes).
- *
- * Returns: The packet size, in bytes.
- *
- * Since: 0.6.0
- */
+static gboolean
+test_packet_check (ArvDevice *device,
+		   GPollFD *poll_fd,
+		   GSocket *socket,
+		   char *buffer,
+		   guint packet_size,
+		   gboolean is_command)
+{
+	unsigned n_tries = 0;
+	int n_events;
+	size_t read_count;
 
-guint
-arv_gv_device_auto_packet_size (ArvGvDevice *gv_device, GError **error)
+	do {
+		if (is_command) {
+			arv_device_execute_command (device, "GevSCPSFireTestPacket", NULL);
+		} else {
+			arv_device_set_boolean_feature_value (device, "GevSCPSFireTestPacket", FALSE, NULL);
+			arv_device_set_boolean_feature_value (device, "GevSCPSFireTestPacket", TRUE, NULL);
+		}
+
+		do {
+			n_events = g_poll (poll_fd, 1, 10);
+			if (n_events != 0)
+				read_count = g_socket_receive (socket, buffer, 16384, NULL, NULL);
+			else
+				read_count = 0;
+			/* Discard late packets, read_count should be equal to packet size minus IP and UDP headers */
+		} while (n_events != 0 && read_count != (packet_size - sizeof (struct iphdr) - sizeof (struct udphdr)));
+
+		n_tries++;
+	} while (n_events == 0 && n_tries < 3);
+
+	return n_events != 0;
+}
+
+static guint
+auto_packet_size (ArvGvDevice *gv_device, gboolean exit_early, GError **error)
 {
 	ArvGvDevicePrivate *priv = arv_gv_device_get_instance_private (gv_device);
 	ArvDevice *device = ARV_DEVICE (gv_device);
@@ -556,13 +576,13 @@ arv_gv_device_auto_packet_size (ArvGvDevice *gv_device, GError **error)
 	guint16 port;
 	gboolean do_not_fragment;
 	gboolean is_command;
-	int n_events;
-	guint max_size, min_size, current_size;
+	guint max_size, min_size;
 	guint packet_size = 1500;
-	gint64 minimum, maximum;
+	gint64 minimum, maximum, current_packet_size;
 	guint inc;
 	char *buffer;
 	guint last_size = 0;
+	gboolean success;
 
 	g_return_val_if_fail (ARV_IS_GV_DEVICE (gv_device), 1500);
 
@@ -577,6 +597,7 @@ arv_gv_device_auto_packet_size (ArvGvDevice *gv_device, GError **error)
 	inc = arv_device_get_integer_feature_increment (device, "GevSCPSPacketSize", NULL);
 	if (inc < 1)
 		inc = 1;
+	current_packet_size = arv_device_get_integer_feature_value (device, "GevSCPSPacketSize", NULL);
 	arv_device_get_integer_feature_bounds (device, "GevSCPSPacketSize", &minimum, &maximum, NULL);
 	max_size = MIN (65536, maximum);
 	min_size = MAX (ARV_GVSP_PACKET_PROTOCOL_OVERHEAD, minimum);
@@ -613,67 +634,77 @@ arv_gv_device_auto_packet_size (ArvGvDevice *gv_device, GError **error)
 	poll_fd.events =  G_IO_IN;
 	poll_fd.revents = 0;
 
-	current_size = 1500;
-
 	buffer = g_malloc (max_size);
 
-	do {
-		size_t read_count;
-		unsigned n_tries = 0;
+	success = test_packet_check (device, &poll_fd, socket, buffer, current_packet_size, is_command);
 
-		current_size = ((current_size + inc - 1) / inc) * inc;
+	/* When exit_early is set, the function only checks the current packet size is working.
+	 * If not, the full automatic packet size adjustement is run. */
+	if (success && exit_early) {
+		arv_debug_device ("[GvDevice::auto_packet_size] Current packet size check successfull "
+				  "(%" G_GINT64_FORMAT " bytes)",
+				  current_packet_size);
 
-		arv_debug_device ("[GvDevice::auto_packet_size] Try packet size = %d", current_size);
-		arv_device_set_integer_feature_value (device, "GevSCPSPacketSize", current_size, NULL);
-
-		current_size = arv_device_get_integer_feature_value(device, "GevSCPSPacketSize", NULL);
-
-		if (current_size == last_size)
-			break;
-
-		last_size = current_size;
+		packet_size = current_packet_size;
+	} else {
+		guint current_size = CLAMP (current_packet_size, min_size, max_size);
 
 		do {
-			if (is_command) {
-				arv_device_execute_command (device, "GevSCPSFireTestPacket", NULL);
+			current_size = ((current_size + inc - 1) / inc) * inc;
+
+			arv_debug_device ("[GvDevice::auto_packet_size] Try packet size = %d", current_size);
+			arv_device_set_integer_feature_value (device, "GevSCPSPacketSize", current_size, NULL);
+
+			current_size = arv_device_get_integer_feature_value (device, "GevSCPSPacketSize", NULL);
+
+			if (current_size == last_size)
+				break;
+
+			last_size = current_size;
+
+			success = test_packet_check (device, &poll_fd, socket, buffer, current_size, is_command);
+
+			if (success) {
+				packet_size = current_size;
+				min_size = current_size;
+				current_size = (max_size - min_size) / 2 + min_size;
 			} else {
-				arv_device_set_boolean_feature_value (device, "GevSCPSFireTestPacket", FALSE, NULL);
-				arv_device_set_boolean_feature_value (device, "GevSCPSFireTestPacket", TRUE, NULL);
+				max_size = current_size;
+				current_size = (max_size - min_size) / 2 + min_size;
 			}
+		} while ((max_size - min_size) > 16);
 
-			do {
-				n_events = g_poll (&poll_fd, 1, 10);
-				if (n_events != 0)
-					read_count = g_socket_receive (socket, buffer, 16384, NULL, NULL);
-				else
-					read_count = 0;
-				/* Discard late packets, read_count should be equal to packet size minus IP and UDP headers */
-			} while (n_events != 0 && read_count != (current_size - sizeof (struct iphdr) - sizeof (struct udphdr)));
-
-			n_tries++;
-		} while (n_events == 0 && n_tries < 3);
-
-		if (n_events != 0) {
-			arv_debug_device ("[GvDevice::auto_packet_size] Received %d bytes", (int) read_count);
-
-			packet_size = current_size;
-			min_size = current_size;
-			current_size = (max_size - min_size) / 2 + min_size;
-		} else {
-			max_size = current_size;
-			current_size = (max_size - min_size) / 2 + min_size;
-		}
-	} while ((max_size - min_size) > 16);
+		arv_debug_device ("[GvDevice::auto_packet_size] Packet size set to %d bytes", packet_size);
+	}
 
 	g_clear_pointer (&buffer, g_free);
 	g_clear_object (&socket);
-
-	arv_debug_device ("[GvDevice::auto_packet_size] Packet size set to %d bytes", packet_size);
 
 	arv_device_set_boolean_feature_value (device, "GevSCPSDoNotFragment", do_not_fragment, NULL);
 	arv_device_set_integer_feature_value (device, "GevSCPSPacketSize", packet_size, NULL);
 
 	return packet_size;
+}
+
+/**
+ * arv_gv_device_auto_packet_size:
+ * @gv_device: a #ArvGvDevice
+ * @error: a #GError placeholder, %NULL to ignore
+ *
+ * Automatically determine the biggest packet size that can be used data
+ * streaming, and set GevSCPSPacketSize value accordingly. This function relies
+ * on the GevSCPSFireTestPacket feature. If this feature is not available, the
+ * packet size will be set to a default value (1500 bytes).
+ *
+ * Returns: The packet size, in bytes.
+ *
+ * Since: 0.6.0
+ */
+
+guint
+arv_gv_device_auto_packet_size (ArvGvDevice *gv_device, GError **error)
+{
+	return auto_packet_size (gv_device, FALSE, error);
 }
 
 /**
@@ -691,7 +722,7 @@ arv_gv_device_is_controller (ArvGvDevice *gv_device)
 	ArvGvDevicePrivate *priv = arv_gv_device_get_instance_private (gv_device);
 
 	g_return_val_if_fail (ARV_IS_GV_DEVICE (gv_device), 0);
-	
+
 	return priv->io_data->is_controller;
 }
 
@@ -1082,6 +1113,7 @@ arv_gv_device_create_stream (ArvDevice *device, ArvStreamCallback callback, void
 	ArvGvDevicePrivate *priv = arv_gv_device_get_instance_private (gv_device);
 	ArvStream *stream;
 	guint32 n_stream_channels;
+	GError *local_error = NULL;
 
 	n_stream_channels = arv_device_get_integer_feature_value (device, "GevStreamChannelCount", NULL);
 	arv_debug_device ("[GvDevice::create_stream] Number of stream channels = %d", n_stream_channels);
@@ -1096,6 +1128,12 @@ arv_gv_device_create_stream (ArvDevice *device, ArvStreamCallback callback, void
 		arv_warning_device ("[GvDevice::create_stream] Can't create stream without control access");
 		g_set_error (error, ARV_DEVICE_ERROR, ARV_DEVICE_ERROR_NOT_CONTROLLER,
 			     "Controller privilege required for streaming control");
+		return NULL;
+	}
+
+	auto_packet_size (gv_device, TRUE, &local_error);
+	if (local_error != NULL) {
+		g_propagate_error (error, local_error);
 		return NULL;
 	}
 

--- a/src/arvgvdevice.c
+++ b/src/arvgvdevice.c
@@ -91,6 +91,8 @@ typedef struct {
 
 	ArvGvStreamOption stream_options;
 	ArvGvPacketSizeAdjustement packet_size_adjustement;
+
+	gboolean first_stream_created;
 } ArvGvDevicePrivate ;
 
 struct _ArvGvDevice {
@@ -715,7 +717,10 @@ arv_gv_device_auto_packet_size (ArvGvDevice *gv_device, GError **error)
  * @adjustement: a #ArvGvPacketSizeAdjustement option
  *
  * Sets the option for the packet size adjustement happening at stream object creation. See
- * arv_gv_device_auto_packet_size().
+ * arv_gv_device_auto_packet_size() for a description of the packet adjustement feature. The default behaviour is
+ * @ARV_GV_PACKET_SIZE_ADJUSTEMENT_ON_FAILURE_ONCE, which means the packet size is adjusted if the current packet size
+ * check fails, and only the first time arv_device_create_stream() is successfully called during @gv_device instance
+ * life.
  *
  * Since: 0.8.3
  */
@@ -1154,8 +1159,13 @@ arv_gv_device_create_stream (ArvDevice *device, ArvStreamCallback callback, void
 		return NULL;
 	}
 
-	if (priv->packet_size_adjustement != ARV_GV_PACKET_SIZE_ADJUSTEMENT_NEVER) {
-		auto_packet_size (gv_device, priv->packet_size_adjustement == ARV_GV_PACKET_SIZE_ADJUSTEMENT_ON_FAILURE,
+	if (priv->packet_size_adjustement != ARV_GV_PACKET_SIZE_ADJUSTEMENT_NEVER &&
+	    ((priv->packet_size_adjustement != ARV_GV_PACKET_SIZE_ADJUSTEMENT_ONCE &&
+	      priv->packet_size_adjustement != ARV_GV_PACKET_SIZE_ADJUSTEMENT_ON_FAILURE_ONCE) ||
+	     !priv->first_stream_created)) {
+		auto_packet_size (gv_device,
+				  priv->packet_size_adjustement == ARV_GV_PACKET_SIZE_ADJUSTEMENT_ON_FAILURE ||
+				      priv->packet_size_adjustement == ARV_GV_PACKET_SIZE_ADJUSTEMENT_ON_FAILURE_ONCE,
 				  &local_error);
 		if (local_error != NULL) {
 			g_propagate_error (error, local_error);
@@ -1169,6 +1179,8 @@ arv_gv_device_create_stream (ArvDevice *device, ArvStreamCallback callback, void
 
 	if (!priv->is_packet_resend_supported)
 		g_object_set (stream, "packet-resend", ARV_GV_STREAM_PACKET_RESEND_NEVER, NULL);
+
+	priv->first_stream_created = TRUE;
 
 	return stream;
 }
@@ -1543,6 +1555,7 @@ arv_gv_device_class_init (ArvGvDeviceClass *gv_device_class)
 					 g_param_spec_enum ("packet-size-adjustement", "Packet size adjustement",
 							    "Packet size adjustement option",
 							    ARV_TYPE_GV_PACKET_SIZE_ADJUSTEMENT,
-							    ARV_GV_PACKET_SIZE_ADJUSTEMENT_ON_FAILURE,
-							    G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+							    ARV_GV_PACKET_SIZE_ADJUSTEMENT_ON_FAILURE_ONCE,
+							    G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS |
+								G_PARAM_CONSTRUCT));
 }

--- a/src/arvgvdevice.c
+++ b/src/arvgvdevice.c
@@ -581,8 +581,7 @@ auto_packet_size (ArvGvDevice *gv_device, gboolean exit_early, GError **error)
 	gboolean do_not_fragment;
 	gboolean is_command;
 	guint max_size, min_size;
-	guint packet_size = 1500;
-	gint64 minimum, maximum, current_packet_size;
+	gint64 minimum, maximum, packet_size;
 	guint inc;
 	char *buffer;
 	guint last_size = 0;
@@ -592,27 +591,23 @@ auto_packet_size (ArvGvDevice *gv_device, gboolean exit_early, GError **error)
 
 	node = arv_device_get_feature (device, "GevSCPSFireTestPacket");
 	if (!ARV_IS_GC_COMMAND (node) && !ARV_IS_GC_BOOLEAN (node)) {
-		arv_debug_device ("[GvDevice::auto_packet_size] No GevSCPSFireTestPacket feature found, "
-				  "use default packet size (%d bytes)",
-				  packet_size);
-		return packet_size;
+		arv_debug_device ("[GvDevice::auto_packet_size] No GevSCPSFireTestPacket feature found");
+		return arv_device_get_integer_feature_value (device, "GevSCPSPacketSize", error);
 	}
 
 	inc = arv_device_get_integer_feature_increment (device, "GevSCPSPacketSize", NULL);
 	if (inc < 1)
 		inc = 1;
-	current_packet_size = arv_device_get_integer_feature_value (device, "GevSCPSPacketSize", NULL);
+	packet_size = arv_device_get_integer_feature_value (device, "GevSCPSPacketSize", NULL);
 	arv_device_get_integer_feature_bounds (device, "GevSCPSPacketSize", &minimum, &maximum, NULL);
 	max_size = MIN (65536, maximum);
 	min_size = MAX (ARV_GVSP_PACKET_PROTOCOL_OVERHEAD, minimum);
 
 	if (max_size < min_size ||
 	    inc > max_size - min_size ||
-	    max_size < packet_size ||
-	    min_size > packet_size ||
 	    inc > 16) {
 		arv_warning_device ("[GvDevice::auto_packet_size] Invalid GevSCPSPacketSize properties");
-		return packet_size;
+		return arv_device_get_integer_feature_value (device, "GevSCPSPacketSize", error);
 	}
 
 	is_command = ARV_IS_GC_COMMAND (node);
@@ -640,18 +635,16 @@ auto_packet_size (ArvGvDevice *gv_device, gboolean exit_early, GError **error)
 
 	buffer = g_malloc (max_size);
 
-	success = test_packet_check (device, &poll_fd, socket, buffer, current_packet_size, is_command);
+	success = test_packet_check (device, &poll_fd, socket, buffer, packet_size, is_command);
 
 	/* When exit_early is set, the function only checks the current packet size is working.
 	 * If not, the full automatic packet size adjustement is run. */
 	if (success && exit_early) {
 		arv_debug_device ("[GvDevice::auto_packet_size] Current packet size check successfull "
 				  "(%" G_GINT64_FORMAT " bytes)",
-				  current_packet_size);
-
-		packet_size = current_packet_size;
+				  packet_size);
 	} else {
-		guint current_size = CLAMP (current_packet_size, min_size, max_size);
+		guint current_size = CLAMP (packet_size, min_size, max_size);
 
 		do {
 			current_size = ((current_size + inc - 1) / inc) * inc;
@@ -678,14 +671,16 @@ auto_packet_size (ArvGvDevice *gv_device, gboolean exit_early, GError **error)
 			}
 		} while ((max_size - min_size) > 16);
 
-		arv_debug_device ("[GvDevice::auto_packet_size] Packet size set to %d bytes", packet_size);
+		arv_device_set_integer_feature_value (device, "GevSCPSPacketSize", packet_size, error);
+
+		arv_debug_device ("[GvDevice::auto_packet_size] Packet size set to %" G_GINT64_FORMAT " bytes",
+				  packet_size);
 	}
 
 	g_clear_pointer (&buffer, g_free);
 	g_clear_object (&socket);
 
 	arv_device_set_boolean_feature_value (device, "GevSCPSDoNotFragment", do_not_fragment, NULL);
-	arv_device_set_integer_feature_value (device, "GevSCPSPacketSize", packet_size, NULL);
 
 	return packet_size;
 }
@@ -695,12 +690,10 @@ auto_packet_size (ArvGvDevice *gv_device, gboolean exit_early, GError **error)
  * @gv_device: a #ArvGvDevice
  * @error: a #GError placeholder, %NULL to ignore
  *
- * Automatically determine the biggest packet size that can be used data
- * streaming, and set GevSCPSPacketSize value accordingly. This function relies
- * on the GevSCPSFireTestPacket feature. If this feature is not available, the
- * packet size will be set to a default value (1500 bytes).
+ * Automatically determine the biggest packet size that can be used data streaming, and set GevSCPSPacketSize value
+ * accordingly. This function relies on the GevSCPSFireTestPacket feature.
  *
- * Returns: The packet size, in bytes.
+ * Returns: The automatic packet size, in bytes, or the current one if GevSCPSFireTestPacket is not supported.
  *
  * Since: 0.6.0
  */

--- a/src/arvgvdevice.c
+++ b/src/arvgvdevice.c
@@ -49,7 +49,8 @@ enum
 {
 	PROP_0,
 	PROP_GV_DEVICE_INTERFACE_ADDRESS,
-	PROP_GV_DEVICE_DEVICE_ADDRESS
+	PROP_GV_DEVICE_DEVICE_ADDRESS,
+	PROP_GV_DEVICE_PACKET_SIZE_ADJUSTEMENT
 };
 
 typedef struct {
@@ -89,6 +90,7 @@ typedef struct {
 	gboolean is_write_memory_supported;
 
 	ArvGvStreamOption stream_options;
+	ArvGvPacketSizeAdjustement packet_size_adjustement;
 } ArvGvDevicePrivate ;
 
 struct _ArvGvDevice {
@@ -708,6 +710,27 @@ arv_gv_device_auto_packet_size (ArvGvDevice *gv_device, GError **error)
 }
 
 /**
+ * arv_gv_device_set_packet_size_adjustement:
+ * @gv_device: a #ArvGvDevice
+ * @adjustement: a #ArvGvPacketSizeAdjustement option
+ *
+ * Sets the option for the packet size adjustement happening at stream object creation. See
+ * arv_gv_device_auto_packet_size().
+ *
+ * Since: 0.8.3
+ */
+
+void
+arv_gv_device_set_packet_size_adjustement (ArvGvDevice *gv_device, ArvGvPacketSizeAdjustement adjustement)
+{
+	ArvGvDevicePrivate *priv = arv_gv_device_get_instance_private (gv_device);
+
+	g_return_if_fail (ARV_IS_GV_DEVICE (gv_device));
+
+	priv->packet_size_adjustement = adjustement;
+}
+
+/**
  * arv_gv_device_is_controller:
  * @gv_device: a #ArvGvDevice
  *
@@ -1131,10 +1154,13 @@ arv_gv_device_create_stream (ArvDevice *device, ArvStreamCallback callback, void
 		return NULL;
 	}
 
-	auto_packet_size (gv_device, TRUE, &local_error);
-	if (local_error != NULL) {
-		g_propagate_error (error, local_error);
-		return NULL;
+	if (priv->packet_size_adjustement != ARV_GV_PACKET_SIZE_ADJUSTEMENT_NEVER) {
+		auto_packet_size (gv_device, priv->packet_size_adjustement == ARV_GV_PACKET_SIZE_ADJUSTEMENT_ON_FAILURE,
+				  &local_error);
+		if (local_error != NULL) {
+			g_propagate_error (error, local_error);
+			return NULL;
+		}
 	}
 
 	stream = arv_gv_stream_new (gv_device, callback, user_data, error);
@@ -1454,8 +1480,26 @@ arv_gv_device_set_property (GObject *self, guint prop_id, const GValue *value, G
 			g_clear_object (&priv->device_address);
 			priv->device_address = g_value_dup_object (value);
 			break;
+		case PROP_GV_DEVICE_PACKET_SIZE_ADJUSTEMENT:
+			priv->packet_size_adjustement = g_value_get_enum (value);
+			break;
 		default:
 			G_OBJECT_WARN_INVALID_PROPERTY_ID (self, prop_id, pspec);
+			break;
+	}
+}
+
+static void
+arv_gv_device_get_property (GObject *object, guint prop_id, GValue *value, GParamSpec *pspec)
+{
+	ArvGvDevicePrivate *priv = arv_gv_device_get_instance_private (ARV_GV_DEVICE (object));
+
+	switch (prop_id) {
+		case PROP_GV_DEVICE_PACKET_SIZE_ADJUSTEMENT:
+			g_value_set_enum (value, priv->packet_size_adjustement);
+			break;
+		default:
+			G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
 			break;
 	}
 }
@@ -1469,6 +1513,7 @@ arv_gv_device_class_init (ArvGvDeviceClass *gv_device_class)
 	object_class->finalize = arv_gv_device_finalize;
 	object_class->constructed = arv_gv_device_constructed;
 	object_class->set_property = arv_gv_device_set_property;
+	object_class->get_property = arv_gv_device_get_property;
 
 	device_class->create_stream = arv_gv_device_create_stream;
 	device_class->get_genicam_xml = arv_gv_device_get_genicam_xml;
@@ -1494,4 +1539,10 @@ arv_gv_device_class_init (ArvGvDeviceClass *gv_device_class)
 				      "The device address",
 				      G_TYPE_INET_ADDRESS,
 				      G_PARAM_WRITABLE | G_PARAM_CONSTRUCT_ONLY));
+	g_object_class_install_property (object_class, PROP_GV_DEVICE_PACKET_SIZE_ADJUSTEMENT,
+					 g_param_spec_enum ("packet-size-adjustement", "Packet size adjustement",
+							    "Packet size adjustement option",
+							    ARV_TYPE_GV_PACKET_SIZE_ADJUSTEMENT,
+							    ARV_GV_PACKET_SIZE_ADJUSTEMENT_ON_FAILURE,
+							    G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
 }

--- a/src/arvgvdevice.h
+++ b/src/arvgvdevice.h
@@ -37,16 +37,20 @@ G_BEGIN_DECLS
 /**
  * ArvGvPacketSizeAdjustement:
  * @ARV_GV_PACKET_SIZE_ADJUSTEMENT_NEVER: never adjust packet size
+ * @ARV_GV_PACKET_SIZE_ADJUSTEMENT_ON_FAILURE_ONCE: adjust packet size if test packet check fails the with current
+ * packet size, only on the first stream creation
+ * @ARV_GV_PACKET_SIZE_ADJUSTEMENT_ON_FAILURE: adjust packet size if test packet check fails with current packet size
+ * @ARV_GV_PACKET_SIZE_ADJUSTEMENT_ONCE: adjust packet size on the first stream creation
  * @ARV_GV_PACKET_SIZE_ADJUSTEMENT_ALWAYS: always adjust the stream packet size
- * @ARV_GV_PACKET_SIZE_ADJUSTEMENT_ON_FAILURE: adjust packet size if test packet check fails with current packet
- * size
  */
 
 typedef enum
 {
 	ARV_GV_PACKET_SIZE_ADJUSTEMENT_NEVER,
-	ARV_GV_PACKET_SIZE_ADJUSTEMENT_ALWAYS,
-	ARV_GV_PACKET_SIZE_ADJUSTEMENT_ON_FAILURE
+	ARV_GV_PACKET_SIZE_ADJUSTEMENT_ON_FAILURE_ONCE,
+	ARV_GV_PACKET_SIZE_ADJUSTEMENT_ON_FAILURE,
+	ARV_GV_PACKET_SIZE_ADJUSTEMENT_ONCE,
+	ARV_GV_PACKET_SIZE_ADJUSTEMENT_ALWAYS
 } ArvGvPacketSizeAdjustement;
 
 #define ARV_TYPE_GV_DEVICE             (arv_gv_device_get_type ())

--- a/src/arvgvdevice.h
+++ b/src/arvgvdevice.h
@@ -34,6 +34,21 @@
 
 G_BEGIN_DECLS
 
+/**
+ * ArvGvPacketSizeAdjustement:
+ * @ARV_GV_PACKET_SIZE_ADJUSTEMENT_NEVER: never adjust packet size
+ * @ARV_GV_PACKET_SIZE_ADJUSTEMENT_ALWAYS: always adjust the stream packet size
+ * @ARV_GV_PACKET_SIZE_ADJUSTEMENT_ON_FAILURE: adjust packet size if test packet check fails with current packet
+ * size
+ */
+
+typedef enum
+{
+	ARV_GV_PACKET_SIZE_ADJUSTEMENT_NEVER,
+	ARV_GV_PACKET_SIZE_ADJUSTEMENT_ALWAYS,
+	ARV_GV_PACKET_SIZE_ADJUSTEMENT_ON_FAILURE
+} ArvGvPacketSizeAdjustement;
+
 #define ARV_TYPE_GV_DEVICE             (arv_gv_device_get_type ())
 G_DECLARE_FINAL_TYPE (ArvGvDevice, arv_gv_device, ARV, GV_DEVICE, ArvDevice)
 
@@ -50,6 +65,8 @@ GSocketAddress *	arv_gv_device_get_device_address  		(ArvGvDevice *device);
 
 guint			arv_gv_device_get_packet_size 			(ArvGvDevice *gv_device, GError **error);
 void			arv_gv_device_set_packet_size 			(ArvGvDevice *gv_device, gint packet_size, GError **error);
+void 			arv_gv_device_set_packet_size_adjustement 	(ArvGvDevice *gv_device,
+									 ArvGvPacketSizeAdjustement adjustement);
 guint			arv_gv_device_auto_packet_size 			(ArvGvDevice *gv_device, GError **error);
 
 ArvGvStreamOption	arv_gv_device_get_stream_options		(ArvGvDevice *gv_device);

--- a/tests/arvcameratest.c
+++ b/tests/arvcameratest.c
@@ -83,7 +83,8 @@ static const GOptionEntry arv_option_entries[] =
 	},
 	{
 		"packet-size-adjustement",		'j', 0, G_OPTION_ARG_STRING,
-		&arv_option_packet_size_adjustement,	"Packet size adjustement",  "{never|always|on-failure}"
+		&arv_option_packet_size_adjustement,	"Packet size adjustement",
+		"{never|always|once|on-failure|on-failure-once}"
 	},
 	{
 		"no-packet-resend",			'r', 0, G_OPTION_ARG_NONE,
@@ -341,12 +342,18 @@ main (int argc, char **argv)
 			arv_camera_uv_set_bandwidth (camera, arv_option_bandwidth_limit, NULL);
 		}
 
-		adjustement = ARV_GV_PACKET_SIZE_ADJUSTEMENT_ON_FAILURE;
+		adjustement = ARV_GV_PACKET_SIZE_ADJUSTEMENT_ON_FAILURE_ONCE;
 		if (arv_option_packet_size_adjustement != NULL) {
 			if (g_ascii_strcasecmp (arv_option_packet_size_adjustement, "always") == 0)
 				adjustement = ARV_GV_PACKET_SIZE_ADJUSTEMENT_ALWAYS;
 			else if (g_ascii_strcasecmp (arv_option_packet_size_adjustement, "never") == 0)
 				adjustement = ARV_GV_PACKET_SIZE_ADJUSTEMENT_NEVER;
+			else if (g_ascii_strcasecmp (arv_option_packet_size_adjustement, "once") == 0)
+				adjustement = ARV_GV_PACKET_SIZE_ADJUSTEMENT_ONCE;
+			else if (g_ascii_strcasecmp (arv_option_packet_size_adjustement, "on-failure") == 0)
+				adjustement = ARV_GV_PACKET_SIZE_ADJUSTEMENT_ON_FAILURE;
+			else if (g_ascii_strcasecmp (arv_option_packet_size_adjustement, "on-failure-once") == 0)
+				adjustement = ARV_GV_PACKET_SIZE_ADJUSTEMENT_ON_FAILURE_ONCE;
 		}
 
 		if (arv_camera_is_gv_device (camera)) {

--- a/tests/arvcameratest.c
+++ b/tests/arvcameratest.c
@@ -359,13 +359,6 @@ main (int argc, char **argv)
 		printf ("exposure              = %g µs\n", exposure);
 		printf ("gain                  = %d dB\n", gain);
 
-		if (arv_camera_is_gv_device (camera)) {
-			printf ("gv n_stream channels  = %d\n", arv_camera_gv_get_n_stream_channels (camera, NULL));
-			printf ("gv current channel    = %d\n", arv_camera_gv_get_current_stream_channel (camera, NULL));
-			g_print ("gv packet delay       = %" G_GINT64_FORMAT " ns\n", arv_camera_gv_get_packet_delay (camera, NULL));
-			printf ("gv packet size        = %d bytes\n", arv_camera_gv_get_packet_size (camera, NULL));
-		}
-
 		if (arv_camera_is_uv_device (camera)) {
 			guint min,max;
 
@@ -374,6 +367,16 @@ main (int argc, char **argv)
 		}
 
 		stream = arv_camera_create_stream (camera, stream_cb, NULL, &error);
+
+		if (arv_camera_is_gv_device (camera)) {
+			printf ("gv n_stream channels  = %d\n", arv_camera_gv_get_n_stream_channels (camera, NULL));
+			printf ("gv current channel    = %d\n",
+				arv_camera_gv_get_current_stream_channel (camera, NULL));
+			g_print ("gv packet delay       = %" G_GINT64_FORMAT " ns\n",
+				 arv_camera_gv_get_packet_delay (camera, NULL));
+			printf ("gv packet size        = %d bytes\n", arv_camera_gv_get_packet_size (camera, NULL));
+		}
+
 		if (ARV_IS_STREAM (stream)) {
 			if (ARV_IS_GV_STREAM (stream)) {
 				if (arv_option_auto_socket_buffer)

--- a/tests/arvcameratest.c
+++ b/tests/arvcameratest.c
@@ -342,7 +342,6 @@ main (int argc, char **argv)
 			arv_camera_uv_set_bandwidth (camera, arv_option_bandwidth_limit, NULL);
 		}
 
-		adjustement = ARV_GV_PACKET_SIZE_ADJUSTEMENT_ON_FAILURE_ONCE;
 		if (arv_option_packet_size_adjustement != NULL) {
 			if (g_ascii_strcasecmp (arv_option_packet_size_adjustement, "always") == 0)
 				adjustement = ARV_GV_PACKET_SIZE_ADJUSTEMENT_ALWAYS;
@@ -363,7 +362,8 @@ main (int argc, char **argv)
 			arv_camera_gv_set_stream_options (camera, arv_option_no_packet_socket ?
 							  ARV_GV_STREAM_OPTION_PACKET_SOCKET_DISABLED :
 							  ARV_GV_STREAM_OPTION_NONE);
-			arv_camera_gv_set_packet_size_adjustement (camera, adjustement);
+			if (arv_option_packet_size_adjustement != NULL)
+				arv_camera_gv_set_packet_size_adjustement (camera, adjustement);
 		}
 
 		arv_camera_get_region (camera, &x, &y, &width, &height, NULL);


### PR DESCRIPTION
Some camera defaults packet size to a non standard value, which may not pass the network link. Check the packet size and adjust it if needed.