### PR TITLE
Feature/add network settings arvtool

### DIFF
--- a/src/arvcamera.c
+++ b/src/arvcamera.c
@@ -3046,40 +3046,11 @@ arv_camera_gv_set_persistent_ip_from_string (ArvCamera *camera,
                                              const char *ip, const char *mask, const char *gateway,
                                              GError **error)
 {
-	GError *local_error = NULL;
-	GInetAddress *ip_gi;
-	GInetAddressMask *mask_gi;
-	GInetAddress *gateway_gi;
 	ArvCameraPrivate *priv = arv_camera_get_instance_private (camera);
 
 	g_return_if_fail (arv_camera_is_gv_device (camera));
 
-	ip_gi = g_inet_address_new_from_string (ip);
-	mask_gi = g_inet_address_mask_new_from_string (mask, NULL);
-	gateway_gi = g_inet_address_new_from_string (gateway);
-
-	if (ip_gi == NULL) {
-		local_error = g_error_new (ARV_DEVICE_ERROR, ARV_DEVICE_ERROR_INVALID_PARAMETER,
-                                           "IP address could not be parsed: \"%s\"", ip);
-	}else if (mask_gi == NULL) {
-		local_error = g_error_new (ARV_DEVICE_ERROR, ARV_DEVICE_ERROR_INVALID_PARAMETER,
-                                           "Netmask could not be parsed: \"%s\"", mask);
-	}else if (gateway_gi == NULL) {
-		local_error = g_error_new (ARV_DEVICE_ERROR, ARV_DEVICE_ERROR_INVALID_PARAMETER,
-                                           "Gateway address could not be parsed: \"%s\"", gateway);
-	}
-	if (local_error != NULL){
-		g_propagate_error (error, local_error);
-		g_clear_object (&ip_gi);
-		g_clear_object (&mask_gi);
-		g_clear_object (&gateway_gi);
-		return;
-	}
-
-	arv_gv_device_set_persistent_ip (ARV_GV_DEVICE (priv->device), ip_gi, mask_gi, gateway_gi, error);
-	g_object_unref (ip_gi);
-	g_object_unref (mask_gi);
-	g_object_unref (gateway_gi);
+	arv_gv_device_set_persistent_ip_from_string (ARV_GV_DEVICE (priv->device), ip, mask, gateway, error);
 }
 
 /**

--- a/src/arvgvdevice.c
+++ b/src/arvgvdevice.c
@@ -915,6 +915,59 @@ arv_gv_device_set_persistent_ip (ArvGvDevice *gv_device,
 	arv_gv_device_set_ip_configuration_mode (gv_device, ARV_GV_IP_CONFIGURATION_MODE_PERSISTENT_IP, NULL);
 }
 
+
+/**
+ * arv_gv_device_set_persistent_ip_from_string:
+ * @gv_device: a #ArvGvDevice
+ * @ip: IPv4 address in string format
+ * @mask: netmask in string format
+ * @gateway: Gateway IPv4 address in string format
+ * @error: a #GError placeholder, %NULL to ignore
+ *
+ * Sets the persistent IP address to device.
+ *
+ * Since: 0.8.22
+ */
+
+void
+arv_gv_device_set_persistent_ip_from_string (ArvGvDevice *gv_device,
+                                             const char *ip, const char *mask, const char *gateway,
+                                             GError **error)
+{
+	GError *local_error = NULL;
+	GInetAddress *ip_gi = NULL;
+	GInetAddressMask *mask_gi = NULL;
+	GInetAddress *gateway_gi = NULL;
+
+	g_return_if_fail (ARV_IS_GV_DEVICE (gv_device));
+
+	ip_gi = g_inet_address_new_from_string (ip);
+	mask_gi = g_inet_address_mask_new_from_string (mask, NULL);
+	gateway_gi = g_inet_address_new_from_string (gateway);
+
+	if (ip_gi == NULL) {
+		local_error = g_error_new (ARV_DEVICE_ERROR, ARV_DEVICE_ERROR_INVALID_PARAMETER,
+                                           "IP address could not be parsed: \"%s\"", ip);
+	}else if (mask_gi == NULL) {
+		local_error = g_error_new (ARV_DEVICE_ERROR, ARV_DEVICE_ERROR_INVALID_PARAMETER,
+                                           "Netmask could not be parsed: \"%s\"", mask);
+	}else if (gateway_gi == NULL) {
+		local_error = g_error_new (ARV_DEVICE_ERROR, ARV_DEVICE_ERROR_INVALID_PARAMETER,
+                                           "Gateway address could not be parsed: \"%s\"", gateway);
+	}
+	if (local_error != NULL){
+		g_propagate_error (error, local_error);
+		g_clear_object (&ip_gi);
+		g_clear_object (&mask_gi);
+		g_clear_object (&gateway_gi);
+		return;
+	}
+	arv_gv_device_set_persistent_ip (gv_device, ip_gi, mask_gi, gateway_gi, error);
+	g_object_unref (ip_gi);
+	g_object_unref (mask_gi);
+	g_object_unref (gateway_gi);
+}
+
 /**
  * arv_gv_device_get_ip_configuration_mode:
  * @gv_device: a #ArvGvDevice

--- a/src/arvgvdevice.c
+++ b/src/arvgvdevice.c
@@ -791,9 +791,9 @@ arv_gv_device_set_packet_size_adjustment (ArvGvDevice *gv_device, ArvGvPacketSiz
  * arv_gv_device_get_persistent_ip:
  * @gv_device: a #ArvGvDevice
  * @ip: (out): a IP address placeholder
- * @mask: (out) (optional): a netmask placeholder, %NULL to ignore
- * @gateway: (out) (optional): a gateway IP address placeholder, %NULL to ignore
- * @error: a #GError placeholder, %NULL to ignore
+ * @mask: (out) (optional): a netmask placeholder
+ * @gateway: (out) (optional): a gateway IP address placeholder
+ * @error: a #GError placeholder
  *
  * Get the persistent IP address setting of device.
  *
@@ -842,10 +842,10 @@ arv_gv_device_get_persistent_ip (ArvGvDevice *gv_device,
 /**
  * arv_gv_device_set_persistent_ip:
  * @gv_device: a #ArvGvDevice
- * @ip: IPv4 address
- * @mask: Netmask
- * @gateway: Gateway IPv4 address
- * @error: a #GError placeholder, %NULL to ignore
+ * @ip: (nullable): IPv4 address
+ * @mask: (nullable): Netmask
+ * @gateway: (nullable): Gateway IPv4 address
+ * @error: a #GError placeholder
  *
  * Sets the persistent IP address to device.
  * Also disable DHCP then enable persistent IP mode.
@@ -858,70 +858,97 @@ arv_gv_device_set_persistent_ip (ArvGvDevice *gv_device,
                                  GInetAddress *ip, GInetAddressMask *mask, GInetAddress *gateway,
                                  GError **error)
 {
-	const guint8 *ip_bytes;
-	guint mask_length;
-	const guint8 *gateway_bytes;
-	guint32 ip_int;
-	guint32 mask_int;
-	guint32 gateway_int;
-	guint32 be_value;
-	const guint8 *mask_bytes;
-
 	g_return_if_fail (ARV_IS_GV_DEVICE (gv_device));
 
-	g_return_if_fail (G_IS_INET_ADDRESS (ip));
-	g_return_if_fail (G_IS_INET_ADDRESS_MASK (mask));
-	g_return_if_fail (G_IS_INET_ADDRESS (gateway));
+	if (G_IS_INET_ADDRESS (ip)) {
+		GError *local_error = NULL;
+		const guint8 *ip_bytes;
+		guint32 be_value;
+		guint32 ip_int;
 
-	/* GigEVision specification does not support IPv6 */
-	if (g_inet_address_get_family (ip) != G_SOCKET_FAMILY_IPV4) {
-		g_set_error (error, ARV_DEVICE_ERROR, ARV_DEVICE_ERROR_INVALID_PARAMETER,
-				     "IP address is not IPv4 address");
-		return;
+		/* GigEVision specification does not support IPv6 */
+		if (g_inet_address_get_family (ip) != G_SOCKET_FAMILY_IPV4) {
+			g_set_error (error, ARV_DEVICE_ERROR, ARV_DEVICE_ERROR_INVALID_PARAMETER,
+						"IP address is not IPv4 address");
+			return;
+		}
+
+		ip_bytes = g_inet_address_to_bytes (ip);
+		be_value = ((guint32)ip_bytes[3] << 24) | (ip_bytes[2] << 16) | (ip_bytes[1] << 8) | ip_bytes[0];
+		ip_int = GUINT32_FROM_BE(be_value);
+
+		arv_device_set_integer_feature_value (ARV_DEVICE (gv_device), "GevPersistentIPAddress", ip_int, &local_error);
+		if (local_error != NULL) {
+			g_propagate_error(error, local_error);
+			return;
+		}
 	}
-	if (g_inet_address_mask_get_family (mask) != G_SOCKET_FAMILY_IPV4) {
-		g_set_error (error, ARV_DEVICE_ERROR, ARV_DEVICE_ERROR_INVALID_PARAMETER,
-					 "Netmask is not IPv4 address");
-		return;
+
+	if (G_IS_INET_ADDRESS_MASK (mask)) {
+		GError *local_error = NULL;
+		const guint8 *mask_bytes;
+		guint32 be_value;
+		guint mask_length;
+		guint32 mask_int;
+
+		/* GigEVision specification does not support IPv6 */
+		if (g_inet_address_mask_get_family (mask) != G_SOCKET_FAMILY_IPV4) {
+			g_set_error (error, ARV_DEVICE_ERROR, ARV_DEVICE_ERROR_INVALID_PARAMETER,
+						"Netmask is not IPv4 address");
+			return;
+		}
+
+		mask_length = g_inet_address_mask_get_length (mask);
+		mask_bytes = g_inet_address_to_bytes (g_inet_address_mask_get_address (mask));
+
+		if (mask_length == 32) {
+			/* Bitmask format (255.255.255.0) */
+			be_value = ((guint32)mask_bytes[3] << 24) | (mask_bytes[2] << 16) | (mask_bytes[1] << 8) | mask_bytes[0];
+		} else {
+			/* CIDR(slash) format (192.168.1.0/24) */
+			be_value = ~(~(guint32)0 >> mask_length);
+		}
+		mask_int = GUINT32_FROM_BE(be_value);
+		arv_device_set_integer_feature_value (ARV_DEVICE (gv_device), "GevPersistentSubnetMask", mask_int, &local_error);
+		if (local_error != NULL) {
+			g_propagate_error(error, local_error);
+			return;
+		}
 	}
-	if (g_inet_address_get_family (gateway) != G_SOCKET_FAMILY_IPV4) {
-		g_set_error (error, ARV_DEVICE_ERROR, ARV_DEVICE_ERROR_INVALID_PARAMETER,
-					 "Gateway address is not IPv4 address");
-		return;
+
+	if (G_IS_INET_ADDRESS (gateway)) {
+		GError *local_error = NULL;
+		const guint8 *gateway_bytes;
+		guint32 be_value;
+		guint32 gateway_int;
+
+		/* GigEVision specification does not support IPv6 */
+		if (g_inet_address_get_family (gateway) != G_SOCKET_FAMILY_IPV4) {
+			g_set_error (error, ARV_DEVICE_ERROR, ARV_DEVICE_ERROR_INVALID_PARAMETER,
+						"Gateway address is not IPv4 address");
+			return;
+		}
+
+		gateway_bytes = g_inet_address_to_bytes (gateway);
+		be_value = ((guint32)gateway_bytes[3] << 24) | (gateway_bytes[2] << 16) | (gateway_bytes[1] << 8) | gateway_bytes[0];
+		gateway_int = GUINT32_FROM_BE(be_value);
+		arv_device_set_integer_feature_value (ARV_DEVICE (gv_device), "GevPersistentDefaultGateway", gateway_int, &local_error);
+		if (local_error != NULL) {
+			g_propagate_error(error, local_error);
+			return;
+		}
 	}
 
-	ip_bytes = g_inet_address_to_bytes (ip);
-	mask_length = g_inet_address_mask_get_length (mask);
-	mask_bytes = g_inet_address_to_bytes (g_inet_address_mask_get_address (mask));
-	gateway_bytes = g_inet_address_to_bytes (gateway);
-
-	be_value = ((guint32)ip_bytes[0] << 24) | (ip_bytes[1] << 16) | (ip_bytes[2] << 8) | ip_bytes[3];
-	ip_int = GUINT32_FROM_BE(be_value);
-	if (mask_length == 32) {
-		/* Bitmask format (255.255.255.0) */
-		be_value = ((guint32)mask_bytes[0] << 24) | (mask_bytes[1] << 16) | (mask_bytes[2] << 8) | mask_bytes[3];
-	} else {
-		/* CIDR(slash) format (192.168.1.0/24) */
-		be_value = ~(~(guint32)0 >> mask_length);
-	}
-	mask_int = GUINT32_FROM_BE(be_value);
-
-	be_value = ((guint32)gateway_bytes[0] << 24) | (gateway_bytes[1] << 16) | (gateway_bytes[2] << 8) | gateway_bytes[3];
-	gateway_int = GUINT32_FROM_BE(be_value);
-
-	arv_device_set_integer_feature_value (ARV_DEVICE (gv_device), "GevPersistentIPAddress", ip_int, NULL);
-	arv_device_set_integer_feature_value (ARV_DEVICE (gv_device), "GevPersistentSubnetMask", mask_int, NULL);
-	arv_device_set_integer_feature_value (ARV_DEVICE (gv_device), "GevPersistentDefaultGateway", gateway_int, NULL);
-	arv_gv_device_set_ip_configuration_mode (gv_device, ARV_GV_IP_CONFIGURATION_MODE_PERSISTENT_IP, NULL);
+	arv_gv_device_set_ip_configuration_mode (gv_device, ARV_GV_IP_CONFIGURATION_MODE_PERSISTENT_IP, error);
 }
 
 
 /**
  * arv_gv_device_set_persistent_ip_from_string:
  * @gv_device: a #ArvGvDevice
- * @ip: IPv4 address in string format
- * @mask: netmask in string format
- * @gateway: Gateway IPv4 address in string format
+ * @ip: (nullable): IPv4 address in string format
+ * @mask: (nullable): netmask in string format
+ * @gateway: (nullable): Gateway IPv4 address in string format
  * @error: a #GError placeholder, %NULL to ignore
  *
  * Sets the persistent IP address to device.
@@ -941,17 +968,22 @@ arv_gv_device_set_persistent_ip_from_string (ArvGvDevice *gv_device,
 
 	g_return_if_fail (ARV_IS_GV_DEVICE (gv_device));
 
-	ip_gi = g_inet_address_new_from_string (ip);
-	mask_gi = g_inet_address_mask_new_from_string (mask, NULL);
-	gateway_gi = g_inet_address_new_from_string (gateway);
+	if (ip != NULL)
+		ip_gi = g_inet_address_new_from_string (ip);
 
-	if (ip_gi == NULL) {
+	if (mask != NULL)
+		mask_gi = g_inet_address_mask_new_from_string (mask, NULL);
+
+	if (gateway != NULL)
+		gateway_gi = g_inet_address_new_from_string (gateway);
+
+	if (ip != NULL && ip_gi == NULL) {
 		local_error = g_error_new (ARV_DEVICE_ERROR, ARV_DEVICE_ERROR_INVALID_PARAMETER,
                                            "IP address could not be parsed: \"%s\"", ip);
-	}else if (mask_gi == NULL) {
+	} else if (mask != NULL && mask_gi == NULL) {
 		local_error = g_error_new (ARV_DEVICE_ERROR, ARV_DEVICE_ERROR_INVALID_PARAMETER,
                                            "Netmask could not be parsed: \"%s\"", mask);
-	}else if (gateway_gi == NULL) {
+	} else if (gateway != NULL && gateway_gi == NULL) {
 		local_error = g_error_new (ARV_DEVICE_ERROR, ARV_DEVICE_ERROR_INVALID_PARAMETER,
                                            "Gateway address could not be parsed: \"%s\"", gateway);
 	}
@@ -963,9 +995,9 @@ arv_gv_device_set_persistent_ip_from_string (ArvGvDevice *gv_device,
 		return;
 	}
 	arv_gv_device_set_persistent_ip (gv_device, ip_gi, mask_gi, gateway_gi, error);
-	g_object_unref (ip_gi);
-	g_object_unref (mask_gi);
-	g_object_unref (gateway_gi);
+	g_clear_object (&ip_gi);
+	g_clear_object (&mask_gi);
+	g_clear_object (&gateway_gi);
 }
 
 /**

--- a/src/arvgvdevice.c
+++ b/src/arvgvdevice.c
@@ -788,6 +788,58 @@ arv_gv_device_set_packet_size_adjustment (ArvGvDevice *gv_device, ArvGvPacketSiz
 }
 
 /**
+ * arv_gv_device_get_current_ip:
+ * @gv_device: a #ArvGvDevice
+ * @ip: (out): a IP address placeholder
+ * @mask: (out) (optional): a netmask placeholder
+ * @gateway: (out) (optional): a gateway IP address placeholder
+ * @error: a #GError placeholder, %NULL to ignore
+ *
+ * Get the current IP address setting of device.
+ *
+ * Since: 0.8.22
+ */
+
+void
+arv_gv_device_get_current_ip (ArvGvDevice *gv_device,
+                              GInetAddress **ip, GInetAddressMask **mask, GInetAddress **gateway,
+                              GError **error)
+{
+	guint32 be_ip_int;
+	guint32 be_mask_int;
+	guint32 be_gateway_int;
+	guint32 value;
+	GInetAddress *netmask;
+
+	g_return_if_fail (ARV_IS_GV_DEVICE (gv_device));
+	g_return_if_fail (ip != NULL);
+
+	value = arv_device_get_integer_feature_value (ARV_DEVICE (gv_device),
+                                                      "GevCurrentIPAddress", NULL);
+	be_ip_int = g_htonl(value);
+
+	*ip = g_inet_address_new_from_bytes ((guint8 *) &be_ip_int, G_SOCKET_FAMILY_IPV4);
+
+	if (mask != NULL) {
+		value = arv_device_get_integer_feature_value (ARV_DEVICE (gv_device),
+                                                              "GevCurrentSubnetMask", NULL);
+		be_mask_int = g_htonl(value);
+
+		netmask = g_inet_address_new_from_bytes ((guint8 *) &be_mask_int, G_SOCKET_FAMILY_IPV4);
+		*mask = g_inet_address_mask_new (netmask, 32, NULL);
+		g_object_unref (netmask);
+	}
+
+	if (gateway != NULL) {
+		value = arv_device_get_integer_feature_value (ARV_DEVICE (gv_device),
+                                                              "GevCurrentDefaultGateway", NULL);
+		be_gateway_int = g_htonl(value);
+
+		*gateway = g_inet_address_new_from_bytes ((guint8 *) &be_gateway_int, G_SOCKET_FAMILY_IPV4);
+	}
+}
+
+/**
  * arv_gv_device_get_persistent_ip:
  * @gv_device: a #ArvGvDevice
  * @ip: (out): a IP address placeholder

--- a/src/arvgvdevice.h
+++ b/src/arvgvdevice.h
@@ -90,6 +90,7 @@ ARV_API void			arv_gv_device_set_stream_options		(ArvGvDevice *gv_device, ArvGvS
 
 ARV_API void			arv_gv_device_get_persistent_ip			(ArvGvDevice *gv_device, GInetAddress **ip, GInetAddressMask **mask, GInetAddress **gateway, GError **error);
 ARV_API void			arv_gv_device_set_persistent_ip			(ArvGvDevice *gv_device, GInetAddress *ip, GInetAddressMask *mask, GInetAddress *gateway, GError **error);
+ARV_API void			arv_gv_device_set_persistent_ip_from_string	(ArvGvDevice *gv_device, const char *ip, const char *mask, const char *gateway, GError **error);
 ARV_API ArvGvIpConfigurationMode	arv_gv_device_get_ip_configuration_mode	(ArvGvDevice *gv_device, GError **error);
 ARV_API void			arv_gv_device_set_ip_configuration_mode		(ArvGvDevice *gv_device, ArvGvIpConfigurationMode mode, GError **error);
 

--- a/src/arvgvdevice.h
+++ b/src/arvgvdevice.h
@@ -88,6 +88,7 @@ ARV_API guint			arv_gv_device_auto_packet_size			(ArvGvDevice *gv_device, GError
 ARV_API ArvGvStreamOption	arv_gv_device_get_stream_options		(ArvGvDevice *gv_device);
 ARV_API void			arv_gv_device_set_stream_options		(ArvGvDevice *gv_device, ArvGvStreamOption options);
 
+ARV_API void			arv_gv_device_get_current_ip			(ArvGvDevice *gv_device, GInetAddress **ip, GInetAddressMask **mask, GInetAddress **gateway, GError **error);
 ARV_API void			arv_gv_device_get_persistent_ip			(ArvGvDevice *gv_device, GInetAddress **ip, GInetAddressMask **mask, GInetAddress **gateway, GError **error);
 ARV_API void			arv_gv_device_set_persistent_ip			(ArvGvDevice *gv_device, GInetAddress *ip, GInetAddressMask *mask, GInetAddress *gateway, GError **error);
 ARV_API void			arv_gv_device_set_persistent_ip_from_string	(ArvGvDevice *gv_device, const char *ip, const char *mask, const char *gateway, GError **error);


### PR DESCRIPTION
As mentioned here https://github.com/AravisProject/aravis/issues/688 I have added a `network` command to `arvtool`.

I have several remarks:

* Please check the error usage, I am not sure on how to handle errors correctly
* Please check memory management to check if there are memory leaks with glib interactions.
* I am not sure on how to document the new arvtool API
* Should the `network` command support setting several parameters on one line like the `control` command?
* I have a version of the `ip` sub-command with ip, mask and gateway separated with a coma. is this acceptable?
* The `ip` only sub-command prints all three settings (ip, mask, gateway) while `mask` and `gateway` only print their setting. Should I change that?
* `arv_gv_device_get_persistent_ip` always return the IP address but in some cases, I don't use it, is it ok or should I make it optional like the `mask` and `gateway`?
* I had to change this line (and related):
    https://github.com/AravisProject/aravis/blob/af9a095479cce8cff22a538124732eb20bb3ed5f/src/arvgvdevice.c#L898
    By this one:
    ```c++
    be_value = ((guint32)ip_bytes[3] << 24) | (ip_bytes[2] << 16) | (ip_bytes[1] << 8) | ip_bytes[0];
    ```
    Otherwise the set IP was `10.0.168.192` instead of `192.168.0.10`.

