### PR TITLE
added port legacy info for kowaOptronics SC130ET3

### DIFF
--- a/src/arvgcport.c
+++ b/src/arvgcport.c
@@ -44,6 +44,7 @@ typedef struct {
 static ArvGvLegacyInfos arv_gc_port_legacy_infos[] = {
    { .vendor_selection = "Imperx", .model_selection = "IpxGEVCamera"},
    { .vendor_selection = "PleoraTechnologiesInc", .model_selection = "NTxGigE"},
+   { .vendor_selection = "KowaOptronics", .model_selection = "SC130ET3"},
 };
 
 typedef struct {


### PR DESCRIPTION
SC130ET3 is one of our products. I'd like to my camera works on aravis. I hope that aravis project would accept this change.