### PR TITLE
camera: try to improve LucidVision support

### DIFF
--- a/src/arv-test.cfg
+++ b/src/arv-test.cfg
@@ -100,7 +100,8 @@ UseSystemTimestamp=true
 
 [The Imaging Source Europe GmbH:DMK 23G618]
 
-FrameRate=15.0
+FrameRateA=15.0
+FrameRateB=7.5
 ChunksSupport=false
 Schema=1.1
 SensorSize=640;480

--- a/src/arvcamera.c
+++ b/src/arvcamera.c
@@ -1086,17 +1086,17 @@ arv_camera_set_frame_rate (ArvCamera *camera, double frame_rate, GError **error)
 		case ARV_CAMERA_VENDOR_XIMEA:
 		case ARV_CAMERA_VENDOR_MATRIX_VISION:
 		case ARV_CAMERA_VENDOR_UNKNOWN:
-                        if (local_error == NULL)
-                                arv_camera_set_float (camera,
-                                                      priv->has_acquisition_frame_rate ?
-                                                      "AcquisitionFrameRate":
-                                                      "AcquisitionFrameRateAbs", frame_rate, &local_error);
                         if (local_error == NULL) {
                                 if (arv_camera_is_feature_available (camera, "AcquisitionFrameRateEnable", &local_error)) {
                                         if (local_error == NULL)
                                                 arv_camera_set_boolean (camera, "AcquisitionFrameRateEnable", TRUE, &local_error);
                                 }
                         }
+                        if (local_error == NULL)
+                                arv_camera_set_float (camera,
+                                                      priv->has_acquisition_frame_rate ?
+                                                      "AcquisitionFrameRate":
+                                                      "AcquisitionFrameRateAbs", frame_rate, &local_error);
                         break;
         }
 

--- a/src/arvtest.c
+++ b/src/arvtest.c
@@ -541,12 +541,12 @@ arv_test_chunks (ArvTest *test, const char *test_name, ArvTestCamera *test_camer
 }
 
 static void
-arv_test_multiple_acquisition (ArvTest *test, const char *test_name, ArvTestCamera *test_camera)
+_multiple_acquisition (ArvTest *test, const char *test_name, ArvTestCamera *test_camera,
+                       double frame_rate, gboolean use_system_timestamp)
 {
         GError *error = NULL;
         char *message = NULL;
         ArvStream *stream;
-        double frame_rate;
         unsigned int i;
         size_t payload_size;
         gboolean success = TRUE;
@@ -555,12 +555,6 @@ arv_test_multiple_acquisition (ArvTest *test, const char *test_name, ArvTestCame
         gboolean frame_rate_success;
         guint n_completed_buffers = 0;
         guint n_expected_buffers = 10;
-        gboolean use_system_timestamp;
-
-        g_return_if_fail (ARV_IS_TEST (test));
-
-        frame_rate = arv_test_camera_get_key_file_double (test_camera, test, "FrameRate", 10.0);
-        use_system_timestamp = arv_test_camera_get_key_file_boolean (test_camera, test, "UseSystemTimestamp", FALSE);
 
         arv_camera_set_acquisition_mode (test_camera->camera, ARV_ACQUISITION_MODE_CONTINUOUS, &error);
         if (error == NULL)
@@ -645,6 +639,34 @@ arv_test_multiple_acquisition (ArvTest *test, const char *test_name, ArvTestCame
 
         g_clear_error (&error);
         g_clear_pointer (&message, g_free);
+}
+
+static void
+arv_test_multiple_acquisition_a (ArvTest *test, const char *test_name, ArvTestCamera *test_camera)
+{
+        double frame_rate;
+        gboolean use_system_timestamp;
+
+        g_return_if_fail (ARV_IS_TEST (test));
+
+        use_system_timestamp = arv_test_camera_get_key_file_boolean (test_camera, test, "UseSystemTimestamp", FALSE);
+        frame_rate = arv_test_camera_get_key_file_double (test_camera, test, "FrameRateA", 10.0);
+
+        _multiple_acquisition (test, test_name, test_camera, frame_rate, use_system_timestamp);
+}
+
+static void
+arv_test_multiple_acquisition_b (ArvTest *test, const char *test_name, ArvTestCamera *test_camera)
+{
+        double frame_rate;
+        gboolean use_system_timestamp;
+
+        g_return_if_fail (ARV_IS_TEST (test));
+
+        use_system_timestamp = arv_test_camera_get_key_file_boolean (test_camera, test, "UseSystemTimestamp", FALSE);
+        frame_rate = arv_test_camera_get_key_file_double (test_camera, test, "FrameRateB", 5.0);
+
+        _multiple_acquisition (test, test_name, test_camera, frame_rate, use_system_timestamp);
 }
 
 static void
@@ -783,10 +805,11 @@ const struct {
 } tests[] = {
         {"Genicam",                     arv_test_genicam,               FALSE},
         {"Properties",                  arv_test_device_properties,     FALSE},
-        {"MultipleAcquisition",         arv_test_multiple_acquisition,  FALSE},
+        {"MultipleAcquisitionA",        arv_test_multiple_acquisition_a,FALSE},
+        {"SoftwareTrigger",             arv_test_software_trigger,      FALSE},
+        {"MultipleAcquisitionB",        arv_test_multiple_acquisition_b,FALSE},
         {"SingleAcquisition",           arv_test_single_acquisition,    FALSE},
         {"Chunks",                      arv_test_chunks,                FALSE},
-        {"SoftwareTrigger",             arv_test_software_trigger,      FALSE},
         {"GigEVision",                  arv_test_gige_vision,           FALSE},
         {"USB3Vision",                  arv_test_usb3_vision,           FALSE}
 };


### PR DESCRIPTION
It looks like some of their devices require to set the FrameRate before enabling
it.