### PR TITLE
Update path to aravis icon: fix AppStream warning.

### DIFF
--- a/viewer/data/arv-viewer.appdata.xml.in
+++ b/viewer/data/arv-viewer.appdata.xml.in
@@ -18,7 +18,7 @@
 	</description>
 	<screenshots>
 		<screenshot type="default">
-                        <image width="1024" height="576">https://raw.githubusercontent.com/AravisProject/aravis/master/viewer/icons/gnome/256x256/apps/aravis.png</image>
+                        <image width="1024" height="576">https://raw.githubusercontent.com/AravisProject/aravis/main/viewer/icons/gnome/256x256/apps/aravis.png</image>
                 </screenshot>
 	</screenshots>
 	<url type="homepage">https://wiki.gnome.org/Projects/Aravis</url>


### PR DESCRIPTION
This pull request update the path to the aravis icon.
While github in general redirects _master_ links to _main_, AppStream doesn't know about that, then the icon is not retrieved.

Found in packaging for Debian.

Thanks for considering it.