### PR TITLE
Add TriggerSoftware support to fake camera

### DIFF
--- a/src/arv-fake-camera.xml
+++ b/src/arv-fake-camera.xml
@@ -258,6 +258,11 @@
 		<pFeature>AcquisitionMode</pFeature>
 		<pFeature>AcquisitionStart</pFeature>
 		<pFeature>AcquisitionStop</pFeature>
+		<pFeature>TriggerSelector</pFeature>
+		<pFeature>TriggerMode</pFeature>
+		<pFeature>TriggerSoftware</pFeature>
+		<pFeature>TriggerSource</pFeature>
+		<pFeature>TriggerActivation</pFeature>
 		<pFeature>ExposureTimeAbs</pFeature>
 	</Category>
 
@@ -371,6 +376,9 @@
 		<EnumEntry Name="Line0" NameSpace="Standard">
 			<Value>0</Value>
 		</EnumEntry>
+		<EnumEntry Name="Software" NameSpace="Standard">
+			<Value>1</Value>
+		</EnumEntry>
 		<pValue>TriggerSourceRegister</pValue>
 	</Enumeration>
 
@@ -397,6 +405,21 @@
 		<pIndex Offset="0x20">TriggerSelectorInteger</pIndex>
 		<Length>4</Length>
 		<AccessMode>RW</AccessMode>
+		<pPort>Device</pPort>
+		<Sign>Unsigned</Sign>
+		<Endianess>BigEndian</Endianess>
+	</IntReg>
+
+	<Command Name="TriggerSoftware" NameSpace="Standard">
+		<Description>Generates an internal trigger. TriggerSource must be set to Software.</Description>
+		<pValue>TriggerSoftwareCommandRegister</pValue>
+		<CommandValue>1</CommandValue>
+	</Command>
+
+	<IntReg Name="TriggerSoftwareCommandRegister" NameSpace="Custom">
+		<Address>0x30c</Address>
+		<Length>4</Length>
+		<AccessMode>WO</AccessMode>
 		<pPort>Device</pPort>
 		<Sign>Unsigned</Sign>
 		<Endianess>BigEndian</Endianess>

--- a/src/arv-test.cfg
+++ b/src/arv-test.cfg
@@ -3,7 +3,7 @@
 ChunksSupport=false
 Schema=Ignore
 SensorSize=2048;2048
-SoftwareTriggerSupport=false
+SoftwareTriggerSupport=true
 
 [Basler:acA1300-30gc]
 

--- a/src/arvfakecamera.c
+++ b/src/arvfakecamera.c
@@ -859,6 +859,43 @@ arv_fake_camera_set_trigger_frequency (ArvFakeCamera *camera, double frequency)
 	camera->priv->trigger_frequency = frequency;
 }
 
+gboolean
+arv_fake_camera_check_and_acknowledge_software_trigger (ArvFakeCamera *camera)
+{
+	g_return_val_if_fail (ARV_IS_FAKE_CAMERA (camera), FALSE);
+
+
+	if (_get_register (camera, ARV_FAKE_CAMERA_REGISTER_TRIGGER_SOFTWARE) == 1) {
+		arv_fake_camera_write_register (camera, ARV_FAKE_CAMERA_REGISTER_TRIGGER_SOFTWARE, 0);
+		return TRUE;
+	}
+	return FALSE;
+}
+
+gboolean
+arv_fake_camera_is_in_free_running_mode (ArvFakeCamera *camera)
+{
+	g_return_val_if_fail (ARV_IS_FAKE_CAMERA (camera), FALSE);
+
+	if (_get_register (camera, ARV_FAKE_CAMERA_REGISTER_TRIGGER_MODE) == 0 &&
+	    _get_register (camera, ARV_FAKE_CAMERA_REGISTER_ACQUISITION_FRAME_PERIOD_US) > 0) {
+		return TRUE;
+	}
+	return FALSE;
+}
+
+gboolean
+arv_fake_camera_is_in_software_trigger_mode (ArvFakeCamera *camera)
+{
+	g_return_val_if_fail (ARV_IS_FAKE_CAMERA (camera), FALSE);
+
+	if (_get_register (camera, ARV_FAKE_CAMERA_REGISTER_TRIGGER_MODE) == 1 &&
+	    _get_register (camera, ARV_FAKE_CAMERA_REGISTER_TRIGGER_SOURCE) == 1) {
+		return TRUE;
+	}
+	return FALSE;
+}
+
 guint32
 arv_fake_camera_get_control_channel_privilege (ArvFakeCamera *camera)
 {
@@ -1001,6 +1038,11 @@ arv_fake_camera_new_full (const char *serial_number, const char *genicam_filenam
 					1000000.0 / ARV_FAKE_CAMERA_ACQUISITION_FRAME_RATE_DEFAULT);
 	arv_fake_camera_write_register (fake_camera, ARV_FAKE_CAMERA_REGISTER_EXPOSURE_TIME_US,
 					ARV_FAKE_CAMERA_EXPOSURE_TIME_US_DEFAULT);
+
+	arv_fake_camera_write_register (fake_camera, ARV_FAKE_CAMERA_REGISTER_TRIGGER_MODE, 0);
+	arv_fake_camera_write_register (fake_camera, ARV_FAKE_CAMERA_REGISTER_TRIGGER_SOURCE, 0);
+	arv_fake_camera_write_register (fake_camera, ARV_FAKE_CAMERA_REGISTER_TRIGGER_ACTIVATION, 0);
+	arv_fake_camera_write_register (fake_camera, ARV_FAKE_CAMERA_REGISTER_TRIGGER_SOFTWARE, 0);
 
 	arv_fake_camera_write_register (fake_camera, ARV_FAKE_CAMERA_REGISTER_GAIN_RAW, 0);
 	arv_fake_camera_write_register (fake_camera, ARV_FAKE_CAMERA_REGISTER_GAIN_MODE, 1);

--- a/src/arvfakecamera.h
+++ b/src/arvfakecamera.h
@@ -73,6 +73,7 @@ ARV_API void			arv_set_fake_camera_genicam_filename (const char *filename);
 #define ARV_FAKE_CAMERA_REGISTER_TRIGGER_MODE		0x300
 #define ARV_FAKE_CAMERA_REGISTER_TRIGGER_SOURCE		0x304
 #define ARV_FAKE_CAMERA_REGISTER_TRIGGER_ACTIVATION	0x308
+#define ARV_FAKE_CAMERA_REGISTER_TRIGGER_SOFTWARE	0x30c
 
 #define ARV_FAKE_CAMERA_REGISTER_ACQUISITION		0x124
 #define ARV_FAKE_CAMERA_REGISTER_EXPOSURE_TIME_US	0x120
@@ -118,6 +119,9 @@ ARV_API void			arv_fake_camera_set_fill_pattern	(ArvFakeCamera *camera,
 									 ArvFakeCameraFillPattern fill_pattern_callback,
 									 void *fill_pattern_data);
 ARV_API void			arv_fake_camera_set_trigger_frequency	(ArvFakeCamera *camera, double frequency);
+ARV_API gboolean		arv_fake_camera_is_in_free_running_mode (ArvFakeCamera *camera);
+ARV_API gboolean		arv_fake_camera_is_in_software_trigger_mode (ArvFakeCamera *camera);
+ARV_API gboolean		arv_fake_camera_check_and_acknowledge_software_trigger (ArvFakeCamera *camera);
 
 ARV_API const char *		arv_fake_camera_get_genicam_xml		(ArvFakeCamera *camera, size_t *size);
 

--- a/src/arvgvfakecamera.c
+++ b/src/arvgvfakecamera.c
@@ -339,83 +339,87 @@ _thread (void *user_data)
 				image_buffer = arv_buffer_new (payload, NULL);
 			}
 
-			arv_fake_camera_fill_buffer (gv_fake_camera->priv->camera, image_buffer, &gv_packet_size);
+			if (arv_fake_camera_is_in_free_running_mode (gv_fake_camera->priv->camera) ||
+			    (arv_fake_camera_is_in_software_trigger_mode (gv_fake_camera->priv->camera) &&
+			     arv_fake_camera_check_and_acknowledge_software_trigger (gv_fake_camera->priv->camera))) {
+				arv_fake_camera_fill_buffer (gv_fake_camera->priv->camera, image_buffer, &gv_packet_size);
 
-			arv_info_stream_thread ("[GvFakeCamera::thread] Send frame %" G_GUINT64_FORMAT, image_buffer->priv->frame_id);
+				arv_info_stream_thread ("[GvFakeCamera::thread] Send frame %" G_GUINT64_FORMAT, image_buffer->priv->frame_id);
 
-			block_id = 0;
-
-			packet_size = ARV_GV_FAKE_CAMERA_BUFFER_SIZE;
-			arv_gvsp_packet_new_data_leader (image_buffer->priv->frame_id,
-							 block_id,
-							 image_buffer->priv->timestamp_ns,
-							 image_buffer->priv->pixel_format,
-							 image_buffer->priv->width, image_buffer->priv->height,
-							 image_buffer->priv->x_offset, image_buffer->priv->y_offset,
-							 packet_buffer, &packet_size);
-
-			if (g_random_double () >= gv_fake_camera->priv->gvsp_lost_packet_ratio)
-				g_socket_send_to (gv_fake_camera->priv->gvsp_socket, stream_address,
-						  packet_buffer, packet_size, NULL, &error);
-			else
-				arv_info_stream_thread ("Drop GVSP leader packet frame: %" G_GUINT64_FORMAT, image_buffer->priv->frame_id);
-
-			if (error != NULL) {
-				arv_warning_stream_thread ("[GvFakeCamera::thread] Failed to send leader for frame %" G_GUINT64_FORMAT
-							   ": %s", image_buffer->priv->frame_id, error->message);
-				g_clear_error (&error);
-			}
-
-			block_id++;
-
-			offset = 0;
-			while (offset < payload) {
-				size_t data_size;
-
-				data_size = MIN (gv_packet_size - ARV_GVSP_PACKET_PROTOCOL_OVERHEAD,
-						 payload - offset);
+				block_id = 0;
 
 				packet_size = ARV_GV_FAKE_CAMERA_BUFFER_SIZE;
-				arv_gvsp_packet_new_data_block (image_buffer->priv->frame_id, block_id,
-								data_size, ((char *) image_buffer->priv->data) + offset,
+				arv_gvsp_packet_new_data_leader (image_buffer->priv->frame_id,
+								block_id,
+								image_buffer->priv->timestamp_ns,
+								image_buffer->priv->pixel_format,
+								image_buffer->priv->width, image_buffer->priv->height,
+								image_buffer->priv->x_offset, image_buffer->priv->y_offset,
 								packet_buffer, &packet_size);
 
 				if (g_random_double () >= gv_fake_camera->priv->gvsp_lost_packet_ratio)
 					g_socket_send_to (gv_fake_camera->priv->gvsp_socket, stream_address,
-							  packet_buffer, packet_size, NULL, &error);
+							packet_buffer, packet_size, NULL, &error);
 				else
-					arv_info_stream_thread ("Drop GVSP data packet frame:%" G_GUINT64_FORMAT
-								 ", block:%u", image_buffer->priv->frame_id, block_id);
+					arv_info_stream_thread ("Drop GVSP leader packet frame: %" G_GUINT64_FORMAT, image_buffer->priv->frame_id);
 
 				if (error != NULL) {
-					arv_info_stream_thread ("[GvFakeCamera::thread] Failed to send frame block %d for frame"
-								 " %" G_GUINT64_FORMAT ": %s",
-								 block_id, image_buffer->priv->frame_id, error->message);
+					arv_warning_stream_thread ("[GvFakeCamera::thread] Failed to send leader for frame %" G_GUINT64_FORMAT
+								": %s", image_buffer->priv->frame_id, error->message);
 					g_clear_error (&error);
 				}
 
-				offset += data_size;
 				block_id++;
+
+				offset = 0;
+				while (offset < payload) {
+					size_t data_size;
+
+					data_size = MIN (gv_packet_size - ARV_GVSP_PACKET_PROTOCOL_OVERHEAD,
+							payload - offset);
+
+					packet_size = ARV_GV_FAKE_CAMERA_BUFFER_SIZE;
+					arv_gvsp_packet_new_data_block (image_buffer->priv->frame_id, block_id,
+									data_size, ((char *) image_buffer->priv->data) + offset,
+									packet_buffer, &packet_size);
+
+					if (g_random_double () >= gv_fake_camera->priv->gvsp_lost_packet_ratio)
+						g_socket_send_to (gv_fake_camera->priv->gvsp_socket, stream_address,
+								packet_buffer, packet_size, NULL, &error);
+					else
+						arv_info_stream_thread ("Drop GVSP data packet frame:%" G_GUINT64_FORMAT
+									", block:%u", image_buffer->priv->frame_id, block_id);
+
+					if (error != NULL) {
+						arv_info_stream_thread ("[GvFakeCamera::thread] Failed to send frame block %d for frame"
+									" %" G_GUINT64_FORMAT ": %s",
+									block_id, image_buffer->priv->frame_id, error->message);
+						g_clear_error (&error);
+					}
+
+					offset += data_size;
+					block_id++;
+				}
+
+				packet_size = ARV_GV_FAKE_CAMERA_BUFFER_SIZE;
+				arv_gvsp_packet_new_data_trailer (image_buffer->priv->frame_id, block_id,
+								packet_buffer, &packet_size);
+
+				if (g_random_double () >= gv_fake_camera->priv->gvsp_lost_packet_ratio)
+					g_socket_send_to (gv_fake_camera->priv->gvsp_socket, stream_address,
+							packet_buffer, packet_size, NULL, &error);
+				else
+					arv_info_stream_thread ("Drop GVSP trailer packet frame: %" G_GUINT64_FORMAT,
+								image_buffer->priv->frame_id);
+
+				if (error != NULL) {
+					arv_info_stream_thread ("[GvFakeCamera::thread] Failed to send trailer for frame %" G_GUINT64_FORMAT
+								": %s", image_buffer->priv->frame_id, error->message);
+					g_clear_error (&error);
+				}
+
+				is_streaming = TRUE;
 			}
-
-			packet_size = ARV_GV_FAKE_CAMERA_BUFFER_SIZE;
-			arv_gvsp_packet_new_data_trailer (image_buffer->priv->frame_id, block_id,
-							  packet_buffer, &packet_size);
-
-			if (g_random_double () >= gv_fake_camera->priv->gvsp_lost_packet_ratio)
-				g_socket_send_to (gv_fake_camera->priv->gvsp_socket, stream_address,
-						  packet_buffer, packet_size, NULL, &error);
-			else
-				arv_info_stream_thread ("Drop GVSP trailer packet frame: %" G_GUINT64_FORMAT,
-							 image_buffer->priv->frame_id);
-
-			if (error != NULL) {
-				arv_info_stream_thread ("[GvFakeCamera::thread] Failed to send trailer for frame %" G_GUINT64_FORMAT
-							 ": %s", image_buffer->priv->frame_id, error->message);
-				g_clear_error (&error);
-			}
-
-			is_streaming = TRUE;
 		}
 
 	} while (!g_atomic_int_get (&gv_fake_camera->priv->cancel));

--- a/tests/fake.c
+++ b/tests/fake.c
@@ -635,6 +635,45 @@ camera_device_test (void)
 }
 
 static void
+camera_trigger_selector_test (void)
+{
+	ArvCamera *camera;
+	GError *error = NULL;
+	const char *string;
+
+	camera = arv_camera_new ("Fake_1", &error);
+	g_assert (ARV_IS_CAMERA (camera));
+	g_assert (error == NULL);
+
+	/* Enable TriggerMode on FrameStart */
+	arv_camera_set_string (camera, "TriggerSelector", "FrameStart", &error);
+	g_assert (error == NULL);
+	arv_camera_set_string (camera, "TriggerMode", "On", &error);
+	g_assert (error == NULL);
+	string = arv_camera_get_string(camera, "TriggerMode", &error);
+	g_assert (error == NULL);
+	g_assert_cmpstr (string, ==, "On");
+
+	/* Disable TriggerMode on AcquisitionStart */
+	arv_camera_set_string (camera, "TriggerSelector", "AcquisitionStart", &error);
+	g_assert (error == NULL);
+	arv_camera_set_string (camera, "TriggerMode", "Off", &error);
+	g_assert (error == NULL);
+	string = arv_camera_get_string(camera, "TriggerMode", &error);
+	g_assert (error == NULL);
+	g_assert_cmpstr (string, ==, "Off");
+
+	/* Re-check TriggerMode value on FrameStart */
+	arv_camera_set_string (camera, "TriggerSelector", "FrameStart", &error);
+	g_assert (error == NULL);
+	string = arv_camera_get_string(camera, "TriggerMode", &error);
+	g_assert (error == NULL);
+	g_assert_cmpstr (string, ==, "On");
+
+	g_object_unref (camera);
+}
+
+static void
 set_features_from_string_test (void)
 {
 	ArvDevice *device;
@@ -709,6 +748,7 @@ main (int argc, char *argv[])
 	g_test_add_func ("/fake/fake-stream", fake_stream_test);
 	g_test_add_func ("/fake/camera-api", camera_api_test);
 	g_test_add_func ("/fake/camera-device", camera_device_test);
+	g_test_add_func ("/fake/camera-trigger-selector", camera_trigger_selector_test);
 	g_test_add_func ("/fake/set-features-from-string", set_features_from_string_test);
 
 	result = g_test_run();

--- a/tests/fake.c
+++ b/tests/fake.c
@@ -52,6 +52,10 @@ trigger_registers_test (void)
 										 "TriggerActivationRegister")), NULL);
 	g_assert_cmpint (address, ==, ARV_FAKE_CAMERA_REGISTER_TRIGGER_ACTIVATION);
 
+	address = arv_gc_register_get_address (ARV_GC_REGISTER (arv_gc_get_node (genicam,
+										 "TriggerSoftwareCommandRegister")), NULL);
+	g_assert_cmpint (address, ==, ARV_FAKE_CAMERA_REGISTER_TRIGGER_SOFTWARE);
+
 	arv_device_set_string_feature_value (device, "TriggerSelector", "AcquisitionStart", NULL);
 
 	address = arv_gc_register_get_address (ARV_GC_REGISTER (node), NULL);


### PR DESCRIPTION
Preliminary work to introduce TriggerSoftware support in the fake camera

Any comment is welcomed.

Remaining issues:

* [ ] implement `TriggerSelector`. `arv_camera_set_trigger` uses `TriggerSelector` to first enable `TriggerMode` on `FrameStart` and then disable it on `AcquisitionStart`. But the last `TriggerMode` value is `Off` my condition in `arv_fake_camera_is_in_software_trigger_mode` is `false`. An easy solution is to remove the `AcquisitionStart` feature from the XML but there is a test against it in `fake.c`

* [ ] Do we need to check `ARV_FAKE_CAMERA_REGISTER_TRIGGER_SOFTWARE` against the value `1` or `>0`? And to acknowledge, setting it to `0` or decrement it until `0`? Because `arv_gc_command_execute` seems to increment the value.
 
