### PR TITLE
Discover dhcp camera outside subnet

### DIFF
--- a/src/arvgvdevice.c
+++ b/src/arvgvdevice.c
@@ -1966,11 +1966,18 @@ arv_gv_device_constructed (GObject *object)
 	char *address_string;
 	guint32 capabilities;
 	guint32 device_mode;
+	GSocketAddress *any_socket_address;
+	GInetAddress *any_address;
+	int socket_fd;
+	struct ifaddrs *addrs, *iap;
+	struct sockaddr_in *sa;
+	char buf[32];
+	char interface_name[32];
 
-        G_OBJECT_CLASS (arv_gv_device_parent_class)->constructed (object);
+	G_OBJECT_CLASS (arv_gv_device_parent_class)->constructed (object);
 
 	if (!G_IS_INET_ADDRESS (priv->interface_address) ||
-	    !G_IS_INET_ADDRESS (priv->device_address)) {
+		!G_IS_INET_ADDRESS (priv->device_address)) {
 		arv_device_take_init_error (ARV_DEVICE (object), g_error_new (ARV_DEVICE_ERROR, ARV_DEVICE_ERROR_INVALID_PARAMETER,
 									     "Invalid interface or device address"));
 		return;
@@ -1994,14 +2001,47 @@ arv_gv_device_constructed (GObject *object)
 	io_data->socket = g_socket_new (G_SOCKET_FAMILY_IPV4,
 					G_SOCKET_TYPE_DATAGRAM,
 					G_SOCKET_PROTOCOL_UDP, NULL);
-	if (!g_socket_bind (io_data->socket, io_data->interface_address, FALSE, &local_error)) {
+
+	any_address = g_inet_address_new_any (G_SOCKET_FAMILY_IPV4);
+	any_socket_address = g_inet_socket_address_new (any_address, 0);
+ 
+	if (!g_socket_bind (io_data->socket, any_socket_address, FALSE, &local_error)) {
 		if (local_error == NULL)
 			local_error = g_error_new (ARV_DEVICE_ERROR, ARV_DEVICE_ERROR_UNKNOWN,
-						   "Unknown error trying to bind device interface");
+							"Unknown error trying to bind device interface");
 		arv_device_take_init_error (ARV_DEVICE (gv_device), local_error);
 
 		return;
 	}
+	g_object_unref (any_socket_address);
+	g_object_unref (any_address);
+
+	// we have to grab the interface name
+	if (getifaddrs (&addrs) <0) {
+		arv_device_take_init_error (ARV_DEVICE (object),
+							g_error_new (ARV_DEVICE_ERROR, ARV_DEVICE_ERROR_NOT_CONNECTED,
+							 "Couldn't get available interfaces"));
+		return;
+	}
+
+	for (iap = addrs; iap != NULL; iap = iap->ifa_next) {
+		if ((iap->ifa_flags & IFF_UP) != 0 &&
+			(iap->ifa_flags & IFF_POINTOPOINT) == 0 &&
+			(iap->ifa_addr != NULL) &&
+			(iap->ifa_addr->sa_family == AF_INET)) {
+
+			sa = (struct sockaddr_in *)(iap->ifa_addr);
+			inet_ntop(iap->ifa_addr->sa_family, (void *)&(sa->sin_addr), buf, sizeof(buf));
+			if (!strcmp(g_inet_address_to_string (priv->interface_address), buf)) {
+				sprintf(interface_name, "%s", iap->ifa_name);
+			}
+		}
+	}
+
+	freeifaddrs (addrs);
+
+	socket_fd = g_socket_get_fd(io_data->socket);
+	setsockopt (socket_fd, SOL_SOCKET, SO_BINDTODEVICE, interface_name, strlen (interface_name));
 
 	io_data->buffer = g_malloc (ARV_GV_DEVICE_BUFFER_SIZE);
 	io_data->gvcp_n_retries = ARV_GV_DEVICE_GVCP_N_RETRIES_DEFAULT;

--- a/src/arvgvinterface.c
+++ b/src/arvgvinterface.c
@@ -83,7 +83,6 @@ arv_gv_discover_socket_list_new (void)
 		return socket_list;
 
 	for (iface_iter = ifaces; iface_iter != NULL; iface_iter = iface_iter->next) {
-		ArvGvDiscoverSocket *discover_socket_bind_any = g_new0 (ArvGvDiscoverSocket, 1);
 		ArvGvDiscoverSocket *discover_socket = g_new0 (ArvGvDiscoverSocket, 1);
 		GSocketAddress *socket_address;
 		GSocketAddress *socket_broadcast;
@@ -109,38 +108,27 @@ arv_gv_discover_socket_list_new (void)
 		arv_info_interface ("[GvDiscoverSocket::new] Add interface %s (%s)", inet_address_string, inet_broadcast_string);
 		g_free (inet_address_string);
 		g_free (inet_broadcast_string);
-		discover_socket_bind_any->interface_address = g_inet_socket_address_new (inet_address, 0);
-		discover_socket_bind_any->broadcast_address = g_inet_socket_address_new (inet_broadcast, ARV_GVCP_PORT);
 		discover_socket->interface_address = g_inet_socket_address_new (inet_address, 0);
 		discover_socket->broadcast_address = g_inet_socket_address_new (inet_broadcast, ARV_GVCP_PORT);
-
 		g_object_unref (socket_address);
 		g_object_unref (socket_broadcast);
 
-		discover_socket_bind_any->socket = g_socket_new (g_inet_address_get_family (inet_address),
-							G_SOCKET_TYPE_DATAGRAM,
-							G_SOCKET_PROTOCOL_UDP, NULL);
 		discover_socket->socket = g_socket_new (g_inet_address_get_family (inet_address),
 							G_SOCKET_TYPE_DATAGRAM,
 							G_SOCKET_PROTOCOL_UDP, NULL);
-		arv_socket_set_recv_buffer_size (g_socket_get_fd (discover_socket_bind_any->socket), buffer_size);
 		arv_socket_set_recv_buffer_size (g_socket_get_fd (discover_socket->socket), buffer_size);
-
 
 		any_address = g_inet_address_new_any (G_SOCKET_FAMILY_IPV4);
 		any_socket_address = g_inet_socket_address_new (any_address, 0);
-		g_socket_bind (discover_socket->socket, discover_socket->interface_address, FALSE, &error);
-		socket_list->sockets = g_slist_prepend (socket_list->sockets, discover_socket);
-		socket_list->n_sockets++;
-		g_socket_bind (discover_socket_bind_any->socket, any_socket_address, FALSE, &error);
+		g_socket_bind (discover_socket->socket, any_socket_address, FALSE, &error);
 		g_object_unref (any_socket_address);
 		g_object_unref (any_address);
 
 		interface_name = arv_network_interface_get_name (iface_iter->data);
-		socket_fd = g_socket_get_fd(discover_socket_bind_any->socket);
+		socket_fd = g_socket_get_fd(discover_socket->socket);
 		setsockopt (socket_fd, SOL_SOCKET, SO_BINDTODEVICE, interface_name, strlen (interface_name));
 
-		socket_list->sockets = g_slist_prepend (socket_list->sockets, discover_socket_bind_any);
+		socket_list->sockets = g_slist_prepend (socket_list->sockets, discover_socket);
 		socket_list->n_sockets++;
 	}
 	g_list_free_full (ifaces, (GDestroyNotify) arv_network_interface_free);

--- a/src/arvgvinterface.c
+++ b/src/arvgvinterface.c
@@ -83,38 +83,64 @@ arv_gv_discover_socket_list_new (void)
 		return socket_list;
 
 	for (iface_iter = ifaces; iface_iter != NULL; iface_iter = iface_iter->next) {
+		ArvGvDiscoverSocket *discover_socket_bind_any = g_new0 (ArvGvDiscoverSocket, 1);
 		ArvGvDiscoverSocket *discover_socket = g_new0 (ArvGvDiscoverSocket, 1);
 		GSocketAddress *socket_address;
 		GSocketAddress *socket_broadcast;
+		GSocketAddress *any_socket_address;
+		GInetAddress *any_address;
 		GInetAddress *inet_address;
 		GInetAddress *inet_broadcast;
 		char *inet_address_string;
 		char *inet_broadcast_string;
 		GError *error = NULL;
 		gint buffer_size = ARV_GV_INTERFACE_DISCOVERY_SOCKET_BUFFER_SIZE;
+		int socket_fd;
+		const char *interface_name;
+
 		socket_address = g_socket_address_new_from_native (arv_network_interface_get_addr(iface_iter->data),
 									sizeof (struct sockaddr));
 		socket_broadcast = g_socket_address_new_from_native (arv_network_interface_get_broadaddr(iface_iter->data),
 									sizeof (struct sockaddr));
 		inet_address = g_inet_socket_address_get_address (G_INET_SOCKET_ADDRESS (socket_address));
-                inet_broadcast = g_inet_socket_address_get_address (G_INET_SOCKET_ADDRESS (socket_broadcast));
+		inet_broadcast = g_inet_socket_address_get_address (G_INET_SOCKET_ADDRESS (socket_broadcast));
 		inet_address_string = g_inet_address_to_string (inet_address);
 		inet_broadcast_string = g_inet_address_to_string (inet_broadcast);
 		arv_info_interface ("[GvDiscoverSocket::new] Add interface %s (%s)", inet_address_string, inet_broadcast_string);
 		g_free (inet_address_string);
 		g_free (inet_broadcast_string);
+		discover_socket_bind_any->interface_address = g_inet_socket_address_new (inet_address, 0);
+		discover_socket_bind_any->broadcast_address = g_inet_socket_address_new (inet_broadcast, ARV_GVCP_PORT);
 		discover_socket->interface_address = g_inet_socket_address_new (inet_address, 0);
 		discover_socket->broadcast_address = g_inet_socket_address_new (inet_broadcast, ARV_GVCP_PORT);
+
 		g_object_unref (socket_address);
 		g_object_unref (socket_broadcast);
 
+		discover_socket_bind_any->socket = g_socket_new (g_inet_address_get_family (inet_address),
+							G_SOCKET_TYPE_DATAGRAM,
+							G_SOCKET_PROTOCOL_UDP, NULL);
 		discover_socket->socket = g_socket_new (g_inet_address_get_family (inet_address),
 							G_SOCKET_TYPE_DATAGRAM,
 							G_SOCKET_PROTOCOL_UDP, NULL);
+		arv_socket_set_recv_buffer_size (g_socket_get_fd (discover_socket_bind_any->socket), buffer_size);
 		arv_socket_set_recv_buffer_size (g_socket_get_fd (discover_socket->socket), buffer_size);
-		g_socket_bind (discover_socket->socket, discover_socket->interface_address, FALSE, &error);
 
+
+		any_address = g_inet_address_new_any (G_SOCKET_FAMILY_IPV4);
+		any_socket_address = g_inet_socket_address_new (any_address, 0);
+		g_socket_bind (discover_socket->socket, discover_socket->interface_address, FALSE, &error);
 		socket_list->sockets = g_slist_prepend (socket_list->sockets, discover_socket);
+		socket_list->n_sockets++;
+		g_socket_bind (discover_socket_bind_any->socket, any_socket_address, FALSE, &error);
+		g_object_unref (any_socket_address);
+		g_object_unref (any_address);
+
+		interface_name = arv_network_interface_get_name (iface_iter->data);
+		socket_fd = g_socket_get_fd(discover_socket_bind_any->socket);
+		setsockopt (socket_fd, SOL_SOCKET, SO_BINDTODEVICE, interface_name, strlen (interface_name));
+
+		socket_list->sockets = g_slist_prepend (socket_list->sockets, discover_socket_bind_any);
 		socket_list->n_sockets++;
 	}
 	g_list_free_full (ifaces, (GDestroyNotify) arv_network_interface_free);

--- a/src/arvgvinterface.c
+++ b/src/arvgvinterface.c
@@ -118,15 +118,17 @@ arv_gv_discover_socket_list_new (void)
 							G_SOCKET_PROTOCOL_UDP, NULL);
 		arv_socket_set_recv_buffer_size (g_socket_get_fd (discover_socket->socket), buffer_size);
 
-		any_address = g_inet_address_new_any (G_SOCKET_FAMILY_IPV4);
-		any_socket_address = g_inet_socket_address_new (any_address, 0);
-		g_socket_bind (discover_socket->socket, any_socket_address, FALSE, &error);
-		g_object_unref (any_socket_address);
-		g_object_unref (any_address);
-
 		interface_name = arv_network_interface_get_name (iface_iter->data);
 		socket_fd = g_socket_get_fd(discover_socket->socket);
-		setsockopt (socket_fd, SOL_SOCKET, SO_BINDTODEVICE, interface_name, strlen (interface_name));
+		if (setsockopt (socket_fd, SOL_SOCKET, SO_BINDTODEVICE, interface_name, strlen (interface_name)) == 0) {
+			any_address = g_inet_address_new_any (G_SOCKET_FAMILY_IPV4);
+			any_socket_address = g_inet_socket_address_new (any_address, 0);
+			g_socket_bind (discover_socket->socket, any_socket_address, FALSE, &error);
+			g_object_unref (any_socket_address);
+			g_object_unref (any_address);
+		} else {
+			g_socket_bind (discover_socket->socket, discover_socket->interface_address, FALSE, &error);
+		}
 
 		socket_list->sockets = g_slist_prepend (socket_list->sockets, discover_socket);
 		socket_list->n_sockets++;


### PR DESCRIPTION
When possible (running as root) uses SO_BINDTODEVICE to discover cameras outside the subnet.
I did not implement for Stream because the idea is that with this change you can now use arv-tool-0.8 (with root privelages) to re-address the camera and bring it back into communication for proper use.
I'm not sure if there's a better way that does not require root for SO_BINDTODEVICE.
https://aravis-project.discourse.group/t/discover-camera-in-dhcp-mode/598/4
https://github.com/AravisProject/aravis/pull/779

draft until i can test next week