### PR TITLE
ci: enabled gst-plugin for MSVC build; contd from #712

### DIFF
--- a/.github/workflows/aravis-msvc.yml
+++ b/.github/workflows/aravis-msvc.yml
@@ -64,7 +64,7 @@ jobs:
         .\build\activate_build.ps1
         .\build\activate_run.ps1
         echo "::group::configure"
-        meson --prefix ${{ github.workspace }}\install --buildtype ${{ matrix.build_type_meson }} --pkg-config-path ${{ github.workspace }}\build -Ddocumentation=disabled -Dgst-plugin=disabled -Dintrospection=disabled -Dusb=enabled -Dviewer=disabled -Dgv-n-buffers=1 . .\build
+        meson --prefix ${{ github.workspace }}\install --buildtype ${{ matrix.build_type_meson }} --pkg-config-path ${{ github.workspace }}\build -Ddocumentation=disabled -Dgst-plugin=enabled -Dintrospection=disabled -Dusb=enabled -Dviewer=disabled -Dgv-n-buffers=1 . .\build
         echo "::endgroup::"
         echo "::group::compile"
         meson compile -C .\build -v


### PR DESCRIPTION
enabled gst-plugin for MSVC build, which could work since #712 


Sidenote: 

1. gobject-introspection is NOT supported on Conan for Windows, so introspection is still disabled.
2. According to the following conflict between dependencies, viewer is still disabled.
 
`'gtk/4.4.0' requires 'pango/1.50.7' while 'gst-plugins-base/1.19.1' requires 'pango/1.49.3'.`