### PR TITLE
uvstream: check transferred size before using the result

### DIFF
--- a/src/arvuvstream.c
+++ b/src/arvuvstream.c
@@ -534,6 +534,8 @@ arv_uv_stream_thread_sync (void *data)
 		if (error != NULL) {
 			arv_warning_sp ("USB transfer error: %s", error->message);
 			g_clear_error (&error);
+                } else if (transferred < 1) {
+			arv_warning_sp ("No data transferred");
 		} else {
 			ArvUvspPacketType packet_type;
 


### PR DESCRIPTION
It happens arv_uv_device_bulk_transfer succeed, but with no data transferred. Check the number of transferred bytes before trying to interpret the buffer content.

Fixes #737