### PR TITLE
Don't ignore POINTOPOINT interfaces on UNIX family OSes

### DIFF
--- a/src/arvnetwork.c
+++ b/src/arvnetwork.c
@@ -355,7 +355,6 @@ arv_enumerate_network_interfaces (void)
 
 	for (ifap_iter = ifap; ifap_iter != NULL; ifap_iter = ifap_iter->ifa_next) {
 		if ((ifap_iter->ifa_flags & IFF_UP) != 0 &&
-			(ifap_iter->ifa_flags & IFF_POINTOPOINT) == 0 &&
 			(ifap_iter->ifa_addr != NULL) &&
 			(ifap_iter->ifa_addr->sa_family == AF_INET)) {
 			ArvNetworkInterface* a;


### PR DESCRIPTION
This patch allows Aravis to connect to cameras over POINTOPOINT IP links.  Broadcasts are not expected to work, but unicast does.  This allows connecting to cameras across a VPN, or PPPoE network.  This addresses issue #823 