### PR TITLE
arv_camera_set_frame_rate: AcquisitionFrameRateEnable is not available on some Basler camera models

### DIFF
--- a/src/arvcamera.c
+++ b/src/arvcamera.c
@@ -1026,8 +1026,13 @@ arv_camera_set_frame_rate (ArvCamera *camera, double frame_rate, GError **error)
 
 	switch (priv->vendor) {
 		case ARV_CAMERA_VENDOR_BASLER:
-			if (local_error == NULL)
-				arv_camera_set_boolean (camera, "AcquisitionFrameRateEnable", TRUE, &local_error);
+			if (local_error == NULL){
+				if (arv_camera_is_feature_available (camera, "AcquisitionFrameRateEnable", &local_error)){
+					/* enable is optional on some devices */
+					if (local_error == NULL)
+						arv_camera_set_boolean (camera, "AcquisitionFrameRateEnable", TRUE, &local_error);
+				}
+			}
 			if (local_error == NULL)
 				arv_camera_set_float (camera,
 						      priv->has_acquisition_frame_rate ?


### PR DESCRIPTION
The feature 'AcquisitionFrameRateEnable' is not available on Basler dart family models 
and has to be used with prior check for availability.
( any value in feature 'AcquisitionFrameRate'  works as a clipping value for the frame rate )
