### PR TITLE
Wip/libusb dev mem alloc

### DIFF
--- a/src/arvstream.h
+++ b/src/arvstream.h
@@ -58,11 +58,18 @@ struct _ArvStreamClass {
 	void		(*start_thread)		(ArvStream *stream);
 	void		(*stop_thread)		(ArvStream *stream);
 
+        unsigned int    (*create_buffers)       (ArvStream *stream, unsigned int n_buffers, size_t size,
+                                                 void *user_data, GDestroyNotify user_data_destroy_func);
+
 	/* signals */
 	void        	(*new_buffer)   	(ArvStream *stream);
 };
 
 typedef void (*ArvStreamCallback)	(void *user_data, ArvStreamCallbackType type, ArvBuffer *buffer);
+
+ARV_API unsigned int    arv_stream_create_buffers               (ArvStream *stream, unsigned int n_buffers,
+                                                                 void *user_data, GDestroyNotify user_data_destroy_func,
+                                                                 GError **error);
 
 ARV_API void		arv_stream_push_buffer			(ArvStream *stream, ArvBuffer *buffer);
 ARV_API ArvBuffer *	arv_stream_pop_buffer			(ArvStream *stream);

--- a/src/arvuvstream.c
+++ b/src/arvuvstream.c
@@ -114,8 +114,6 @@ typedef struct {
 
 G_DEFINE_TYPE_WITH_CODE (ArvUvStream, arv_uv_stream, ARV_TYPE_STREAM, G_ADD_PRIVATE (ArvUvStream))
 
-int mode_sync;
-
 static void
 arv_uv_stream_buffer_context_wait_transfer_completed (ArvUvStreamBufferContext* ctx)
 {

--- a/src/arvuvstream.c
+++ b/src/arvuvstream.c
@@ -114,6 +114,25 @@ typedef struct {
 
 G_DEFINE_TYPE_WITH_CODE (ArvUvStream, arv_uv_stream, ARV_TYPE_STREAM, G_ADD_PRIVATE (ArvUvStream))
 
+typedef struct {
+        void *buffer;
+        gboolean is_dev_mem;
+        void *user_data;
+        GDestroyNotify user_data_destroy_func;
+} ArvUvStreamBufferInfos;
+
+static void
+_destroy_buffer (void *abstract_data)
+{
+}
+
+static unsigned int
+arv_uv_stream_create_buffers (ArvStream *stream, unsigned int n_buffers, size_t size,
+                              void *user_data, GDestroyNotify user_data_destroy_func)
+{
+        return 0;
+}
+
 static void
 arv_uv_stream_buffer_context_wait_transfer_completed (ArvUvStreamBufferContext* ctx)
 {

--- a/viewer/arvviewer.c
+++ b/viewer/arvviewer.c
@@ -1212,8 +1212,6 @@ start_video (ArvViewer *viewer)
 	GstElement *videoconvert;
 	GstCaps *caps;
 	ArvPixelFormat pixel_format;
-	unsigned payload;
-	unsigned i;
 	gint width, height;
 	const char *caps_string;
 
@@ -1248,9 +1246,8 @@ start_video (ArvViewer *viewer)
 	}
 
 	arv_stream_set_emit_signals (viewer->stream, TRUE);
-	payload = arv_camera_get_payload (viewer->camera, NULL);
-	for (i = 0; i < 10; i++)
-		arv_stream_push_buffer (viewer->stream, arv_buffer_new (payload, NULL));
+
+        arv_stream_create_buffers (viewer->stream, 10, NULL, NULL, NULL);
 
 	set_camera_widgets(viewer);
 	pixel_format = arv_camera_get_pixel_format (viewer->camera, NULL);


### PR DESCRIPTION
An attempt to create device optimized buffers, using libusb_dev_mem_alloc for USB devices.