### PR TITLE
fix set priority Class

### DIFF
--- a/src/arvrealtime.c
+++ b/src/arvrealtime.c
@@ -329,7 +329,8 @@ arv_make_thread_high_priority (int nice_level)
 gboolean
 arv_make_thread_realtime (int priority)
 {
-	if(!SetPriorityClass(GetCurrentThread(), THREAD_PRIORITY_TIME_CRITICAL))
+	SetPriorityClass(GetCurrentProcess(), REALTIME_PRIORITY_CLASS);
+	if(!SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_TIME_CRITICAL))
    {
 		DWORD err = GetLastError();
 		arv_warning_misc ("SetPriorityClass(..., THREAD_PRIORITY_TIME_CRITICAL) failed (%lu)", err);
@@ -342,10 +343,10 @@ arv_make_thread_realtime (int priority)
 gboolean
 arv_make_thread_high_priority (int priority)
 {
-	if(!SetPriorityClass(GetCurrentThread(), THREAD_PRIORITY_ABOVE_NORMAL))
+	if(!SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_HIGHEST))
    {
 		DWORD err = GetLastError();
-		arv_warning_misc ("SetPriorityClass(..., THREAD_PRIORITY_ABOVE_NORMAL) failed (%lu)", err);
+		arv_warning_misc ("SetPriorityClass(..., THREAD_PRIORITY_HIGHEST) failed (%lu)", err);
 		return FALSE;
 	}
 	g_critical("Thread made high-priority!");


### PR DESCRIPTION
Fix this error: 
https://github.com/AravisProject/aravis/issues/593

Thanks to @EmmanuelP and @eudoxos for your help.

`arv_make_thread_realtime` works, but there is a bug in it.

Please refer to 
https://docs.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-setpriorityclass

https://docs.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-setthreadpriority

for information. 

