### PR TITLE
Add arv_network_get_interface_by_name, use it in fake camera

### DIFF
--- a/.github/workflows/aravis-mingw.yml
+++ b/.github/workflows/aravis-mingw.yml
@@ -56,4 +56,4 @@ jobs:
         ninja -C ./build --verbose install
     - name: meson test
       run: |
-        meson test -C ./build --no-suite="network"
+        meson test -C ./build

--- a/.github/workflows/aravis-mingw.yml
+++ b/.github/workflows/aravis-mingw.yml
@@ -54,6 +54,8 @@ jobs:
     - name: ninja install
       run: |
         ninja -C ./build --verbose install
+    - name: fakegv
+      run: ARV_DEBUG=all ./build/tests/fakegv
     - name: meson test
       run: |
         meson test -C ./build

--- a/.github/workflows/aravis-mingw.yml
+++ b/.github/workflows/aravis-mingw.yml
@@ -54,8 +54,6 @@ jobs:
     - name: ninja install
       run: |
         ninja -C ./build --verbose install
-    - name: fakegv
-      run: ARV_DEBUG=all ./build/tests/fakegv
     - name: meson test
       run: |
         meson test -C ./build

--- a/src/arvgvfakecamera.c
+++ b/src/arvgvfakecamera.c
@@ -487,14 +487,15 @@ arv_gv_fake_camera_start (ArvGvFakeCamera *gv_fake_camera)
 
 	g_return_val_if_fail (ARV_IS_GV_FAKE_CAMERA (gv_fake_camera), FALSE);
 
-	iface = arv_network_get_interface_by_name(gv_fake_camera->priv->interface_name);
+	iface = arv_network_get_interface_by_address(gv_fake_camera->priv->interface_name);
+	if (iface == NULL) iface = arv_network_get_interface_by_name(gv_fake_camera->priv->interface_name);
 	#ifdef G_OS_WIN32
 		// fake "lo" interface in windows
 		if(iface == NULL && g_strcmp0 (gv_fake_camera->priv->interface_name,"lo") == 0)
 			iface = arv_network_get_fake_ipv4_loopback();
 	#endif
 	if (iface == NULL) {
-		arv_warning_device ("[GvFakeCamera::start] No network interface named '%s' found.",gv_fake_camera->priv->interface_name);
+		arv_warning_device ("[GvFakeCamera::start] No network interface with address or name '%s' found.",gv_fake_camera->priv->interface_name);
 		return FALSE;
 	}
 

--- a/src/arvgvfakecamera.c
+++ b/src/arvgvfakecamera.c
@@ -499,8 +499,6 @@ arv_gv_fake_camera_start (ArvGvFakeCamera *gv_fake_camera)
 		return FALSE;
 	}
 
-	g_critical("okay, the interface is %s",arv_network_interface_get_name(iface));
-
 	socket_address = g_socket_address_new_from_native (arv_network_interface_get_addr(iface),
 								sizeof (struct sockaddr));
 	gvcp_inet_address = g_object_ref (g_inet_socket_address_get_address (G_INET_SOCKET_ADDRESS (socket_address)));

--- a/src/arvgvfakecamera.c
+++ b/src/arvgvfakecamera.c
@@ -490,8 +490,8 @@ arv_gv_fake_camera_start (ArvGvFakeCamera *gv_fake_camera)
 	iface = arv_network_get_interface_by_address(gv_fake_camera->priv->interface_name);
 	if (iface == NULL) iface = arv_network_get_interface_by_name(gv_fake_camera->priv->interface_name);
 	#ifdef G_OS_WIN32
-		// fake "lo" interface in windows
-		if(iface == NULL && g_strcmp0 (gv_fake_camera->priv->interface_name,"lo") == 0)
+		// fake the default loopback interface in windows, in case not found
+		if(iface == NULL && g_strcmp0 (gv_fake_camera->priv->interface_name,ARV_GV_FAKE_CAMERA_DEFAULT_INTERFACE) == 0)
 			iface = arv_network_get_fake_ipv4_loopback();
 	#endif
 	if (iface == NULL) {

--- a/src/arvgvfakecamera.c
+++ b/src/arvgvfakecamera.c
@@ -488,6 +488,11 @@ arv_gv_fake_camera_start (ArvGvFakeCamera *gv_fake_camera)
 	g_return_val_if_fail (ARV_IS_GV_FAKE_CAMERA (gv_fake_camera), FALSE);
 
 	iface = arv_network_get_interface_by_name(gv_fake_camera->priv->interface_name);
+	#ifdef G_OS_WIN32
+		// fake "lo" interface in windows
+		if(iface == NULL && g_strcmp0 (gv_fake_camera->priv->interface_name,"lo") == 0)
+			iface = arv_network_get_fake_ipv4_loopback();
+	#endif
 	if (iface == NULL) {
 		arv_warning_device ("[GvFakeCamera::start] No network interface named '%s' found.",gv_fake_camera->priv->interface_name);
 		return FALSE;

--- a/src/arvgvfakecamera.c
+++ b/src/arvgvfakecamera.c
@@ -478,82 +478,75 @@ _create_and_bind_input_socket (GSocket **socket_out, const char *socket_name,
 static gboolean
 arv_gv_fake_camera_start (ArvGvFakeCamera *gv_fake_camera)
 {
-	GList *ifaces;
-	GList *iface_iter;
-	gboolean interface_found = FALSE;
 	gboolean success = TRUE;
+	ArvNetworkInterface *iface;
+	GSocketAddress *socket_address;
+	GInetAddress *inet_address;
+	GInetAddress *gvcp_inet_address;
+	unsigned int n_socket_fds;
 
 	g_return_val_if_fail (ARV_IS_GV_FAKE_CAMERA (gv_fake_camera), FALSE);
 
-	ifaces = arv_enumerate_network_interfaces ();
-	if (!ifaces) {
-		arv_warning_device ("[GvFakeCamera::start] No network interface found");
+	iface = arv_network_get_interface_by_name(gv_fake_camera->priv->interface_name);
+	if (iface == NULL) {
+		arv_warning_device ("[GvFakeCamera::start] No network interface named '%s' found.",gv_fake_camera->priv->interface_name);
 		return FALSE;
 	}
 
-	for (iface_iter = ifaces; iface_iter != NULL && !interface_found; iface_iter = iface_iter->next) {
-		if (g_strcmp0 (gv_fake_camera->priv->interface_name,
-			       arv_network_interface_get_name (iface_iter->data)) == 0) {
-			GSocketAddress *socket_address;
-			GInetAddress *inet_address;
-			GInetAddress *gvcp_inet_address;
-			unsigned int n_socket_fds;
-			unsigned int i;
-			socket_address = g_socket_address_new_from_native (arv_network_interface_get_addr(iface_iter->data),
-									   sizeof (struct sockaddr));
-			gvcp_inet_address = g_object_ref (g_inet_socket_address_get_address (G_INET_SOCKET_ADDRESS (socket_address)));
-			g_clear_object (&socket_address);
-			arv_fake_camera_set_inet_address (gv_fake_camera->priv->camera, gvcp_inet_address);
 
-			success = success && _create_and_bind_input_socket (&gv_fake_camera->priv->gvsp_socket,
-									    "GVSP", gvcp_inet_address, 0, FALSE, TRUE);
-			success = success && _create_and_bind_input_socket
-				(&gv_fake_camera->priv->input_sockets[ARV_GV_FAKE_CAMERA_INPUT_SOCKET_GVCP],
-				 "GVCP", gvcp_inet_address, ARV_GVCP_PORT, FALSE, FALSE);
+	socket_address = g_socket_address_new_from_native (arv_network_interface_get_addr(iface),
+								sizeof (struct sockaddr));
+	gvcp_inet_address = g_object_ref (g_inet_socket_address_get_address (G_INET_SOCKET_ADDRESS (socket_address)));
+	g_clear_object (&socket_address);
+	arv_fake_camera_set_inet_address (gv_fake_camera->priv->camera, gvcp_inet_address);
 
-			inet_address = g_inet_address_new_from_string ("255.255.255.255");
-			if (!g_inet_address_equal (gvcp_inet_address, inet_address))
-				success = success && _create_and_bind_input_socket
-					(&gv_fake_camera->priv->input_sockets[ARV_GV_FAKE_CAMERA_INPUT_SOCKET_GLOBAL_DISCOVERY],
-					 "Global discovery", inet_address, ARV_GVCP_PORT, TRUE, FALSE);
-			g_clear_object (&inet_address);
-			socket_address = g_socket_address_new_from_native (arv_network_interface_get_broadaddr(iface_iter->data),
-									   sizeof (struct sockaddr));
-			inet_address = g_object_ref (g_inet_socket_address_get_address (G_INET_SOCKET_ADDRESS (socket_address)));
-			g_clear_object (&socket_address);
-			if (!g_inet_address_equal (gvcp_inet_address, inet_address))
-				success = success && _create_and_bind_input_socket
-					(&gv_fake_camera->priv->input_sockets[ARV_GV_FAKE_CAMERA_INPUT_SOCKET_SUBNET_DISCOVERY],
-					 "Subnet discovery", inet_address, ARV_GVCP_PORT, FALSE, FALSE);
-			g_clear_object (&inet_address);
+	success = success && _create_and_bind_input_socket (&gv_fake_camera->priv->gvsp_socket,
+								 "GVSP", gvcp_inet_address, 0, FALSE, TRUE);
+	success = success && _create_and_bind_input_socket
+		(&gv_fake_camera->priv->input_sockets[ARV_GV_FAKE_CAMERA_INPUT_SOCKET_GVCP],
+		 "GVCP", gvcp_inet_address, ARV_GVCP_PORT, FALSE, FALSE);
 
-			g_clear_object (&gvcp_inet_address);
+	inet_address = g_inet_address_new_from_string ("255.255.255.255");
+	if (!g_inet_address_equal (gvcp_inet_address, inet_address))
+		success = success && _create_and_bind_input_socket
+			(&gv_fake_camera->priv->input_sockets[ARV_GV_FAKE_CAMERA_INPUT_SOCKET_GLOBAL_DISCOVERY],
+			 "Global discovery", inet_address, ARV_GVCP_PORT, TRUE, FALSE);
+	g_clear_object (&inet_address);
+	socket_address = g_socket_address_new_from_native (arv_network_interface_get_broadaddr(iface),
+								sizeof (struct sockaddr));
+	inet_address = g_object_ref (g_inet_socket_address_get_address (G_INET_SOCKET_ADDRESS (socket_address)));
+	if (!g_inet_address_equal (gvcp_inet_address, inet_address))
+		success = success && _create_and_bind_input_socket
+			(&gv_fake_camera->priv->input_sockets[ARV_GV_FAKE_CAMERA_INPUT_SOCKET_SUBNET_DISCOVERY],
+			 "Subnet discovery", inet_address, ARV_GVCP_PORT, FALSE, FALSE);
 
-			n_socket_fds = 0;
-			if (success) {
-				for (i = 0; i < ARV_GV_FAKE_CAMERA_N_INPUT_SOCKETS; i++) {
-					GSocket *socket = gv_fake_camera->priv->input_sockets[i];
+	arv_network_interface_free(iface);
+	g_clear_object (&socket_address);
+	g_clear_object (&inet_address);
+	g_clear_object (&gvcp_inet_address);
 
-					if (G_IS_SOCKET (socket)) {
-						gv_fake_camera->priv->socket_fds[n_socket_fds].fd = g_socket_get_fd (socket);
-						gv_fake_camera->priv->socket_fds[n_socket_fds].events = G_IO_IN;
-						gv_fake_camera->priv->socket_fds[n_socket_fds].revents = 0;
+	n_socket_fds = 0;
+	if (success) {
+		unsigned int i;
 
-						n_socket_fds++;
-					}
-				}
+		for (i = 0; i < ARV_GV_FAKE_CAMERA_N_INPUT_SOCKETS; i++) {
+			GSocket *socket = gv_fake_camera->priv->input_sockets[i];
 
-				arv_info_device ("Listening to %d sockets", n_socket_fds);
+			if (G_IS_SOCKET (socket)) {
+				gv_fake_camera->priv->socket_fds[n_socket_fds].fd = g_socket_get_fd (socket);
+				gv_fake_camera->priv->socket_fds[n_socket_fds].events = G_IO_IN;
+				gv_fake_camera->priv->socket_fds[n_socket_fds].revents = 0;
+
+				n_socket_fds++;
 			}
-
-			gv_fake_camera->priv->n_socket_fds = n_socket_fds;
-
-			arv_gpollfd_prepare_all (gv_fake_camera->priv->socket_fds, n_socket_fds);
-
-			interface_found = TRUE;
 		}
+
+		arv_info_device ("Listening to %d sockets", n_socket_fds);
 	}
-	g_list_free_full (ifaces, (GDestroyNotify) arv_network_interface_free);
+
+	gv_fake_camera->priv->n_socket_fds = n_socket_fds;
+
+	arv_gpollfd_prepare_all (gv_fake_camera->priv->socket_fds, n_socket_fds);
 
 	if (!success) {
 		unsigned int i;
@@ -562,10 +555,6 @@ arv_gv_fake_camera_start (ArvGvFakeCamera *gv_fake_camera)
 			g_clear_object (&gv_fake_camera->priv->input_sockets[i]);
 		g_clear_object (&gv_fake_camera->priv->gvsp_socket);
 
-		return FALSE;
-	}
-
-	if (!interface_found) {
 		return FALSE;
 	}
 

--- a/src/arvnetwork.c
+++ b/src/arvnetwork.c
@@ -530,3 +530,19 @@ arv_network_get_fake_ipv4_loopback(void){
 	return ret;
 }
 
+gboolean arv_network_interface_is_loopback(ArvNetworkInterface *a){
+	if(!a) return FALSE;
+	if(a->addr->sa_family==AF_INET) return (ntohl(((struct sockaddr_in*)a->addr)->sin_addr.s_addr)>>24)==0x7f;
+	if(a->addr->sa_family==AF_INET6){
+		/* 16 unsigned chars in network byte order (big-endian),
+		loopback is ::1, i.e. zeros and 1 at the end */
+		unsigned char* i6=(unsigned char*)(&(((struct sockaddr_in6*)a->addr)->sin6_addr));
+		for(unsigned pos=0; pos<16; pos++){
+			if(i6[pos]!=0) return FALSE;
+		}
+		if(i6[16]!=1) return FALSE;
+		return TRUE;
+	}
+	return FALSE;
+}
+

--- a/src/arvnetwork.c
+++ b/src/arvnetwork.c
@@ -474,3 +474,20 @@ arv_network_get_interface_by_name (const char* name){
 
 	return ret;
 }
+
+ArvNetworkInterface*
+arv_network_get_fake_ipv4_loopback(void){
+	ArvNetworkInterface* ret = (ArvNetworkInterface*) g_malloc0(sizeof(ArvNetworkInterface));
+	ret->name = g_strdup("<fake IPv4 localhost>");
+	ret->addr = g_malloc0(sizeof(struct sockaddr_in));
+	ret->addr->sa_family = AF_INET;
+	((struct sockaddr_in*)ret->addr)->sin_addr.s_addr = htonl(0x7f000001); // INADDR_LOOPBACK
+	ret->netmask = g_malloc0(sizeof(struct sockaddr_in));
+	ret->netmask->sa_family = AF_INET;
+	((struct sockaddr_in*)ret->netmask)->sin_addr.s_addr = htonl(0xff000000);
+	ret->broadaddr = g_malloc0(sizeof(struct sockaddr_in));
+	ret->broadaddr->sa_family = AF_INET;
+	((struct sockaddr_in*)ret->broadaddr)->sin_addr.s_addr = htonl(0x7fffffff);
+	return ret;
+}
+

--- a/src/arvnetwork.c
+++ b/src/arvnetwork.c
@@ -449,3 +449,28 @@ arv_socket_set_recv_buffer_size (int socket_fd, gint buffer_size)
 	return result == 0;
 }
 
+
+ArvNetworkInterface*
+arv_network_get_interface_by_name (const char* name){
+	GList *ifaces;
+	GList *iface_iter;
+	ArvNetworkInterface *ret = NULL;
+
+	ifaces = arv_enumerate_network_interfaces ();
+
+	for (iface_iter = ifaces; iface_iter != NULL; iface_iter = iface_iter->next) {
+		if (g_strcmp0 (name, arv_network_interface_get_name (iface_iter->data)) == 0) 
+			break;
+	}
+
+	if(iface_iter != NULL){
+		/* remove the interface node from the list (deleted below) but don't delete its data */
+		ret = iface_iter->data;
+		ifaces = g_list_remove_link(ifaces, iface_iter);
+		g_list_free(iface_iter); 
+	}
+
+	g_list_free_full (ifaces, (GDestroyNotify) arv_network_interface_free);
+
+	return ret;
+}

--- a/src/arvnetworkprivate.h
+++ b/src/arvnetworkprivate.h
@@ -86,6 +86,7 @@ typedef struct _ArvNetworkInterface ArvNetworkInterface;
 
 GList *			arv_enumerate_network_interfaces	(void);
 ArvNetworkInterface* arv_network_get_interface_by_name (const char* name);
+ArvNetworkInterface* arv_network_get_fake_ipv4_loopback(void);
 
 void 			arv_network_interface_free		(ArvNetworkInterface *a);
 struct sockaddr *	arv_network_interface_get_addr		(ArvNetworkInterface *a);

--- a/src/arvnetworkprivate.h
+++ b/src/arvnetworkprivate.h
@@ -86,6 +86,7 @@ typedef struct _ArvNetworkInterface ArvNetworkInterface;
 
 GList *			arv_enumerate_network_interfaces	(void);
 ArvNetworkInterface* arv_network_get_interface_by_name (const char* name);
+ArvNetworkInterface* arv_network_get_interface_by_address (const char* addr);
 ArvNetworkInterface* arv_network_get_fake_ipv4_loopback(void);
 
 void 			arv_network_interface_free		(ArvNetworkInterface *a);

--- a/src/arvnetworkprivate.h
+++ b/src/arvnetworkprivate.h
@@ -94,6 +94,7 @@ struct sockaddr *	arv_network_interface_get_addr		(ArvNetworkInterface *a);
 struct sockaddr *	arv_network_interface_get_netmask	(ArvNetworkInterface *a);
 struct sockaddr *	arv_network_interface_get_broadaddr	(ArvNetworkInterface *a);
 const char *		arv_network_interface_get_name		(ArvNetworkInterface *a);
+gboolean          arv_network_interface_is_loopback   (ArvNetworkInterface *a);
 
 gboolean 		arv_socket_set_recv_buffer_size		(int socket_fd, gint buffer_size);
 

--- a/src/arvnetworkprivate.h
+++ b/src/arvnetworkprivate.h
@@ -85,6 +85,7 @@ struct iphdr
 typedef struct _ArvNetworkInterface ArvNetworkInterface;
 
 GList *			arv_enumerate_network_interfaces	(void);
+ArvNetworkInterface* arv_network_get_interface_by_name (const char* name);
 
 void 			arv_network_interface_free		(ArvNetworkInterface *a);
 struct sockaddr *	arv_network_interface_get_addr		(ArvNetworkInterface *a);

--- a/tests/arvnetworktest.c
+++ b/tests/arvnetworktest.c
@@ -12,12 +12,22 @@ int
 main (int argc, char **argv){
 	GList *ifaces;
 	GList *iface_iter;
+	ArvNetworkInterface* lo;
 
 	ifaces = arv_enumerate_network_interfaces ();
 	if (!ifaces) {
 		fprintf (stderr,"No network interfaces found (or enumeration failed).");
 		return 1;
 	}
+
+	lo=arv_network_get_interface_by_address("127.0.0.1");
+	if(lo) {
+		printf("(loopback 127.0.0.1 interface is '%s'.)\r\n",arv_network_interface_get_name(lo));
+		arv_network_interface_free(lo);
+	}
+	else
+		printf("(loopback 127.0.0.1 interface not found.)\r\n");
+
 	printf(_LINEFMT,"proto","address","mask","broadcast","interface");
 
 	for (iface_iter=ifaces; iface_iter!=NULL; iface_iter=iface_iter->next){


### PR DESCRIPTION
The intent is to make it eventually possible to use also IP address (rather than interface name) in fake camera, and this will make it easier. Perhaps such function would be also used elsewhere where interface is looked up by name, but I did not check much.