### PR TITLE
ci: update GitHub Actions versions

### DIFF
--- a/.github/workflows/aravis-linux.yml
+++ b/.github/workflows/aravis-linux.yml
@@ -12,7 +12,7 @@ jobs:
   linux:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Install dependencies
       run: |
         pip3 install meson ninja Markdown toml typogrify

--- a/.github/workflows/aravis-macos.yml
+++ b/.github/workflows/aravis-macos.yml
@@ -12,8 +12,8 @@ jobs:
   macos:
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
       with:
         python-version: '3.x'
     - name: Unbreak Python in Github Actions
@@ -33,7 +33,7 @@ jobs:
         CC: gcc
     - name: Tests
       run: meson test -C build/ -v
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       if: failure()
       with:
         name: MacOS_Meson_Testlog

--- a/.github/workflows/aravis-mingw.yml
+++ b/.github/workflows/aravis-mingw.yml
@@ -45,7 +45,7 @@ jobs:
           mingw-w64-${{matrix.env}}-libusb
           mingw-w64-${{matrix.env}}-gobject-introspection-runtime
           mingw-w64-${{matrix.env}}-python-gobject
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: meson
       run: |
         mkdir build
@@ -56,7 +56,7 @@ jobs:
     - name: meson test
       run: |
         meson test -C ./build
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       if: failure()
       with:
         name: ${{matrix.sys}}_Meson_Testlog

--- a/.github/workflows/aravis-msvc.yml
+++ b/.github/workflows/aravis-msvc.yml
@@ -26,7 +26,7 @@ jobs:
       run: |
         rm -r C:\Strawberry\perl
     - name: checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: conan
       env:
         INPUT_CONANFILE: |
@@ -79,7 +79,7 @@ jobs:
         .\build\activate_run.ps1
         meson test -C .\build
     - name: logs
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       if: failure()
       with:
         name: msvc_${{ matrix.version }}_${{ matrix.arch }}_${{ matrix.build_type_meson }}_Meson_Testlog


### PR DESCRIPTION
Node.js 12 actions are deprecated. These actions are using Node.js 16.