### PR TITLE
camera: remove duplicate of arv_camera_clear_triggers

### DIFF
--- a/src/arvcamera.c
+++ b/src/arvcamera.c
@@ -939,30 +939,6 @@ arv_camera_get_frame_count_bounds (ArvCamera *camera, gint64 *min, gint64 *max, 
 	arv_camera_get_integer_bounds (camera, "AcquisitionFrameCount", min, max, error);
 }
 
-static void
-arv_camera_disable_all_triggers (ArvCamera *camera, GError **error)
-{
-	GError *local_error = NULL;
-        const char **triggers = NULL;
-        guint n_triggers;
-        unsigned int i;
-
-	g_return_if_fail (ARV_IS_CAMERA (camera));
-
-        triggers = arv_camera_dup_available_enumerations_as_strings (camera, "TriggerSelector", &n_triggers,
-                                                                     &local_error);
-
-        for (i = 0; i < n_triggers && local_error == NULL; i++) {
-                arv_camera_set_string (camera, "TriggerSelector", triggers[i], &local_error);
-                if (local_error == NULL)
-                        arv_camera_set_string (camera, "TriggerMode", "Off", &local_error);
-        }
-        g_free (triggers);
-
-	if (local_error != NULL)
-		g_propagate_error (error, local_error);
-}
-
 /**
  * arv_camera_set_frame_rate:
  * @camera: a #ArvCamera
@@ -998,7 +974,7 @@ arv_camera_set_frame_rate (ArvCamera *camera, double frame_rate, GError **error)
 		return;
 	}
 
-        arv_camera_disable_all_triggers (camera, &local_error);
+	arv_camera_clear_triggers (camera, &local_error);
 	if (local_error != NULL) {
 		g_propagate_error (error, local_error);
 		return;


### PR DESCRIPTION
In the process of supporting Imperx cameras, I will need to make the usage of TriggerSelector optional.
But it appears that the implementation of `arv_camera_disable_all_triggers` introduced 8 months ago is the same as the `arv_camera_clear_triggers` that was already there.