### PR TITLE
Fix various warnings

### DIFF
--- a/src/arvcamera.c
+++ b/src/arvcamera.c
@@ -1872,7 +1872,7 @@ arv_camera_get_gain_auto (ArvCamera *camera, GError **error)
 /**
  * arv_camera_select_gain:
  * @camera: a #ArvCamera
- * @gainSelector: gain selector
+ * @selector: gain selector
  * @error: a #GError placeholder, %NULL to ignore
  *
  * Configures Gain Selector feature.
@@ -1881,9 +1881,9 @@ arv_camera_get_gain_auto (ArvCamera *camera, GError **error)
  **/
 
 void
-arv_camera_select_gain (ArvCamera *camera, const char *gainSelector, GError **error)
+arv_camera_select_gain (ArvCamera *camera, const char *selector, GError **error)
 {
-	arv_camera_set_string (camera, "GainSelector", gainSelector, error);
+	arv_camera_set_string (camera, "GainSelector", selector, error);
 }
 
 /**
@@ -1986,7 +1986,7 @@ arv_camera_get_black_level (ArvCamera *camera, GError **error)
 /**
  * arv_camera_select_black_level:
  * @camera: a #ArvCamera
- * @blackLevelSelector: black level selection
+ * @selector: black level selection
  * @error: a #GError placeholder, %NULL to ignore
  *
  * Configures Black Level Selector feature.
@@ -1995,9 +1995,9 @@ arv_camera_get_black_level (ArvCamera *camera, GError **error)
  **/
 
 void
-arv_camera_select_black_level (ArvCamera *camera, const char *blackLevelSelector, GError **error)
+arv_camera_select_black_level (ArvCamera *camera, const char *selector, GError **error)
 {
-	arv_camera_set_string (camera, "BlackLevelSelector", blackLevelSelector, error);
+	arv_camera_set_string (camera, "BlackLevelSelector", selector, error);
 }
 
 /**

--- a/src/arvcamera.h
+++ b/src/arvcamera.h
@@ -141,8 +141,8 @@ ARV_API void		arv_camera_set_exposure_mode		(ArvCamera *camera, ArvExposureMode 
 
 ARV_API gboolean	arv_camera_is_gain_available		(ArvCamera *camera, GError **error);
 ARV_API gboolean	arv_camera_is_gain_auto_available	(ArvCamera *camera, GError **error);
-ARV_API void		arv_camera_select_gain				(ArvCamera *camera, const char *selector, GError **error);
-ARV_API const char **	arv_camera_dup_available_gains	(ArvCamera *camera, guint *n_selectors, GError **error);
+ARV_API void		arv_camera_select_gain			(ArvCamera *camera, const char *gainSelector, GError **error);
+ARV_API const char **	arv_camera_dup_available_gains	        (ArvCamera *camera, guint *n_selectors, GError **error);
 
 ARV_API void		arv_camera_set_gain			(ArvCamera *camera, double gain, GError **error);
 ARV_API double		arv_camera_get_gain			(ArvCamera *camera, GError **error);
@@ -152,8 +152,8 @@ ARV_API ArvAuto		arv_camera_get_gain_auto		(ArvCamera *camera, GError **error);
 
 ARV_API gboolean	arv_camera_is_black_level_available	(ArvCamera *camera, GError **error);
 ARV_API gboolean	arv_camera_is_black_level_auto_available(ArvCamera *camera, GError **error);
-ARV_API void		arv_camera_select_black_level		(ArvCamera *camera, const char *selector, GError **error);
-ARV_API const char **	arv_camera_dup_available_black_level(ArvCamera *camera, guint *n_selectors, GError **error);
+ARV_API void		arv_camera_select_black_level		(ArvCamera *camera, const char *blackLevelSelector, GError **error);
+ARV_API const char **	arv_camera_dup_available_black_levels   (ArvCamera *camera, guint *n_selectors, GError **error);
 
 ARV_API void		arv_camera_set_black_level		(ArvCamera *camera, double blacklevel, GError **error);
 ARV_API double		arv_camera_get_black_level		(ArvCamera *camera, GError **error);

--- a/src/arvcamera.h
+++ b/src/arvcamera.h
@@ -141,7 +141,7 @@ ARV_API void		arv_camera_set_exposure_mode		(ArvCamera *camera, ArvExposureMode 
 
 ARV_API gboolean	arv_camera_is_gain_available		(ArvCamera *camera, GError **error);
 ARV_API gboolean	arv_camera_is_gain_auto_available	(ArvCamera *camera, GError **error);
-ARV_API void		arv_camera_select_gain			(ArvCamera *camera, const char *gainSelector, GError **error);
+ARV_API void		arv_camera_select_gain			(ArvCamera *camera, const char *selector, GError **error);
 ARV_API const char **	arv_camera_dup_available_gains	        (ArvCamera *camera, guint *n_selectors, GError **error);
 
 ARV_API void		arv_camera_set_gain			(ArvCamera *camera, double gain, GError **error);
@@ -152,7 +152,7 @@ ARV_API ArvAuto		arv_camera_get_gain_auto		(ArvCamera *camera, GError **error);
 
 ARV_API gboolean	arv_camera_is_black_level_available	(ArvCamera *camera, GError **error);
 ARV_API gboolean	arv_camera_is_black_level_auto_available(ArvCamera *camera, GError **error);
-ARV_API void		arv_camera_select_black_level		(ArvCamera *camera, const char *blackLevelSelector, GError **error);
+ARV_API void		arv_camera_select_black_level		(ArvCamera *camera, const char *selector, GError **error);
 ARV_API const char **	arv_camera_dup_available_black_levels   (ArvCamera *camera, guint *n_selectors, GError **error);
 
 ARV_API void		arv_camera_set_black_level		(ArvCamera *camera, double blacklevel, GError **error);

--- a/src/arvgvspprivate.h
+++ b/src/arvgvspprivate.h
@@ -372,7 +372,7 @@ arv_gvsp_leader_packet_get_buffer_payload_type (const ArvGvspPacket *packet, gbo
                 ArvGvspLeader *leader;
                 guint16 payload_type;
 
-                leader = (ArvGvspLeader*) arv_gvsp_packet_get_data (packet);
+                leader = (ArvGvspLeader *) arv_gvsp_packet_get_data (packet);
                 payload_type = g_ntohs (leader->payload_type);
 
                 if (has_chunks != NULL)
@@ -391,7 +391,7 @@ arv_gvsp_leader_packet_get_timestamp (const ArvGvspPacket *packet)
         if (G_LIKELY (arv_gvsp_packet_get_content_type (packet) == ARV_GVSP_CONTENT_TYPE_LEADER)) {
                 ArvGvspLeader *leader;
 
-                leader = (ArvGvspLeader*) arv_gvsp_packet_get_data (packet);
+                leader = (ArvGvspLeader *) arv_gvsp_packet_get_data (packet);
 
                 return ((guint64) g_ntohl (leader->timestamp_high) << 32) | g_ntohl (leader->timestamp_low);
         }
@@ -437,7 +437,7 @@ arv_gvsp_leader_packet_get_multipart_infos (const ArvGvspPacket *packet,
         if (part_id >= n_parts)
                 return FALSE;
 
-        leader = (ArvGvspMultipartLeader*) arv_gvsp_packet_get_data (packet);
+        leader = (ArvGvspMultipartLeader *) arv_gvsp_packet_get_data (packet);
         infos = &leader->parts[part_id];
 
         *purpose_id = g_ntohs(infos->data_purpose_id);
@@ -466,7 +466,7 @@ arv_gvsp_leader_packet_get_multipart_size (const ArvGvspPacket *packet,
         if (part_id >= n_parts)
                 return 0;
 
-        leader = (ArvGvspMultipartLeader*) arv_gvsp_packet_get_data (packet);
+        leader = (ArvGvspMultipartLeader *) arv_gvsp_packet_get_data (packet);
         infos = &leader->parts[part_id];
 
         return g_ntohl (infos->part_length_low) + (((guint64) g_ntohs (infos->part_length_high)) << 32);
@@ -487,7 +487,7 @@ arv_gvsp_leader_packet_get_image_infos (const ArvGvspPacket *packet,
             payload_type == ARV_BUFFER_PAYLOAD_TYPE_EXTENDED_CHUNK_DATA) {
                 ArvGvspImageLeader *leader;
 
-                leader = (ArvGvspImageLeader*) arv_gvsp_packet_get_data (packet);
+                leader = (ArvGvspImageLeader *) arv_gvsp_packet_get_data (packet);
 
                 *pixel_format = g_ntohl (leader->infos.pixel_format);
                 *width = g_ntohl (leader->infos.width);
@@ -526,7 +526,7 @@ arv_gvsp_multipart_packet_get_infos (const ArvGvspPacket *packet, guint *part_id
                 return FALSE;
         }
 
-        multipart = (ArvGvspMultipart*) arv_gvsp_packet_get_data(packet);
+        multipart = (ArvGvspMultipart *) arv_gvsp_packet_get_data(packet);
 
         *part_id = multipart->part_id;
         *offset = ( (guint64) g_ntohs(multipart->offset_high) << 32) + g_ntohl(multipart->offset_low);

--- a/src/arvuvcpprivate.h
+++ b/src/arvuvcpprivate.h
@@ -314,7 +314,7 @@ static inline ArvUvcpFlags
 arv_uvcp_packet_get_flags (const ArvUvcpPacket *packet)
 {
 	if (packet == NULL)
-		return 0;
+		return (ArvUvcpFlags) 0;
 
 	return (ArvUvcpFlags) GUINT16_FROM_LE (packet->header.flags);
 }

--- a/src/arvuvspprivate.h
+++ b/src/arvuvspprivate.h
@@ -123,7 +123,7 @@ arv_uvsp_packet_get_buffer_payload_type (ArvUvspPacket *packet, gboolean *has_ch
         if (has_chunks != NULL)
                 *has_chunks = (payload_type & 0x4000) != 0;
 
-        return payload_type & 0x3fff;
+        return (ArvBufferPayloadType) (payload_type & 0x3fff);
 }
 
 static inline guint64


### PR DESCRIPTION
This fixes a couple of warnings I got when locally building aravis. It also casts to the correct return types at various places.

Another noticeable change is that `arv_camera_dup_available_black_levels` was wrongly named in the corresponding `arvcamera.h`.