### PR TITLE
genicam: ignore leading spaces in local data url

### DIFF
--- a/src/arvmisc.c
+++ b/src/arvmisc.c
@@ -957,7 +957,8 @@ arv_parse_genicam_url (const char *url, gssize url_length,
 	l_authority = tokens[4][0] != '\0' ? tokens[4] : NULL;
 
 	if (g_ascii_strcasecmp (l_scheme, "local") == 0) {
-		local_regex = g_regex_new ("(.+);(?:0x)?([0-9:a-f]*);(?:0x)?([0-9:a-f]*)", G_REGEX_CASELESS, 0, NULL);
+	local_regex = g_regex_new ("(?:\\s*)?(.+);(?:\\s*)?(?:0x)?([0-9:a-f]*);(?:\\s*)?(?:0x)?([0-9:a-f]*)",
+                                           G_REGEX_CASELESS, 0, NULL);
 
 		if (local_regex == NULL) {
 			g_strfreev (tokens);

--- a/tests/genicam.c
+++ b/tests/genicam.c
@@ -825,7 +825,13 @@ const struct {
 		0, 0 },
 	{ "file:///C|program%20files/aravis/genicam.xml?SchemaVersion=1.0.0",
 		"file", NULL, "/C|program%20files/aravis/genicam.xml", "SchemaVersion=1.0.0", NULL,
-		0, 0}
+		0, 0},
+        { "Local: guide_gige_test.zip; 00010000; 06c5",
+                "Local", NULL, "guide_gige_test.zip", NULL, NULL,
+                0x10000, 0x6c5},
+        { "Local:   guide_gige_test.zip;    00010000;    06c5",
+                "Local", NULL, "guide_gige_test.zip", NULL, NULL,
+                0x10000, 0x6c5}
 };
 
 static void


### PR DESCRIPTION
Someone at GlobalSensorTechnology thought it was a good idea to pretify the
genicam data url, hence url like this one:

'Local: guide_gige_test.zip; 00010000; 06c5'