### PR TITLE
workaround not unique guid on some cams (DFM 37UX462-ML)

### DIFF
--- a/src/arvuvdevice.c
+++ b/src/arvuvdevice.c
@@ -37,6 +37,7 @@
 #include <arvstr.h>
 #include <arvzip.h>
 #include <arvmisc.h>
+#include <stdio.h>
 
 enum
 {
@@ -784,6 +785,13 @@ _open_usb_device (ArvUvDevice *uv_device, GError **error)
 			index = get_guid_index(devices[i]);
 			if (index > 0)
 				libusb_get_string_descriptor_ascii (usb_device, index, guid, 256);
+
+			/*
+			 * When guid_index is wrongly equal to the product index, append the serial number
+			 * Matching code in arvuvinterface.c
+			 */
+			if (index == desc.iProduct)
+				snprintf((char *)guid, 256, "%s-%s", product, serial_number);
 
 			if ((priv->vendor != NULL &&
                              g_strcmp0 ((char * ) manufacturer, priv->vendor) == 0 &&

--- a/src/arvuvinterface.c
+++ b/src/arvuvinterface.c
@@ -242,6 +242,13 @@ _usb_device_to_device_ids (ArvUvInterface *uv_interface, libusb_device *device)
 		if (index > 0)
 			libusb_get_string_descriptor_ascii (device_handle, index, guid, 256);
 
+		/*
+		 * When guid_index is wrongly equal to the product index, append the serial number
+		 * Matching code in arvuvdevice.c
+		 */
+		if (index == desc.iProduct)
+			snprintf((char *)guid, 256, "%s-%s", product, serial_nbr);
+
 		device_infos = arv_uv_interface_device_infos_new ((char *) manufacturer, (char *) product,
                                                                   (char *) serial_nbr, (char *) guid);
 		g_hash_table_replace (uv_interface->priv->devices, device_infos->id,


### PR DESCRIPTION
When plugin two and more such cams into the system, cams provide same guid (usually product id) and this confuses Aravis when accessing those so the only one seems to be available. The workaround is to concat serial number to the wrongly formed guid in such a case.