### PR TITLE
tests: Compile 'realtimetest.c' only on Linux.

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -71,8 +71,8 @@ if get_option('tests')
 		['cpp-test',			'cpp.cc']
 	]
 
-	if host_machine.system()!='windows'
-		examples+=[['realtime-test','realtimetest.c']] # uses Linux RT API unavailable under mingw
+	if host_machine.system()=='linux'
+		examples+=[['realtime-test','realtimetest.c']] # uses Linux RT API unavailable on other platforms
 	endif
 
 	foreach example: examples


### PR DESCRIPTION
Current `realtimetest.c` uses private functions from `arvrealtimeprivate.h` that are Linux RealtimeKit specific. Therefore disable this test on other platforms.

Potentially another more high-level test could be written that uses public `arv_make_thread_realtime` and `arv_make_thread_high_priority` functions. That could be enabled on all platforms.