### PR TITLE
mingw: replace M_PI and M_E with G_PI and G_E

### DIFF
--- a/src/arvevaluator.c
+++ b/src/arvevaluator.c
@@ -1486,8 +1486,8 @@ arv_evaluator_init (ArvEvaluator *evaluator)
 	evaluator->priv->sub_expressions = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_free);
 	evaluator->priv->constants = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_free);
 
-	arv_evaluator_set_double_variable (evaluator, "PI", M_PI);
-	arv_evaluator_set_double_variable (evaluator, "E", M_E);
+	arv_evaluator_set_double_variable (evaluator, "PI", G_PI);
+	arv_evaluator_set_double_variable (evaluator, "E", G_E);
 }
 
 static void


### PR DESCRIPTION
Constants M_PI and M_E are not defined in standard C. This will result compilation errors under MinGW (x86_64-w64-mingw32-gcc, version 10.2.0). Fortunately glib defines G_PI and G_E so use those instead.