### PR TITLE
gvdevice: improve auto packet size

### DIFF
--- a/src/arvgvspprivate.h
+++ b/src/arvgvspprivate.h
@@ -167,6 +167,12 @@ typedef struct {
 	guint8 header[];
 } ArvGvspPacket;
 
+/* Minimum ethernet frame size minus ethernet protocol overhead */
+#define ARV_GVSP_MINIMUM_PACKET_SIZE                    (64 - 14 - 4)
+/* Maximum ethernet frame size minus ethernet protocol overhead */
+#define ARV_GVSP_MAXIMUM_PACKET_SIZE                    (65536 - 14 - 4)
+ /* IP + UDP */
+#define ARV_GVSP_PACKET_UDP_OVERHEAD    		(20 + 8)
  /* IP + UDP + GVSP headers */
 #define ARV_GVSP_PACKET_PROTOCOL_OVERHEAD		(20 + 8 + sizeof (ArvGvspPacket) + sizeof (ArvGvspHeader))
  /* IP + UDP + GVSP extended headers */


### PR DESCRIPTION
The computation of the expected test packet was wrong on some platform, so don't use sizeof.

Also, GevSCPSPacketSize increment was not correctly take into account.

And finally, don't limit the precision to 16 but to increment instead. I fear forcing the precision may conflict with cameras with increment not a divisor of 16 (which would be surprising, but who knows (yes, the GigEVision documentation, but we can not use it :( )).