### PR TITLE
Fix crash when using stream callback in Python

### DIFF
--- a/src/arvcamera.c
+++ b/src/arvcamera.c
@@ -137,7 +137,7 @@ enum
 };
 
 /**
- * arv_camera_create_stream:
+ * arv_camera_create_stream: (skip)
  * @camera: a #ArvCamera
  * @callback: (scope call) (allow-none): a frame processing callback
  * @user_data: (closure) (allow-none): user data for @callback
@@ -154,11 +154,33 @@ enum
 ArvStream *
 arv_camera_create_stream (ArvCamera *camera, ArvStreamCallback callback, gpointer user_data, GError **error)
 {
+	return arv_camera_create_stream_full(camera, callback, user_data, NULL, error);
+}
+
+/**
+ * arv_camera_create_stream_full: (rename-to arv_camera_create_stream)
+ * @camera: a #ArvCamera
+ * @callback: (scope notified) (allow-none): a frame processing callback
+ * @user_data: (closure) (allow-none): user data for @callback
+ * @destroy: a #GDestroyNotify placeholder, %NULL to ignore
+ * @error: a #GError placeholder, %NULL to ignore
+ *
+ * Creates a new [class@ArvStream] for video stream reception. See
+ * [callback@ArvStreamCallback] for details regarding the callback function.
+ *
+ * Returns: (transfer full): a new [class@ArvStream], to be freed after use with [method@GObject.Object.unref].
+ *
+ * Since: 0.2.0
+ */
+
+ArvStream *
+arv_camera_create_stream_full (ArvCamera *camera, ArvStreamCallback callback, gpointer user_data, GDestroyNotify destroy, GError **error)
+{
 	ArvCameraPrivate *priv = arv_camera_get_instance_private (camera);
 
 	g_return_val_if_fail (ARV_IS_CAMERA (camera), NULL);
 
-	return arv_device_create_stream (priv->device, callback, user_data, error);
+	return arv_device_create_stream_full (priv->device, callback, user_data, destroy, error);
 }
 
 /* Device control */

--- a/src/arvcamera.c
+++ b/src/arvcamera.c
@@ -170,7 +170,7 @@ arv_camera_create_stream (ArvCamera *camera, ArvStreamCallback callback, gpointe
  *
  * Returns: (transfer full): a new [class@ArvStream], to be freed after use with [method@GObject.Object.unref].
  *
- * Since: 0.2.0
+ * Since: 0.8.23
  */
 
 ArvStream *

--- a/src/arvcamera.h
+++ b/src/arvcamera.h
@@ -47,6 +47,7 @@ ARV_API ArvCamera *	arv_camera_new_with_device	(ArvDevice *device, GError **erro
 ARV_API ArvDevice *	arv_camera_get_device		(ArvCamera *camera);
 
 ARV_API ArvStream *	arv_camera_create_stream	(ArvCamera *camera, ArvStreamCallback callback, void *user_data, GError **error);
+ARV_API ArvStream *	arv_camera_create_stream_full	(ArvCamera *camera, ArvStreamCallback callback, void *user_data, GDestroyNotify destroy, GError **error);
 
 /* Device informations */
 

--- a/src/arvdevice.c
+++ b/src/arvdevice.c
@@ -99,7 +99,7 @@ arv_device_create_stream (ArvDevice *device, ArvStreamCallback callback, void *u
  *
  * Return value: (transfer full): a new #ArvStream.
  *
- * Since: 0.2.0
+ * Since: 0.8.23
  */
 
 ArvStream *

--- a/src/arvdevice.c
+++ b/src/arvdevice.c
@@ -66,7 +66,7 @@ G_DEFINE_ABSTRACT_TYPE_WITH_CODE (ArvDevice, arv_device, G_TYPE_OBJECT,
 				  G_IMPLEMENT_INTERFACE (G_TYPE_INITABLE, arv_device_initable_iface_init))
 
 /**
- * arv_device_create_stream:
+ * arv_device_create_stream: (skip)
  * @device: a #ArvDevice
  * @callback: (scope call): a frame processing callback
  * @user_data: (allow-none) (closure): user data for @callback
@@ -83,9 +83,31 @@ G_DEFINE_ABSTRACT_TYPE_WITH_CODE (ArvDevice, arv_device, G_TYPE_OBJECT,
 ArvStream *
 arv_device_create_stream (ArvDevice *device, ArvStreamCallback callback, void *user_data, GError **error)
 {
+	return arv_device_create_stream_full(device, callback, user_data, NULL, error);
+}
+
+/**
+ * arv_device_create_stream_full: (rename-to arv_device_create_stream)
+ * @device: a #ArvDevice
+ * @callback: (scope notified): a frame processing callback
+ * @user_data: (allow-none) (closure): user data for @callback
+ * @destroy: a #GDestroyNotify placeholder, %NULL to ignore
+ * @error: a #GError placeholder, %NULL to ignore
+ *
+ * Creates a new #ArvStream for video stream handling. See
+ * @ArvStreamCallback for details regarding the callback function.
+ *
+ * Return value: (transfer full): a new #ArvStream.
+ *
+ * Since: 0.2.0
+ */
+
+ArvStream *
+arv_device_create_stream_full (ArvDevice *device, ArvStreamCallback callback, void *user_data, GDestroyNotify destroy, GError **error)
+{
 	g_return_val_if_fail (ARV_IS_DEVICE (device), NULL);
 
-	return ARV_DEVICE_GET_CLASS (device)->create_stream (device, callback, user_data, error);
+	return ARV_DEVICE_GET_CLASS (device)->create_stream (device, callback, user_data, destroy, error);
 }
 
 /**

--- a/src/arvdevice.h
+++ b/src/arvdevice.h
@@ -76,7 +76,7 @@ ARV_API G_DECLARE_DERIVABLE_TYPE (ArvDevice, arv_device, ARV, DEVICE, GObject)
 struct _ArvDeviceClass {
 	GObjectClass parent_class;
 
-	ArvStream *	(*create_stream)	(ArvDevice *device, ArvStreamCallback callback, void *user_data, GError **error);
+	ArvStream *	(*create_stream)	(ArvDevice *device, ArvStreamCallback callback, void *user_data, GDestroyNotify destroy, GError **error);
 
 	const char *	(*get_genicam_xml)	(ArvDevice *device, size_t *size);
 	ArvGc *		(*get_genicam)		(ArvDevice *device);
@@ -91,6 +91,7 @@ struct _ArvDeviceClass {
 };
 
 ARV_API ArvStream *	arv_device_create_stream		(ArvDevice *device, ArvStreamCallback callback, void *user_data, GError **error);
+ARV_API ArvStream *	arv_device_create_stream_full		(ArvDevice *device, ArvStreamCallback callback, void *user_data, GDestroyNotify destroy, GError **error);
 
 ARV_API gboolean	arv_device_read_memory			(ArvDevice *device, guint64 address, guint32 size, void *buffer, GError **error);
 ARV_API gboolean	arv_device_write_memory			(ArvDevice *device, guint64 address, guint32 size, void *buffer, GError **error);

--- a/src/arvfakedevice.c
+++ b/src/arvfakedevice.c
@@ -59,9 +59,9 @@ G_DEFINE_TYPE_WITH_CODE (ArvFakeDevice, arv_fake_device, ARV_TYPE_DEVICE, G_ADD_
 /* ArvDevice implemenation */
 
 static ArvStream *
-arv_fake_device_create_stream (ArvDevice *device, ArvStreamCallback callback, void *user_data, GError **error)
+arv_fake_device_create_stream (ArvDevice *device, ArvStreamCallback callback, void *user_data, GDestroyNotify destroy, GError **error)
 {
-	return arv_fake_stream_new (ARV_FAKE_DEVICE (device), callback, user_data, error);
+	return arv_fake_stream_new (ARV_FAKE_DEVICE (device), callback, user_data, destroy, error);
 }
 
 static const char *

--- a/src/arvfakestream.c
+++ b/src/arvfakestream.c
@@ -161,12 +161,13 @@ arv_fake_stream_stop_thread (ArvStream *stream)
  */
 
 ArvStream *
-arv_fake_stream_new (ArvFakeDevice *device, ArvStreamCallback callback, void *callback_data, GError **error)
+arv_fake_stream_new (ArvFakeDevice *device, ArvStreamCallback callback, void *callback_data, GDestroyNotify destroy, GError **error)
 {
 	return g_initable_new (ARV_TYPE_FAKE_STREAM, NULL, error,
 			       "device", device,
 			       "callback", callback,
 			       "callback-data", callback_data,
+						 "destroy-notify", destroy,
 			       NULL);
 }
 

--- a/src/arvfakestreamprivate.h
+++ b/src/arvfakestreamprivate.h
@@ -32,7 +32,7 @@
 
 G_BEGIN_DECLS
 
-ArvStream * 	arv_fake_stream_new	(ArvFakeDevice *device, ArvStreamCallback callback, void *callback_data, GError **error);
+ArvStream * 	arv_fake_stream_new	(ArvFakeDevice *device, ArvStreamCallback callback, void *callback_data, GDestroyNotify destroy, GError **error);
 
 G_END_DECLS
 

--- a/src/arvgvdevice.c
+++ b/src/arvgvdevice.c
@@ -1607,7 +1607,7 @@ arv_gv_device_load_genicam (ArvGvDevice *gv_device, GError **error)
 /* ArvDevice implemenation */
 
 static ArvStream *
-arv_gv_device_create_stream (ArvDevice *device, ArvStreamCallback callback, void *user_data, GError **error)
+arv_gv_device_create_stream (ArvDevice *device, ArvStreamCallback callback, void *user_data, GDestroyNotify destroy, GError **error)
 {
 	ArvGvDevice *gv_device = ARV_GV_DEVICE (device);
 	ArvGvDevicePrivate *priv = arv_gv_device_get_instance_private (gv_device);
@@ -1645,7 +1645,7 @@ arv_gv_device_create_stream (ArvDevice *device, ArvStreamCallback callback, void
 		}
 	}
 
-	stream = arv_gv_stream_new (gv_device, callback, user_data, error);
+	stream = arv_gv_stream_new (gv_device, callback, user_data, destroy, error);
 	if (!ARV_IS_STREAM (stream))
 		return NULL;
 

--- a/src/arvgvstream.c
+++ b/src/arvgvstream.c
@@ -1247,12 +1247,13 @@ arv_gv_stream_stop_thread (ArvStream *stream)
  */
 
 ArvStream *
-arv_gv_stream_new (ArvGvDevice *gv_device, ArvStreamCallback callback, void *callback_data, GError **error)
+arv_gv_stream_new (ArvGvDevice *gv_device, ArvStreamCallback callback, void *callback_data, GDestroyNotify destroy, GError **error)
 {
 	return g_initable_new (ARV_TYPE_GV_STREAM, NULL, error,
 			       "device", gv_device,
 			       "callback", callback,
 			       "callback-data", callback_data,
+						 "destroy-notify", destroy,
 			       NULL);
 }
 

--- a/src/arvgvstreamprivate.h
+++ b/src/arvgvstreamprivate.h
@@ -35,7 +35,7 @@ G_BEGIN_DECLS
 #define ARV_GV_STREAM_FRAME_RETENTION_US_DEFAULT	100000
 #define ARV_GV_STREAM_PACKET_REQUEST_RATIO_DEFAULT	0.25
 
-ArvStream * 	arv_gv_stream_new		(ArvGvDevice *gv_device, ArvStreamCallback callback, void *callback_data, GError **error);
+ArvStream * 	arv_gv_stream_new		(ArvGvDevice *gv_device, ArvStreamCallback callback, void *callback_data, GDestroyNotify destroy, GError **error);
 
 G_END_DECLS
 

--- a/src/arvuvdevice.c
+++ b/src/arvuvdevice.c
@@ -167,10 +167,10 @@ arv_uv_device_bulk_transfer (ArvUvDevice *uv_device, ArvUvEndpointType endpoint_
 }
 
 static ArvStream *
-arv_uv_device_create_stream (ArvDevice *device, ArvStreamCallback callback, void *user_data, GError **error)
+arv_uv_device_create_stream (ArvDevice *device, ArvStreamCallback callback, void *user_data, GDestroyNotify destroy, GError **error)
 {
 	ArvUvDevicePrivate *priv = arv_uv_device_get_instance_private (ARV_UV_DEVICE (device));
-	return arv_uv_stream_new (ARV_UV_DEVICE (device), callback, user_data, priv->usb_mode, error);
+	return arv_uv_stream_new (ARV_UV_DEVICE (device), callback, user_data, destroy, priv->usb_mode, error);
 }
 
 static gboolean

--- a/src/arvuvstream.c
+++ b/src/arvuvstream.c
@@ -792,13 +792,14 @@ arv_uv_stream_stop_thread (ArvStream *stream)
  */
 
 ArvStream *
-arv_uv_stream_new (ArvUvDevice *uv_device, ArvStreamCallback callback, void *callback_data,
+arv_uv_stream_new (ArvUvDevice *uv_device, ArvStreamCallback callback, void *callback_data, GDestroyNotify destroy,
                    ArvUvUsbMode usb_mode, GError **error)
 {
 	return g_initable_new (ARV_TYPE_UV_STREAM, NULL, error,
 			       "device", uv_device,
 			       "callback", callback,
 			       "callback-data", callback_data,
+						 "destroy-notify", destroy,
 			       "usb-mode", usb_mode,
 			       NULL);
 }

--- a/src/arvuvstreamprivate.h
+++ b/src/arvuvstreamprivate.h
@@ -33,7 +33,7 @@
 
 G_BEGIN_DECLS
 
-ArvStream * 	arv_uv_stream_new	(ArvUvDevice *uv_device, ArvStreamCallback callback, void *user_data,
+ArvStream * 	arv_uv_stream_new	(ArvUvDevice *uv_device, ArvStreamCallback callback, void *user_data, GDestroyNotify destroy,
                                          ArvUvUsbMode usb_mode, GError **error);
 
 G_END_DECLS

--- a/tests/python/arv-stream-callback.py
+++ b/tests/python/arv-stream-callback.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+
+#  If you have installed aravis in a non standard location, you may need
+#   to make GI_TYPELIB_PATH point to the correct location. For example:
+#
+#   export GI_TYPELIB_PATH=$GI_TYPELIB_PATH:/opt/bin/lib/girepositry-1.0/
+#
+#  You may also have to give the path to libaravis.so, using LD_PRELOAD or
+#  LD_LIBRARY_PATH.
+
+import threading
+import time
+
+import gi
+# autopep8: off
+gi.require_version('Aravis', '0.8')
+from gi.repository import Aravis  # noqa: E402
+# autopep8: on
+
+Aravis.enable_interface('Fake')
+
+
+class UserData:
+
+    def __init__(self) -> None:
+        self.stream = None
+
+
+def callback(user_data, cb_type, buffer):
+    print(f'Callback[{threading.get_native_id()}] {cb_type.value_name} {buffer=}')
+    if buffer is not None:
+        # Fake some light computation here (like copying the buffer). Do not do heavy image processing here
+        # since it would block the acquisition thread.
+        time.sleep(0.01)
+        # Re-enqueue the buffer
+        user_data.stream.push_buffer(buffer)
+
+
+print(f'Main thread[{threading.get_native_id()}]')
+cam = Aravis.Camera.new('Fake_1')
+
+user_data = UserData()
+stream = cam.create_stream(callback, user_data)
+user_data.stream = stream
+
+payload = cam.get_payload()
+stream.push_buffer(Aravis.Buffer.new_allocate(payload))
+
+cam.start_acquisition()
+time.sleep(1)
+cam.stop_acquisition()


### PR DESCRIPTION
This PR should fix the crash seen in #453. The crash was caused by `ArvStreamCallback` only living for the time of the call to `arv_camera_create_stream` because of `(scope call)`. Using `(scope notified)` allows us to control the lifetime of the callback.

Also added a small Python sample showing how to use stream callback.

:warning: GObject & GLib noob here, careful review required.