### PR TITLE
gvdevice: Add support for URLs with SchemaVersion.

### DIFF
--- a/src/arvgvdevice.c
+++ b/src/arvgvdevice.c
@@ -715,7 +715,7 @@ _load_genicam (ArvGvDevice *gv_device, guint32 address, size_t  *size)
 	tokens = g_regex_split (arv_gv_device_get_url_regex (), filename, 0);
 
 	if (tokens[0] != NULL) {
-		if (g_ascii_strcasecmp (tokens[0], "file") == 0) {
+		if ((tokens[1] != NULL) && (g_ascii_strcasecmp (tokens[0], "file") == 0)) {
 			gsize len;
 			g_file_get_contents (tokens[1], &genicam, &len, NULL);
 			if (genicam)

--- a/tests/genicam.c
+++ b/tests/genicam.c
@@ -777,6 +777,26 @@ url_test (void)
 	g_assert_cmpstr (tokens[4], ==, "SchemaVersion=1.1.0");
 
 	g_strfreev (tokens);
+
+	tokens = g_regex_split (arv_gv_device_get_url_regex(), "file:///C|program%20files/aravis/genicam.xml?SchemaVersion=1.0.0", 0);
+
+	g_assert_cmpint (g_strv_length (tokens), ==, 3);
+
+	g_assert_cmpstr (tokens[0], ==, "file");
+	g_assert_cmpstr (tokens[1], ==, "///C|program%20files/aravis/genicam.xml");
+	g_assert_cmpstr (tokens[2], ==, "SchemaVersion=1.0.0");
+
+	g_strfreev (tokens);
+
+	tokens = g_regex_split (arv_gv_device_get_url_regex(), "http://github.com/AravisProject/aravis/tree/master/tests/data/genicam.xml", 0);
+
+	g_assert_cmpint (g_strv_length (tokens), ==, 2);
+
+	g_assert_cmpstr (tokens[0], ==, "http");
+	g_assert_cmpstr (tokens[1], ==, "//github.com/AravisProject/aravis/tree/master/tests/data/genicam.xml");
+
+	g_strfreev (tokens);
+
 }
 
 static void

--- a/tests/genicam.c
+++ b/tests/genicam.c
@@ -745,28 +745,37 @@ url_test (void)
 
 	tokens = g_regex_split (arv_gv_device_get_url_regex (), "Local:Basler_Ace_GigE_e7c9b87e_Version_3_3.zip;c0000000;10cca", 0);
 
-	g_assert_cmpint (g_strv_length (tokens), ==, 6);
+	g_assert_cmpint (g_strv_length (tokens), ==, 4);
 
-	g_assert_cmpstr (tokens[0], ==, "");
-	g_assert_cmpstr (tokens[1], ==, "Local:");
-	g_assert_cmpstr (tokens[2], ==, "Basler_Ace_GigE_e7c9b87e_Version_3_3.zip");
-	g_assert_cmpstr (tokens[3], ==, "c0000000");
-	g_assert_cmpstr (tokens[4], ==, "10cca");
+	g_assert_cmpstr (tokens[0], ==, "Local");
+	g_assert_cmpstr (tokens[1], ==, "Basler_Ace_GigE_e7c9b87e_Version_3_3.zip");
+	g_assert_cmpuint (strtoul(tokens[2], NULL, 16), ==, 0xC0000000);
+	g_assert_cmpuint (strtoul(tokens[3], NULL, 16), ==, 0x10CCA);
 
 	g_strfreev (tokens);
 
 	tokens = g_regex_split (arv_gv_device_get_url_regex (), "Local:C4_2040_GigE_1.0.0.zip;0x8C400904;0x4D30", 0);
 
-	g_assert_cmpint (g_strv_length (tokens), ==, 6);
+	g_assert_cmpint (g_strv_length (tokens), ==, 4);
 
-	g_assert_cmpstr (tokens[0], ==, "");
-	g_assert_cmpstr (tokens[1], ==, "Local:");
-	g_assert_cmpstr (tokens[2], ==, "C4_2040_GigE_1.0.0.zip");
-	g_assert_cmpstr (tokens[3], ==, "8C400904");
-	g_assert_cmpstr (tokens[4], ==, "4D30");
+	g_assert_cmpstr (tokens[0], ==, "Local");
+	g_assert_cmpstr (tokens[1], ==, "C4_2040_GigE_1.0.0.zip");
+	g_assert_cmpuint (strtoul(tokens[2], NULL, 16), ==, 0x8C400904);
+	g_assert_cmpuint (strtoul(tokens[3], NULL, 16), ==, 0x4D30);
 
 	g_strfreev (tokens);
 
+	tokens = g_regex_split (arv_gv_device_get_url_regex (), "Local:Mikrotron_GmbH_MC206xS11_Rev0_00_007.zip;8001000;395C?SchemaVersion=1.1.0", 0);
+
+	g_assert_cmpint (g_strv_length (tokens), ==, 5);
+
+	g_assert_cmpstr (tokens[0], ==, "Local");
+	g_assert_cmpstr (tokens[1], ==, "Mikrotron_GmbH_MC206xS11_Rev0_00_007.zip");
+	g_assert_cmpuint (strtoul(tokens[2], NULL, 16), ==, 0x8001000);
+	g_assert_cmpuint (strtoul(tokens[3], NULL, 16), ==, 0x395C);
+	g_assert_cmpstr (tokens[4], ==, "SchemaVersion=1.1.0");
+
+	g_strfreev (tokens);
 }
 
 static void

--- a/tests/genicam.c
+++ b/tests/genicam.c
@@ -1,6 +1,7 @@
 #include <glib.h>
 #include <arv.h>
 #include <string.h>
+#include <stdlib.h>
 
 #define ARAVIS_COMPILATION
 #include "../src/arvbufferprivate.h"


### PR DESCRIPTION
Fixes bug #429 by simplifying the parsing process. I also changed the tests to reflect the changed output from the URL parser. I'm not sure this is the correct fix, but it works for me with the Mikrotron camera referenced and an Allied Vision camera.