### PR TITLE
Add .vscode dir to .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build/
 *~
 build-*/
 .cache/
+.vscode/


### PR DESCRIPTION
Add .vscode dir to .gitignore file.  This helps 'git status' remain clean for folks who use vscode with workspace-specific settings.