### PR TITLE
gst: Add GstQueryLatency handling

### DIFF
--- a/gst/gstaravis.c
+++ b/gst/gstaravis.c
@@ -280,17 +280,16 @@ gst_aravis_set_caps (GstBaseSrc *src, GstCaps *caps)
 	}
 
 	if (!error && frame_rate != NULL) {
-		double dbl_frame_rate;
 
-		dbl_frame_rate = (double) gst_value_get_fraction_numerator (frame_rate) /
+		gst_aravis->frame_rate = (double) gst_value_get_fraction_numerator (frame_rate) /
 			(double) gst_value_get_fraction_denominator (frame_rate);
 
-		GST_DEBUG_OBJECT (gst_aravis, "Frame rate = %g Hz", dbl_frame_rate);
-		arv_camera_set_frame_rate (gst_aravis->camera, dbl_frame_rate, &error);
+		GST_DEBUG_OBJECT (gst_aravis, "Frame rate = %g Hz", gst_aravis->frame_rate);
+		arv_camera_set_frame_rate (gst_aravis->camera, gst_aravis->frame_rate, &error);
 
-		if (dbl_frame_rate > 0.0)
+		if (gst_aravis->frame_rate > 0.0)
 			gst_aravis->buffer_timeout_us = MAX (GST_ARAVIS_BUFFER_TIMEOUT_DEFAULT,
-							     3e6 / dbl_frame_rate);
+                                                 3e6 / gst_aravis->frame_rate);
 		else
 			gst_aravis->buffer_timeout_us = GST_ARAVIS_BUFFER_TIMEOUT_DEFAULT;
 	} else
@@ -664,6 +663,7 @@ gst_aravis_init (GstAravis *gst_aravis)
 	gst_aravis->usb_mode = ARV_UV_USB_MODE_DEFAULT;
 
 	gst_aravis->buffer_timeout_us = GST_ARAVIS_BUFFER_TIMEOUT_DEFAULT;
+	gst_aravis->frame_rate = 0.0;
 
 	gst_aravis->camera = NULL;
 	gst_aravis->stream = NULL;
@@ -892,6 +892,62 @@ gst_aravis_get_property (GObject * object, guint prop_id, GValue * value,
 	}
 }
 
+static gboolean
+gst_aravis_query (GstBaseSrc *bsrc, GstQuery *query)
+{
+	GstAravis *src = GST_ARAVIS (bsrc);
+	gboolean res = FALSE;
+
+	switch (GST_QUERY_TYPE (query))
+	{
+		case GST_QUERY_LATENCY:
+		{
+			GstClockTime min_latency;
+			GstClockTime max_latency;
+
+			/* device must be open */
+			if (!src->stream)
+			{
+				GST_WARNING_OBJECT (src, "Can't give latency since device isn't open !");
+				goto done;
+			}
+
+			/* we must have a framerate */
+			if (src->frame_rate <= 0.0)
+			{
+				GST_WARNING_OBJECT (src, "Can't give latency since framerate isn't fixated !");
+				goto done;
+			}
+
+			/* min latency is the time to capture one frame/field */
+			min_latency = gst_util_gdouble_to_guint64 (src->frame_rate);
+
+			/* max latency is set to NONE because cameras may enter trigger mode
+			   and not deliver images for an unspecified amount of time */
+			max_latency = GST_CLOCK_TIME_NONE;
+
+			GST_DEBUG_OBJECT (bsrc, "report latency min %" GST_TIME_FORMAT " max %" GST_TIME_FORMAT,
+					  GST_TIME_ARGS (min_latency), GST_TIME_ARGS (max_latency));
+
+			/* we are always live, the min latency is 1 frame and the max latency is
+			 * the complete buffer of frames. */
+			gst_query_set_latency (query, TRUE, min_latency, max_latency);
+
+			res = TRUE;
+			break;
+		}
+		default:
+		{
+			res = GST_BASE_SRC_CLASS (gst_aravis_parent_class)->query (bsrc, query);
+			break;
+		}
+	}
+
+done:
+
+	return res;
+}
+
 static void
 gst_aravis_class_init (GstAravisClass * klass)
 {
@@ -1057,6 +1113,7 @@ gst_aravis_class_init (GstAravisClass * klass)
 	gstbasesrc_class->fixate = GST_DEBUG_FUNCPTR (gst_aravis_fixate_caps);
 	gstbasesrc_class->start = GST_DEBUG_FUNCPTR (gst_aravis_start);
 	gstbasesrc_class->stop = GST_DEBUG_FUNCPTR (gst_aravis_stop);
+	gstbasesrc_class->query = GST_DEBUG_FUNCPTR (gst_aravis_query);
 
 	gstbasesrc_class->get_times = GST_DEBUG_FUNCPTR (gst_aravis_get_times);
 

--- a/gst/gstaravis.h
+++ b/gst/gstaravis.h
@@ -68,6 +68,7 @@ struct _GstAravis {
 	gint payload;
 
 	guint64 buffer_timeout_us;
+    gdouble frame_rate;
 
 	ArvCamera *camera;
 	ArvStream *stream;


### PR DESCRIPTION
Define maximum latency and GST_CLOCK_TIME_NONE to prevent timeouts.

Potential fix for #528.

All gstreamer sources must be synchronized with the gstreamer clock.
Since aravissrc is a live source it can't give reliable increasing timestamps and instead works with durations.
Ideally that would mean first timestamp (0) + duration of frame. New timestamp + duration of frame, etc.
Since we cannot know what the duration of a frame is (some come faster, some slower, thus never being 100% accurate) gstreamer wants to know a latency range. 
This patch defined the latency as min=framerate and max=GST_CLOCK_TIME_NONE.
That basically says expect the next buffer between average duration and any given time in the future after that,
users more than enough time to trigger, extended exposure times, etc.