### PR TITLE
Frame rate limit disabling also need vendor specific quirks

### DIFF
--- a/src/arvcamera.h
+++ b/src/arvcamera.h
@@ -110,6 +110,7 @@ ARV_API ArvAcquisitionMode	arv_camera_get_acquisition_mode (ArvCamera *camera, G
 ARV_API void		arv_camera_set_frame_count		(ArvCamera *camera, gint64 frame_count, GError **error);
 ARV_API gint64		arv_camera_get_frame_count		(ArvCamera *camera, GError **error);
 ARV_API void		arv_camera_get_frame_count_bounds	(ArvCamera *camera, gint64 *min, gint64 *max, GError **error);
+ARV_API void            arv_camera_set_frame_rate_enable       (ArvCamera *camera, gboolean enable, GError **error);
 
 ARV_API gboolean	arv_camera_is_frame_rate_available	(ArvCamera *camera, GError **error);
 


### PR DESCRIPTION
Hi,

I have the following fixes running successfully in my project as a patch and am now proposing to add these upstream so they can be included in a future release (and I can just update my buildroot's Aravis version).

This PR fixes the following:
- Vendor specific quirks to set the frame rate limit were only checked when frame rate limiting must be enabled.
- When wanting to disable frame rate limiting by calling arv_camera_set_frame_rate(cam,  **0**, NULL), the vendor specific quirks were not applied.
- This was observed on a FLIR and Basler camera, where the Basler works out of the box, but the the FLIR one needed a quirk to disable frame rate limiting.

I have proposed to fix this by extracting the code with the vendor specific quirks to a new method arv_camera_set_frame_rate_enable(cam, TRUE/FALSE, GError) that encapsulates this, and then call this in arv_camera_set_frame_rate().

(Now that I think of it, it might be good to provide a arv_camera_get_frame_rate_enable() as well?)

As it's my first time working with the GLib 'flow' and Aravis internals, please verify if everything is up to standards regarding code style, error handling,...

Kind regards,
Durnezj

