### PR TITLE
Add support for EVK Helios cameras (Genicam 1.0 legacy mode)

### DIFF
--- a/src/arvgcport.c
+++ b/src/arvgcport.c
@@ -67,6 +67,7 @@ static ArvGvLegacyInfos arv_gc_port_legacy_infos[] = {
    { .vendor_selection = "PleoraTechnologiesInc",       .model_selection = "NTxGigE"},
    { .vendor_selection = "TeledyneDALSA",               .model_selection = "ICE"},
    { .vendor_selection = "Sony",                        .model_selection = "XCG_CGSeries"},
+   { .vendor_selection = "EVK",                         .model_selection = "HELIOS"},
 };
 
 typedef struct {


### PR DESCRIPTION
Adds EVK HELIOS to ArvGvLegacyInfos struct in arvgcport.c