### PR TITLE
ci: enable gst-plugin in msvc pipeline

### DIFF
--- a/.github/workflows/aravis-msvc.yml
+++ b/.github/workflows/aravis-msvc.yml
@@ -22,6 +22,9 @@ jobs:
     - name: pip
       run: |
         pip install conan
+    - name: disable-perl
+      run: |
+        rm -r C:\Strawberry\perl
     - name: checkout
       uses: actions/checkout@v2
     - name: conan
@@ -31,8 +34,8 @@ jobs:
           libiconv/1.17
           glib/2.70.0
           #gobject-introspection/1.69.0
-          #gstreamer/1.19.1
-          #gst-plugins-base/1.19.1
+          gstreamer/1.19.1
+          gst-plugins-base/1.19.1
           #gtk/4.4.0
           libxml2/2.9.12
           zlib/1.2.11
@@ -40,6 +43,7 @@ jobs:
 
           [build_requires]
           meson/0.59.2
+          pkgconf/1.7.4
 
           [generators]
           pkg_config


### PR DESCRIPTION
in msvc pipeline

1. disabled strawberry perl and added pkg-config on conanfile
2. enabled gst-plugin

---

1. somehow the latest meason does not support pkg-config bundled with strawberry perl. So removed directory under `C:\Strawberry\perl`

Runner image of [Microsoft Windows Server 2019 Datacenter](https://github.com/actions/runner-images/blob/main/images/win/Windows2019-Readme.md) has Perl 5.32.1 as a default and it is located under `C:\Strawberry\perl`

![image](https://user-images.githubusercontent.com/64802768/188021382-7dd6b0c1-bdd1-473d-abf0-157cd4d0852a.png)

2.  pkg-config installed as dependencies with conan now can find glib-2.0 and gst-plugins-base is successfully installed