### PR TITLE
gcenumeration: revert bogus entry ordering commit

### DIFF
--- a/src/arvgcenumeration.c
+++ b/src/arvgcenumeration.c
@@ -247,7 +247,7 @@ _dup_available_string_values (ArvGcEnumeration *enumeration, gboolean display_na
 
 			if (is_implemented) {
 				(*n_values)++;
-				available_entries = g_slist_append (available_entries, iter->data);
+				available_entries = g_slist_prepend (available_entries, iter->data);
 			}
 		}
 	}


### PR DESCRIPTION
This reverts commit 93d536bb26fa3e6af6e1d2ced60f0b8d295e2df5.

Fixes #765