### PR TITLE
Add AutomationTechnology C6 to legacy exceptions; add ARV_QUIRK_LEGACY_ENDIANNESS env var

### DIFF
--- a/src/arvgcport.c
+++ b/src/arvgcport.c
@@ -146,6 +146,8 @@ _use_legacy_endianness_mechanism (ArvGcPort *port, guint64 length)
 
 		if (arv_gc_register_description_node_compare_schema_version (register_description, 1, 1, 0) < 0) {
 			port->priv->has_legacy_infos = TRUE;
+		} else if (g_getenv("ARV_QUIRK_LEGACY_ENDIANNESS")) {
+			port->priv->has_legacy_infos = TRUE;
 		} else {
 			for (i = 0; i < G_N_ELEMENTS (arv_gc_port_legacy_infos); i++) {
 				if (g_pattern_match_simple(arv_gc_port_legacy_infos[i].vendor_selection, vendor_name) == TRUE &&

--- a/src/arvgcport.c
+++ b/src/arvgcport.c
@@ -68,6 +68,7 @@ static ArvGvLegacyInfos arv_gc_port_legacy_infos[] = {
    { .vendor_selection = "TeledyneDALSA",               .model_selection = "ICE"},
    { .vendor_selection = "Sony",                        .model_selection = "XCG_CGSeries"},
    { .vendor_selection = "EVK",                         .model_selection = "HELIOS"},
+   { .vendor_selection = "AT_Automation_Technology_GmbH",.model_selection = "C6_X_GigE"},
 };
 
 typedef struct {


### PR DESCRIPTION
Please have a look what it feels like. I don't feel strong about the env var workaround (and the name could be also different); for quick testing, it could work better than repeated instruction "add to the exception list and recompile".