### PR TITLE
Dev/uvdependencies

### DIFF
--- a/src/arvcamera.h
+++ b/src/arvcamera.h
@@ -32,7 +32,9 @@
 #include <arvstream.h>
 #include <arvgvstream.h>
 #include <arvgvdevice.h>
+#if ARAVIS_HAS_USB
 #include <arvuvdevice.h>
+#endif
 
 G_BEGIN_DECLS
 

--- a/src/arvcamera.h
+++ b/src/arvcamera.h
@@ -199,6 +199,7 @@ ARV_API void		arv_camera_gv_set_packet_size_adjustment	(ArvCamera *camera,
 ARV_API void		arv_camera_gv_set_stream_options		(ArvCamera *camera, ArvGvStreamOption options);
 
 /* USB3Vision specific API */
+#if ARAVIS_HAS_USB
 
 ARV_API gboolean	arv_camera_is_uv_device				(ArvCamera *camera);
 ARV_API gboolean	arv_camera_uv_is_bandwidth_control_available	(ArvCamera *camera, GError **error);
@@ -206,6 +207,7 @@ ARV_API void		arv_camera_uv_set_bandwidth			(ArvCamera *camera, guint bandwidth,
 ARV_API guint		arv_camera_uv_get_bandwidth			(ArvCamera *camera, GError **error);
 ARV_API void		arv_camera_uv_get_bandwidth_bounds		(ArvCamera *camera, guint *min, guint *max, GError **error);
 ARV_API void            arv_camera_uv_set_usb_mode			(ArvCamera *camera, ArvUvUsbMode usb_mode);
+#endif
 
 /* Chunk data */
 


### PR DESCRIPTION
Issue 581
If the USB3 Vision is not present, the arvuv*.h are not installed.
The file arv.h and arvcamera.h require arvuvdevice.h, arvuvinterface.h and arvuvstream.h.