### PR TITLE
Add thread priorities for windows, add high-precision clock for windows

### DIFF
--- a/src/arvcameratest.c
+++ b/src/arvcameratest.c
@@ -398,6 +398,11 @@ main (int argc, char **argv)
 	arv_enable_interface ("Fake");
 
 	arv_debug_enable (arv_option_debug_domains);
+    
+    #ifdef G_OS_WIN32
+        setbuf(stderr,NULL);
+        setbuf(stdout,NULL);
+    #endif
 
 	if (arv_option_camera_name == NULL)
 		g_print ("Looking for the first available camera\n");

--- a/src/arvmisc.c
+++ b/src/arvmisc.c
@@ -27,6 +27,10 @@
 #include <stdio.h>
 #include <zlib.h>
 
+#ifdef G_OS_WIN32
+	 #include <windows.h>
+#endif
+
 typedef struct _ArvHistogramVariable ArvHistogramVariable;
 
 struct _ArvHistogramVariable {
@@ -920,3 +924,19 @@ arv_parse_genicam_url (const char *url, gssize url_length,
 
 	return TRUE;
 }
+
+
+gint64 arv_monotonic_time_us (void)
+{
+	 #ifdef G_OS_WIN32
+		  static LARGE_INTEGER freq = { .QuadPart = 0 };
+		  LARGE_INTEGER t;
+	 
+		  if (freq.QuadPart == 0) { QueryPerformanceFrequency(&freq); }
+		  QueryPerformanceCounter(&t);
+		  return (t.QuadPart*1000000) / freq.QuadPart;
+	 #else
+		  return g_get_monotonic_time();
+	 #endif
+}
+

--- a/src/arvmiscprivate.h
+++ b/src/arvmiscprivate.h
@@ -77,6 +77,9 @@ void * 		arv_decompress 			(void *input_buffer, size_t input_size, size_t *outpu
 
 const char *	arv_vendor_alias_lookup		(const char *vendor);
 
+/* this only wraps g_get_monotonic_time on non-windows platforms */
+gint64 arv_monotonic_time_us (void);
+
 #if GLIB_CHECK_VERSION(2,68,0)
 #define arv_memdup(p,s) g_memdup2(p,s)
 #else


### PR DESCRIPTION
1. Priorities are there, but I was never able to see them changed successfully.
2. The monotonic clock for windows should be more precise than libc functions, but I did not see much improvement in errors when I tested it back then. Aravis never calls that function, but it will be easier to do so if needed, plus the code does not get forgotten.
3. Disable buffering in arvcameratest.c for `stderr` and `stdout`; this might be just limitation of mingw (not sure) but in any case output would otherwise appear only when the program terminates.