### PR TITLE
retrieve timeouts, missing frames/packets and resend limits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ addons:
     update: true
 
 before_install:
-  - sudo pip3 install --upgrade setuptools pip
+  - sudo pip3 install --upgrade setuptools pip==20.3.4
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then sudo pip3 install ninja ; fi
   - sudo pip3 install 'meson==0.47'
 

--- a/src/arvgvstream.c
+++ b/src/arvgvstream.c
@@ -1261,11 +1261,10 @@ _get_detailed_statistics(ArvStream *stream,
 	thread_data = priv->thread_data;
 
 	*n_timeouts = thread_data->n_timeouts;
-        *n_missing_frames = thread_data->n_missing_frames;
+    *n_missing_frames = thread_data->n_missing_frames;
 	*n_resent_packets = thread_data->n_resent_packets;
 	*n_missing_packets = thread_data->n_missing_packets;
-        *n_resend_ratio_reached = thread_data->n_resend_ratio_reached;
-        printf("calling _get_detailed_statistics");
+    *n_resend_ratio_reached = thread_data->n_resend_ratio_reached;
 }
 
 
@@ -1420,7 +1419,7 @@ arv_gv_stream_class_init (ArvGvStreamClass *gv_stream_class)
 	stream_class->start_thread = arv_gv_stream_start_thread;
 	stream_class->stop_thread = arv_gv_stream_stop_thread;
 	stream_class->get_statistics = _get_statistics;
-        stream_class->get_detailed_statistics = _get_detailed_statistics;
+    stream_class->get_detailed_statistics = _get_detailed_statistics;
 
 	g_object_class_install_property (
 		object_class, ARV_GV_STREAM_PROPERTY_SOCKET_BUFFER,

--- a/src/arvgvstream.c
+++ b/src/arvgvstream.c
@@ -705,7 +705,7 @@ _process_packet (ArvGvStreamThreadData *thread_data, const ArvGvspPacket *packet
 
 			thread_data->n_error_packets++;
 		} else if (packet_id < frame->n_packets &&
-		           frame->packet_data[packet_id].received) {
+			   frame->packet_data[packet_id].received) {
 			/* Ignore duplicate packet */
 			thread_data->n_duplicated_packets++;
 			arv_log_stream_thread ("[GvStream::process_packet] Duplicated packet %d for frame %" G_GUINT64_FORMAT,
@@ -856,7 +856,7 @@ _interface_index_from_address (guint32 ip)
     unsigned index = 0;
 
     if (getifaddrs(&ifaddr) == -1) {
-        return index;
+	return index;
     }
 
     for (ifa = ifaddr; ifa != NULL; ifa = ifa->ifa_next) {
@@ -1247,13 +1247,13 @@ _get_statistics (ArvStream *stream,
 	*n_underruns = thread_data->n_underruns;
 }
 
-static void 
+static void
 _get_detailed_statistics(ArvStream *stream,
-                 guint64 *n_timeouts,
-                 guint64 *n_missing_frames,
-                 guint64 *n_resent_packets,
-                 guint64 *n_missing_packets,
-                 guint64 *n_resend_ratio_reached)
+		 guint64 *n_timeouts,
+		 guint64 *n_missing_frames,
+		 guint64 *n_resent_packets,
+		 guint64 *n_missing_packets,
+		 guint64 *n_resend_ratio_reached)
 {
 	ArvGvStreamPrivate *priv = arv_gv_stream_get_instance_private (ARV_GV_STREAM (stream));
 	ArvGvStreamThreadData *thread_data;
@@ -1261,10 +1261,10 @@ _get_detailed_statistics(ArvStream *stream,
 	thread_data = priv->thread_data;
 
 	*n_timeouts = thread_data->n_timeouts;
-    *n_missing_frames = thread_data->n_missing_frames;
+	*n_missing_frames = thread_data->n_missing_frames;
 	*n_resent_packets = thread_data->n_resent_packets;
 	*n_missing_packets = thread_data->n_missing_packets;
-    *n_resend_ratio_reached = thread_data->n_resend_ratio_reached;
+	*n_resend_ratio_reached = thread_data->n_resend_ratio_reached;
 }
 
 

--- a/src/arvgvstream.c
+++ b/src/arvgvstream.c
@@ -1247,6 +1247,28 @@ _get_statistics (ArvStream *stream,
 	*n_underruns = thread_data->n_underruns;
 }
 
+static void 
+_get_detailed_statistics(ArvStream *stream,
+                 guint64 *n_timeouts,
+                 guint64 *n_missing_frames,
+                 guint64 *n_resent_packets,
+                 guint64 *n_missing_packets,
+                 guint64 *n_resend_ratio_reached)
+{
+	ArvGvStreamPrivate *priv = arv_gv_stream_get_instance_private (ARV_GV_STREAM (stream));
+	ArvGvStreamThreadData *thread_data;
+
+	thread_data = priv->thread_data;
+
+	*n_timeouts = thread_data->n_timeouts;
+        *n_missing_frames = thread_data->n_missing_frames;
+	*n_resent_packets = thread_data->n_resent_packets;
+	*n_missing_packets = thread_data->n_missing_packets;
+        *n_resend_ratio_reached = thread_data->n_resend_ratio_reached;
+        printf("calling _get_detailed_statistics");
+}
+
+
 static void
 arv_gv_stream_set_property (GObject * object, guint prop_id,
 			    const GValue * value, GParamSpec * pspec)
@@ -1398,6 +1420,7 @@ arv_gv_stream_class_init (ArvGvStreamClass *gv_stream_class)
 	stream_class->start_thread = arv_gv_stream_start_thread;
 	stream_class->stop_thread = arv_gv_stream_stop_thread;
 	stream_class->get_statistics = _get_statistics;
+        stream_class->get_detailed_statistics = _get_detailed_statistics;
 
 	g_object_class_install_property (
 		object_class, ARV_GV_STREAM_PROPERTY_SOCKET_BUFFER,

--- a/src/arvstream.c
+++ b/src/arvstream.c
@@ -354,7 +354,60 @@ arv_stream_get_statistics (ArvStream *stream,
 
 	stream_class = ARV_STREAM_GET_CLASS (stream);
 	if (stream_class->get_statistics != NULL)
-		stream_class->get_statistics (stream, n_completed_buffers, n_failures, n_underruns);
+		stream_class->get_statistics (stream, n_completed_buffers, n_failures, n_underruns, n_resent_packets, n_missing_packets);
+}
+
+/**
+ * arv_stream_get_detailed_statistics:
+ * @stream: a #ArvStream
+ * @n_timeouts: (out) (allow-none): number of timeouts
+ * @n_missing_frames: (out) (allow-none): number of missing frames
+ * @n_resent_packets: (out) (allow-none): number of resent packets
+ * @n_missing_packets: (out) (allow-none): number of missing packets 
+ * @n_resend_ratio_reached: (out) (allow-none): number of resend ratio reached
+ *
+ * An accessor to the stream statistics.
+ *
+ * Since: 0.8.6
+ */
+
+void
+arv_stream_get_detailed_statistics (ArvStream *stream, 
+                                    guint64 *n_timeouts, 
+                                    guint64 *n_missing_frames,
+                                    guint64 *n_resent_packets, 
+                                    guint64 *n_missing_packets, 
+                                    guint64 *n_resend_ratio_reached)
+{
+	ArvStreamClass *stream_class;
+	guint64 dummy;
+
+	if (n_timeouts == NULL)
+		n_timeouts =  &dummy;
+
+	if (n_missing_frames == NULL)
+		n_missing_frames =  &dummy;
+
+	if (n_resent_packets == NULL)
+		n_resent_packets =  &dummy;
+
+	if (n_missing_packets == NULL)
+		n_missing_packets =  &dummy;
+
+	if (n_resend_ratio_reached == NULL)
+		n_resend_ratio_reached =  &dummy;
+
+	*n_timeouts = 0;
+	*n_missing_frames = 0;
+	*n_resent_packets = 0;
+        *n_missing_packets = 0;
+        *n_resend_ratio_reached = 0;
+
+	g_return_if_fail (ARV_IS_STREAM (stream));
+
+	stream_class = ARV_STREAM_GET_CLASS (stream);
+	if (stream_class->get_detailed_statistics != NULL)
+		stream_class->get_detailed_statistics (stream, n_timeouts, n_missing_frames, n_resent_packets, n_missing_packets, n_resend_ratio_reached);
 }
 
 /**

--- a/src/arvstream.c
+++ b/src/arvstream.c
@@ -400,8 +400,8 @@ arv_stream_get_detailed_statistics (ArvStream *stream,
 	*n_timeouts = 0;
 	*n_missing_frames = 0;
 	*n_resent_packets = 0;
-        *n_missing_packets = 0;
-        *n_resend_ratio_reached = 0;
+    *n_missing_packets = 0;
+    *n_resend_ratio_reached = 0;
 
 	g_return_if_fail (ARV_IS_STREAM (stream));
 

--- a/src/arvstream.c
+++ b/src/arvstream.c
@@ -363,7 +363,7 @@ arv_stream_get_statistics (ArvStream *stream,
  * @n_timeouts: (out) (allow-none): number of timeouts
  * @n_missing_frames: (out) (allow-none): number of missing frames
  * @n_resent_packets: (out) (allow-none): number of resent packets
- * @n_missing_packets: (out) (allow-none): number of missing packets 
+ * @n_missing_packets: (out) (allow-none): number of missing packets
  * @n_resend_ratio_reached: (out) (allow-none): number of resend ratio reached
  *
  * An accessor to the stream statistics.
@@ -372,12 +372,12 @@ arv_stream_get_statistics (ArvStream *stream,
  */
 
 void
-arv_stream_get_detailed_statistics (ArvStream *stream, 
-                                    guint64 *n_timeouts, 
-                                    guint64 *n_missing_frames,
-                                    guint64 *n_resent_packets, 
-                                    guint64 *n_missing_packets, 
-                                    guint64 *n_resend_ratio_reached)
+arv_stream_get_detailed_statistics (ArvStream *stream,
+				    guint64 *n_timeouts,
+				    guint64 *n_missing_frames,
+				    guint64 *n_resent_packets,
+				    guint64 *n_missing_packets,
+				    guint64 *n_resend_ratio_reached)
 {
 	ArvStreamClass *stream_class;
 	guint64 dummy;
@@ -400,8 +400,8 @@ arv_stream_get_detailed_statistics (ArvStream *stream,
 	*n_timeouts = 0;
 	*n_missing_frames = 0;
 	*n_resent_packets = 0;
-    *n_missing_packets = 0;
-    *n_resend_ratio_reached = 0;
+	*n_missing_packets = 0;
+	*n_resend_ratio_reached = 0;
 
 	g_return_if_fail (ARV_IS_STREAM (stream));
 
@@ -676,4 +676,3 @@ arv_stream_initable_iface_init (GInitableIface *iface)
 {
 	iface->init = arv_stream_initable_init;
 }
-

--- a/src/arvstream.c
+++ b/src/arvstream.c
@@ -354,7 +354,7 @@ arv_stream_get_statistics (ArvStream *stream,
 
 	stream_class = ARV_STREAM_GET_CLASS (stream);
 	if (stream_class->get_statistics != NULL)
-		stream_class->get_statistics (stream, n_completed_buffers, n_failures, n_underruns, n_resent_packets, n_missing_packets);
+		stream_class->get_statistics (stream, n_completed_buffers, n_failures, n_underruns);
 }
 
 /**

--- a/src/arvstream.h
+++ b/src/arvstream.h
@@ -59,6 +59,9 @@ struct _ArvStreamClass {
 	void		(*get_statistics)	(ArvStream *stream, guint64 *n_completed_buffers,
 						 guint64 *n_failures, guint64 *n_underruns);
 
+	void            (*get_detailed_statistics) (ArvStream *stream, guint64 *n_timeouts, guint64 *n_missing_frames,
+                                                    guint64 *n_resent_packets, guint64 *n_missing_packets, 
+                                                    guint64 *n_resend_ratio_reached);
 	/* signals */
 	void        	(*new_buffer)   	(ArvStream *stream);
 };
@@ -78,7 +81,16 @@ unsigned int	arv_stream_stop_thread			(ArvStream *stream, gboolean delete_buffer
 void		arv_stream_get_statistics		(ArvStream *stream,
 							 guint64 *n_completed_buffers,
 							 guint64 *n_failures,
-							 guint64 *n_underruns);
+							 guint64 *n_underruns,
+                                                         guint64 *n_resent_packets,
+                                                         guint64 *n_missing_packets);
+
+void            arv_stream_get_detailed_statistics      (ArvStream *stream, 
+                                                         guint64 *n_timeouts, 
+                                                         guint64 *n_missing_frames,
+                                                         guint64 *n_resent_packets, 
+                                                         guint64 *n_missing_packets, 
+                                                    	 guint64 *n_resend_ratio_reached);
 
 void 		arv_stream_set_emit_signals 		(ArvStream *stream, gboolean emit_signals);
 gboolean 	arv_stream_get_emit_signals 		(ArvStream *stream);

--- a/src/arvstream.h
+++ b/src/arvstream.h
@@ -81,9 +81,7 @@ unsigned int	arv_stream_stop_thread			(ArvStream *stream, gboolean delete_buffer
 void		arv_stream_get_statistics		(ArvStream *stream,
 							 guint64 *n_completed_buffers,
 							 guint64 *n_failures,
-							 guint64 *n_underruns,
-                                                         guint64 *n_resent_packets,
-                                                         guint64 *n_missing_packets);
+							 guint64 *n_underruns);
 
 void            arv_stream_get_detailed_statistics      (ArvStream *stream, 
                                                          guint64 *n_timeouts, 


### PR DESCRIPTION
I'd like more detailed stats to be available via the python interface. 
Please let me know if these changes are acceptable or whether the current get_statistics API should be modified to include additional stats. I didn't want to break older code hence the introduction of a new API.