### PR TITLE
Fix setting of trigger for FrameStart

### DIFF
--- a/src/arvcamera.c
+++ b/src/arvcamera.c
@@ -1259,28 +1259,31 @@ arv_camera_set_trigger (ArvCamera *camera, const char *source, GError **error)
 
 	if (local_error == NULL &&
            arv_camera_is_enumeration_entry_available (camera, "TriggerSelector", "FrameStart", &local_error)) {
-                arv_camera_set_string (camera, "TriggerSelector", "FrameStart", &local_error);
-                if (local_error == NULL)
-                        arv_camera_set_string (camera, "TriggerMode", "On", &local_error);
-        } else {
-                has_frame_start = FALSE;
-        }
+		arv_camera_set_string (camera, "TriggerSelector", "FrameStart", &local_error);
+		if (local_error == NULL)
+			arv_camera_set_string (camera, "TriggerMode", "On", &local_error);
+	} else {
+		has_frame_start = FALSE;
+	}
 
 	if (local_error == NULL &&
            arv_camera_is_enumeration_entry_available (camera, "TriggerSelector", "AcquisitionStart", &local_error)) {
 		arv_camera_set_string (camera, "TriggerSelector", "AcquisitionStart", &local_error);
-                if (local_error == NULL)
-                        arv_camera_set_string (camera, "TriggerMode",
+		if (local_error == NULL)
+			arv_camera_set_string (camera, "TriggerMode",
 					       has_frame_start ? "Off" : "On", &local_error);
-        }
+		if (local_error == NULL && has_frame_start) {
+			arv_camera_set_string (camera, "TriggerSelector", "FrameStart", &local_error);
+		}
 
-        if (local_error == NULL
-            && arv_camera_is_enumeration_entry_available (camera, "TriggerActivation", "RisingEdge", &local_error)) {
-                arv_camera_set_string (camera, "TriggerActivation", "RisingEdge", &local_error);
-        }
+		if (local_error == NULL
+		    && arv_camera_is_enumeration_entry_available (camera, "TriggerActivation", "RisingEdge", &local_error)) {
+			arv_camera_set_string (camera, "TriggerActivation", "RisingEdge", &local_error);
+		}
 
-        if (local_error == NULL)
-                arv_camera_set_string (camera, "TriggerSource", source, &local_error);
+		if (local_error == NULL)
+			arv_camera_set_string (camera, "TriggerSource", source, &local_error);
+	}
 
 	if (local_error != NULL)
 		g_propagate_error (error, local_error);


### PR DESCRIPTION
Since `0.8.16`, setting the `TriggerSource` to software results in the following error on our Mako camera:

```
Value not found in <Enumeration> 'TriggerSource'
```

This issue seems to be introduced in [this](https://github.com/AravisProject/aravis/commit/f6d5f6077bcf56d837e4a6bf0eb58cbe64ed3ffa#diff-d7be5be1f918127f4161b7f5a654290347f3334e434d14a61eb04e013b85dd99) commit.

It occurs when both `AcquisitionStart` and `FrameStart` are possible trigger selectors. When both are available, the trigger selector is first set to `FrameStart` and the trigger is enabled. Then, the selector is set to `AcquisitionStart` and the trigger is disabled. Finally, the `TriggerSelector` is set to the chosen source, but the selector is still set to `AcquisitionStart`.

This PR sets the `TriggerSelector` back to `FrameStart` after having disabled the `AcquisitionStart` trigger.