### PR TITLE
fakecamera: allow to specify listening interface by address

### DIFF
--- a/.github/workflows/aravis-ci.yml
+++ b/.github/workflows/aravis-ci.yml
@@ -53,7 +53,7 @@ jobs:
       env:
         CC: gcc
     - name: Tests
-      run: meson test -C build/ -v --no-suite="network"
+      run: meson test -C build/ -v
     - uses: actions/upload-artifact@v2
       if: failure()
       with:

--- a/.github/workflows/aravis-mingw.yml
+++ b/.github/workflows/aravis-mingw.yml
@@ -56,4 +56,4 @@ jobs:
         ninja -C ./build --verbose install
     - name: meson test
       run: |
-        meson test -C ./build --no-suite="network"
+        meson test -C ./build

--- a/src/arvfakegvcamera.c
+++ b/src/arvfakegvcamera.c
@@ -42,7 +42,7 @@ static char *arv_option_debug_domains = NULL;
 static const GOptionEntry arv_option_entries[] =
 {
 	{ "interface",		'i', 0, G_OPTION_ARG_STRING,
-		&arv_option_interface_name,	"Listening interface name", "interface_id"},
+		&arv_option_interface_name,	"Listening interface name or address", "interface"},
 	{ "serial",             's', 0, G_OPTION_ARG_STRING,
 	        &arv_option_serial_number, 	"Fake camera serial number", "serial_nbr"},
 	{ "genicam",            'g', 0, G_OPTION_ARG_STRING,
@@ -66,6 +66,7 @@ description_content[] =
 "Examples:\n"
 "\n"
 "arv-fake-gv-camera-" ARAVIS_API_VERSION " -i eth0\n"
+"arv-fake-gv-camera-" ARAVIS_API_VERSION " -i 127.0.0.1\n"
 "arv-fake-gv-camera-" ARAVIS_API_VERSION " -s GV02 -d all\n";
 
 int

--- a/src/arvgvfakecamera.h
+++ b/src/arvgvfakecamera.h
@@ -32,7 +32,7 @@
 G_BEGIN_DECLS
 
 #define ARV_GV_FAKE_CAMERA_DEFAULT_SERIAL_NUMBER	"GV01"
-#define ARV_GV_FAKE_CAMERA_DEFAULT_INTERFACE		"lo"
+#define ARV_GV_FAKE_CAMERA_DEFAULT_INTERFACE		"127.0.0.1"
 
 #define ARV_TYPE_GV_FAKE_CAMERA (arv_gv_fake_camera_get_type ())
 G_DECLARE_FINAL_TYPE (ArvGvFakeCamera, arv_gv_fake_camera, ARV, GV_FAKE_CAMERA, GObject)

--- a/src/arvnetwork.c
+++ b/src/arvnetwork.c
@@ -362,10 +362,14 @@ arv_enumerate_network_interfaces (void)
 			a->addr = arv_memdup (ifap_iter->ifa_addr, sizeof(struct sockaddr));
 			if (ifap_iter->ifa_netmask)
 				a->netmask = arv_memdup (ifap_iter->ifa_netmask, sizeof(struct sockaddr));
-#if !defined(__APPLE__)
+#if defined(__APPLE__) && defined(__MACH__)
+			if (ifap_iter->ifa_broadaddr)
+				a->broadaddr = arv_memdup(ifap_iter->ifa_broadaddr, sizeof(struct sockaddr));
+#else
 			if (ifap_iter->ifa_ifu.ifu_broadaddr)
 				a->broadaddr = arv_memdup(ifap_iter->ifa_ifu.ifu_broadaddr, sizeof(struct sockaddr));
 #endif
+
 			if (ifap_iter->ifa_name)
 				a->name = g_strdup(ifap_iter->ifa_name);
 

--- a/tests/fakegv.c
+++ b/tests/fakegv.c
@@ -228,10 +228,15 @@ main (int argc, char *argv[])
 
 	arv_set_fake_camera_genicam_filename (GENICAM_FILENAME);
 
-	simulator = arv_gv_fake_camera_new ("lo", "GVTest");
+	simulator = arv_gv_fake_camera_new ("127.0.0.1", "GVTest");
 	g_assert (ARV_IS_GV_FAKE_CAMERA (simulator));
 
+#if !defined(__APPLE__)
 	camera = arv_camera_new ("Aravis-GVTest", NULL);
+#else
+        /* Broadcast listening on 127.0.0.1 does not work on macOS, instantiate the camera by IP.*/
+	camera = arv_camera_new ("127.0.0.1", NULL);
+#endif
 	g_assert (ARV_IS_CAMERA (camera));
 
 	g_test_add_func ("/fakegv/device_registers", register_test);


### PR DESCRIPTION
And default to '127.0.0.1' instead of 'lo'.

Fixes #535