### PR TITLE
Fix arv_camera_set_trigger for Basler

### DIFF
--- a/src/arvcamera.c
+++ b/src/arvcamera.c
@@ -1201,7 +1201,7 @@ arv_camera_set_trigger (ArvCamera *camera, const char *source, GError **error)
 	g_return_if_fail (source != NULL);
 
 	if (priv->vendor == ARV_CAMERA_VENDOR_BASLER)
-		arv_camera_set_integer (camera, "AcquisitionFrameRateEnable", 0, &local_error);
+		arv_camera_set_boolean (camera, "AcquisitionFrameRateEnable", FALSE, &local_error);
 
 	if (local_error == NULL)
 		arv_camera_set_string (camera, "TriggerSelector", "AcquisitionStart", &local_error);


### PR DESCRIPTION
AcquisitionFrameRateEnable is boolean node rather than integer

See: https://docs.baslerweb.com/acquisition-frame-rate
In fact everywhere else in the code the AcquisitionFrameRateEnable is used by means of the integer node.

To be honest I do not understand why the arv_camera_set_trigger disables AcquisitionFrameRateEnable only for Basler cameras but nevertheless without this fix the function fails anyway.