### PR TITLE
doc: fix link to GLib error reporting docs

### DIFF
--- a/docs/reference/aravis/porting-0.8.md
+++ b/docs/reference/aravis/porting-0.8.md
@@ -13,7 +13,7 @@ NULL parameter to most of the modified functions. But you are advised to take
 this opportunity to correctly handle errors.
 
 There is a page explaining Glib errors and how to manage them in the [Glib
-documentation](https://developer.gnome.org/glib/stable/glib-Error-Reporting.html).
+documentation](https://docs.gtk.org/glib/error-reporting.html).
 
 During the camera configuration, in C language it can be somehow cumbersome to
 check for errors at each function call. A convenient way to deal with this issue


### PR DESCRIPTION
I've found a (semantically) broken link in docs. `glib-Error-Reporting.html` is now named `error-reporting.html` and it is in GTK docs and not GNOME developer docs. I've fixed it to help finding the error reporting reference more easily.

Thanks for the project maintenance!