### PR TITLE
Add calling convention to libusb callback functions

### DIFF
--- a/src/arvuvdevice.c
+++ b/src/arvuvdevice.c
@@ -929,7 +929,7 @@ arv_uv_device_new_from_guid (const char *guid, GError **error)
 			       NULL);
 }
 
-static int _disconnect_event (libusb_context *ctx,
+static int LIBUSB_CALL _disconnect_event (libusb_context *ctx,
                               libusb_device *device,
                               libusb_hotplug_event event,
                               void *user_data)

--- a/src/arvuvstream.c
+++ b/src/arvuvstream.c
@@ -138,7 +138,7 @@ arv_uv_stream_buffer_context_notify_transfer_completed (ArvUvStreamBufferContext
 }
 
 static
-void arv_uv_stream_leader_cb (struct libusb_transfer *transfer)
+void LIBUSB_CALL arv_uv_stream_leader_cb (struct libusb_transfer *transfer)
 {
 	ArvUvStreamBufferContext *ctx = transfer->user_data;
 	ArvUvspPacket *packet = (ArvUvspPacket*)transfer->buffer;
@@ -195,7 +195,7 @@ void arv_uv_stream_leader_cb (struct libusb_transfer *transfer)
 }
 
 static
-void arv_uv_stream_payload_cb (struct libusb_transfer *transfer)
+void LIBUSB_CALL arv_uv_stream_payload_cb (struct libusb_transfer *transfer)
 {
 	ArvUvStreamBufferContext *ctx = transfer->user_data;
 
@@ -223,7 +223,7 @@ void arv_uv_stream_payload_cb (struct libusb_transfer *transfer)
 }
 
 static
-void arv_uv_stream_trailer_cb (struct libusb_transfer *transfer)
+void LIBUSB_CALL arv_uv_stream_trailer_cb (struct libusb_transfer *transfer)
 {
 	ArvUvStreamBufferContext *ctx = transfer->user_data;
 	ArvUvspPacket *packet = (ArvUvspPacket*)transfer->buffer;


### PR DESCRIPTION
```
    This fixes compiling with clang 16 in 32 bit mingw environment.

    Here is the compiler error:
    ../src/arvuvstream.c:303:3: error: incompatible function pointer types passing
    'void (struct libusb_transfer *)' to parameter of type 'libusb_transfer_cb_fn'
    (aka 'void (*)(struct libusb_transfer *) __attribute__((stdcall))')
    [-Wincompatible-function-pointer-types]
```
