### PR TITLE
Fixing bounds for clamping of exposure mode

### DIFF
--- a/src/arvenums.c
+++ b/src/arvenums.c
@@ -85,7 +85,7 @@ static const char *arv_exposure_mode_strings[] = {
 const char *
 arv_exposure_mode_to_string (ArvExposureMode value)
 {
-	return arv_exposure_mode_strings[CLAMP (value, 0, ARV_EXPOSURE_MODE_OFF)];
+	return arv_exposure_mode_strings[CLAMP (value, ARV_EXPOSURE_MODE_OFF, ARV_EXPOSURE_MODE_TRIGGER_CONTROLLED)];
 }
 
 ArvExposureMode


### PR DESCRIPTION
The clamping for the strings on the exposure mode had a wrong range, it always clamped to 0 (==Off). 
Single-line fix.
