### PR TITLE
ci: Update Conan package manager configuration for MSVC builds.

### DIFF
--- a/.github/workflows/aravis-msvc.yml
+++ b/.github/workflows/aravis-msvc.yml
@@ -28,17 +28,17 @@ jobs:
       env:
         INPUT_CONANFILE: |
           [requires]
-          pcre/8.45
-          glib/2.69.1
-          #gobject-introspection/1.68.0
+          glib/2.70.0
+          #gobject-introspection/1.69.0
           gstreamer/1.19.1
-          #gtk/3.24.24
+          gst-plugins-base/1.19.1
+          #gtk/4.4.0
           libxml2/2.9.12
           zlib/1.2.11
           libusb/1.0.24
 
           [build_requires]
-          meson/0.59.0
+          meson/0.59.2
 
           [generators]
           pkg_config
@@ -47,9 +47,9 @@ jobs:
           virtualrunenv
 
           [options]
-          pcre:with_utf=True
-          pcre:with_unicode_properties=True
-          pcre:with_stack_for_recursion=True
+          glib:shared=True
+          gstreamer:shared=True
+          gst-plugins-base:shared=True
       run: |
         $Env:INPUT_CONANFILE | Out-File -FilePath ${{ github.workspace }}\conanfile.txt -Encoding utf8
         conan install -s compiler="Visual Studio" -s compiler.version=${{ matrix.version }} -s arch=${{ matrix.arch }} -s build_type=${{ matrix.build_type_conan }} -b pcre -b missing -b cascade -if build .
@@ -59,7 +59,7 @@ jobs:
         .\build\activate_build.ps1
         .\build\activate_run.ps1
         echo "::group::configure"
-        meson --prefix ${{ github.workspace }}\install --buildtype ${{ matrix.build_type_meson }} --pkg-config-path ${{ github.workspace }}\build -Ddocumentation=disabled -Dgst-plugin=disabled -Dintrospection=disabled -Dusb=enabled -Dviewer=disabled . .\build
+        meson --prefix ${{ github.workspace }}\install --buildtype ${{ matrix.build_type_meson }} --pkg-config-path ${{ github.workspace }}\build -Ddocumentation=disabled -Dgst-plugin=enabled -Dintrospection=disabled -Dusb=enabled -Dviewer=disabled . .\build
         echo "::endgroup::"
         echo "::group::compile"
         meson compile -C .\build -v


### PR DESCRIPTION
Workflow updates:
* Adds new gst-plugins-base package to dependencies and enables gst-plugin.
* Removed pcre options since the default options for the packages are now upstreamed.
* Updates various package versions.

The viewer is still not enabled as building GTK on Windows has some bugs in Conan. The gobject introspection is very broken in Conan right now (similar problems as #540) so that is not going to be available soon.

I have tried vcpkg as an alternative to Conan, but I found it very troublesome and difficult to integrate in CI. Hence, I'd keep going with Conan.