### PR TITLE
added get/set register node value

### DIFF
--- a/src/arvcamera.c
+++ b/src/arvcamera.c
@@ -2863,9 +2863,9 @@ arv_camera_get_register (ArvCamera *camera, const char *feature,guint64 length, 
  * arv_camera_get_register_length:
  * @camera: a #ArvCamera
  * @feature: feature name
- * @error: a #GError placeholder, %NULL to ignore
+ * @error: a #GError placeholder
  *
- * Returns: the length of register value.
+ * Returns: the length of register value, 0 if not available
  *
  * Since:
  */
@@ -2875,7 +2875,7 @@ arv_camera_get_register_length (ArvCamera *camera, const char *feature, GError *
 {
 	ArvCameraPrivate *priv = arv_camera_get_instance_private (camera);
 
-	g_return_val_if_fail (ARV_IS_CAMERA (camera), 0.0);
+	g_return_val_if_fail (ARV_IS_CAMERA (camera), 0);
 
 	return arv_device_get_register_feature_length (priv->device, feature, error);
 }

--- a/src/arvcamera.c
+++ b/src/arvcamera.c
@@ -2854,7 +2854,7 @@ arv_camera_get_register (ArvCamera *camera, const char *feature,guint64 length, 
 {
 	ArvCameraPrivate *priv = arv_camera_get_instance_private (camera);
 
-	g_return_val_if_fail (ARV_IS_CAMERA (camera));
+	g_return_if_fail (ARV_IS_CAMERA (camera));
 
 	arv_device_get_register_feature_value (priv->device, feature, length, value, error);
 }

--- a/src/arvcamera.c
+++ b/src/arvcamera.c
@@ -2854,9 +2854,9 @@ arv_camera_get_register (ArvCamera *camera, const char *feature,guint64 length, 
 {
 	ArvCameraPrivate *priv = arv_camera_get_instance_private (camera);
 
-	g_return_val_if_fail (ARV_IS_CAMERA (camera), 0.0);
+	g_return_val_if_fail (ARV_IS_CAMERA (camera));
 
-	return arv_device_get_register_feature_value (priv->device, feature, length, value, error);
+	arv_device_get_register_feature_value (priv->device, feature, length, value, error);
 }
 
 /**

--- a/src/arvcamera.c
+++ b/src/arvcamera.c
@@ -40,6 +40,7 @@
 #include <arvgcfloat.h>
 #include <arvgcenumeration.h>
 #include <arvgcenumentry.h>
+#include <arvgcregister.h>
 #include <arvgcstring.h>
 #include <arvbuffer.h>
 #include <arvgc.h>
@@ -2814,6 +2815,69 @@ arv_camera_get_float_increment (ArvCamera *camera, const char *feature, GError *
 	g_return_val_if_fail (feature != NULL, 1);
 
 	return arv_device_get_float_feature_increment (priv->device, feature, error);
+}
+
+/**
+ * arv_camera_set_register:
+ * @camera: a #ArvCamera
+ * @feature: feature name
+ * @value: new feature value
+ * @error: a #GError placeholder, %NULL to ignore
+ *
+ * Set a register feature value.
+ *
+ * Since: 
+ */
+
+void
+arv_camera_set_register (ArvCamera *camera, const char *feature, guint64 length, void* value, GError **error)
+{
+	ArvCameraPrivate *priv = arv_camera_get_instance_private (camera);
+
+	g_return_if_fail (ARV_IS_CAMERA (camera));
+
+	arv_device_set_register_feature_value (priv->device, feature, length, value, error);
+}
+
+/**
+ * arv_camera_get_register:
+ * @camera: a #ArvCamera
+ * @feature: feature name
+ * @value: (out): the register feature value
+ * @error: a #GError placeholder, %NULL to ignore
+ *
+ * Since: 
+ */
+
+void
+arv_camera_get_register (ArvCamera *camera, const char *feature,guint64 length, void* value, GError **error)
+{
+	ArvCameraPrivate *priv = arv_camera_get_instance_private (camera);
+
+	g_return_val_if_fail (ARV_IS_CAMERA (camera), 0.0);
+
+	return arv_device_get_register_feature_value (priv->device, feature, length, value, error);
+}
+
+/**
+ * arv_camera_get_register_length:
+ * @camera: a #ArvCamera
+ * @feature: feature name
+ * @error: a #GError placeholder, %NULL to ignore
+ *
+ * Returns: the length of register value.
+ *
+ * Since:
+ */
+
+guint64
+arv_camera_get_register_length (ArvCamera *camera, const char *feature, GError **error)
+{
+	ArvCameraPrivate *priv = arv_camera_get_instance_private (camera);
+
+	g_return_val_if_fail (ARV_IS_CAMERA (camera), 0.0);
+
+	return arv_device_get_register_feature_length (priv->device, feature, error);
 }
 
 /**

--- a/src/arvcamera.h
+++ b/src/arvcamera.h
@@ -196,6 +196,10 @@ ARV_API double		arv_camera_get_float			(ArvCamera *camera, const char *feature, 
 ARV_API void		arv_camera_get_float_bounds		(ArvCamera *camera, const char *feature, double *min, double *max, GError **error);
 ARV_API double		arv_camera_get_float_increment		(ArvCamera *camera, const char *feature, GError **error);
 
+ARV_API void            arv_camera_set_register                 (ArvCamera *camera, const char *feature, guint64 length, void* value, GError **error);
+ARV_API void            arv_camera_get_register                 (ArvCamera *camera, const char *feature, guint64 length, void* value, GError **error);
+ARV_API guint64         arv_camera_get_register_length          (ArvCamera *camera, const char *feature, GError **error);   
+
 ARV_API gint64 *	arv_camera_dup_available_enumerations			(ArvCamera *camera, const char *feature,
 										 guint *n_values, GError **error);
 ARV_API const char **	arv_camera_dup_available_enumerations_as_strings	(ArvCamera *camera, const char *feature,

--- a/src/arvchunkparser.c
+++ b/src/arvchunkparser.c
@@ -40,6 +40,7 @@
 #include <arvbuffer.h>
 #include <arvgcinteger.h>
 #include <arvgcfloat.h>
+#include <arvgcregister.h>
 #include <arvgcstring.h>
 #include <arvgcboolean.h>
 #include <arvdebugprivate.h>

--- a/src/arvdevice.c
+++ b/src/arvdevice.c
@@ -849,7 +849,7 @@ arv_device_get_register_feature_value (ArvDevice *device, const char *feature, g
  * @feature: feature name
  * @error: a #GError placeholder
  *
- * Returns: the length of register value.
+ * Returns: the length of register value, 0 if not available
  * 
  * Since:
  */

--- a/src/arvdevice.c
+++ b/src/arvdevice.c
@@ -38,6 +38,7 @@
 #include <arvgcfeaturenode.h>
 #include <arvgcboolean.h>
 #include <arvgcenumeration.h>
+#include <arvgcregister.h>
 #include <arvgcstring.h>
 #include <arvstream.h>
 #include <arvdebug.h>
@@ -796,6 +797,72 @@ arv_device_get_float_feature_increment (ArvDevice *device, const char *feature, 
 	}
 
 	return G_MINDOUBLE;
+}
+
+/**
+ * arv_device_set_register_feature_value:
+ * @device: a #ArvDevice
+ * @feature: feature name
+ * @value: new feature value
+ * @error: a #GError placeholder
+ *
+ * Set the register feature value.
+ * 
+ * Since:
+ */
+
+void
+arv_device_set_register_feature_value (ArvDevice *device, const char *feature, guint64 length, void* value, GError **error)        
+{
+	ArvGcNode *node;
+
+	node = _get_feature (device, ARV_TYPE_GC_REGISTER, feature, error);
+	if (node != NULL)
+		arv_gc_register_set (ARV_GC_REGISTER (node), value, length, error);
+}
+
+/**
+ * arv_device_get_register_feature_value:
+ * @device: a #ArvDevice
+ * @feature: feature name
+ * @value: (out): the register feature value
+ * @error: a #GError placeholder
+ *
+ * Retrive the register feature value.
+ * 
+ * Since:
+ */
+
+void
+arv_device_get_register_feature_value (ArvDevice *device, const char *feature, guint64 length, void* value, GError **error)        
+{
+	ArvGcNode *node;
+
+	node = _get_feature (device, ARV_TYPE_GC_REGISTER, feature, error);
+	if (node != NULL)
+		arv_gc_register_get (ARV_GC_REGISTER (node), value, length, error);
+}
+
+/**
+ * arv_device_get_register_feature_length:
+ * @device: a #ArvDevice
+ * @feature: feature name
+ * @error: a #GError placeholder
+ *
+ * Returns: the length of register value.
+ * 
+ * Since:
+ */
+
+guint64
+arv_device_get_register_feature_length (ArvDevice *device, const char *feature, GError **error)
+{
+	ArvGcNode *node;
+	node = _get_feature (device, ARV_TYPE_GC_REGISTER, feature, error);
+	if (node != NULL)
+		return arv_gc_register_get_length(ARV_GC_REGISTER (node), error);
+
+	return 0;
 }
 
 /**

--- a/src/arvdevice.h
+++ b/src/arvdevice.h
@@ -133,6 +133,10 @@ ARV_API void		arv_device_set_float_feature_value	(ArvDevice *device, const char 
 ARV_API double		arv_device_get_float_feature_value	(ArvDevice *device, const char *feature, GError **error);
 ARV_API void		arv_device_get_float_feature_bounds	(ArvDevice *device, const char *feature, double *min, double *max, GError **error);
 ARV_API double		arv_device_get_float_feature_increment	(ArvDevice *device, const char *feature, GError **error);
+  
+ARV_API void		arv_device_set_register_feature_value   (ArvDevice *device, const char *feature, guint64 length, void* value, GError **error);
+ARV_API void		arv_device_get_register_feature_value   (ArvDevice *device, const char *feature, guint64 length, void* value, GError **error);
+ARV_API guint64		arv_device_get_register_feature_length  (ArvDevice *device, const char *feature, GError **error);
 
 ARV_API gint64 *	arv_device_dup_available_enumeration_feature_values			(ArvDevice *device, const char *feature,
 												 guint *n_values, GError **error);

--- a/src/arvgcenumeration.c
+++ b/src/arvgcenumeration.c
@@ -29,6 +29,7 @@
 #include <arvgcenumentry.h>
 #include <arvgcinteger.h>
 #include <arvgcselector.h>
+#include <arvgcregister.h>
 #include <arvgcstring.h>
 #include <arvgcfeaturenodeprivate.h>
 #include <arvgc.h>

--- a/src/arvgcfeaturenode.c
+++ b/src/arvgcfeaturenode.c
@@ -34,6 +34,7 @@
 #include <arvgcboolean.h>
 #include <arvgcinteger.h>
 #include <arvgcfloat.h>
+#include <arvgcregister.h>
 #include <arvgcstring.h>
 #include <arvgcenumeration.h>
 #include <arvgcenums.h>

--- a/src/arvgcpropertynode.c
+++ b/src/arvgcpropertynode.c
@@ -33,6 +33,7 @@
 #include <arvgcinteger.h>
 #include <arvgcfloat.h>
 #include <arvgcboolean.h>
+#include <arvgcregister.h>
 #include <arvgcstring.h>
 #include <arvgc.h>
 #include <arvdomtext.h>

--- a/src/arvgcstringnode.c
+++ b/src/arvgcstringnode.c
@@ -26,6 +26,7 @@
  */
 
 #include <arvgcstringnode.h>
+#include <arvgcregister.h>
 #include <arvgcstring.h>
 #include <arvgcinteger.h>
 #include <arvgcvalueindexednode.h>


### PR DESCRIPTION
I have implemented an API to set/get the value of the "Register-Type" node in order for the Aravis library to handle cameras in the GENDC data format in the future. 
Currently, when using the arv-tool to display the GenDC descriptor, it appears as follows:

```
$ ./arv-tool-0.8.exe -n  <name of camera> control GenDCDescriptor
Length of GenDCDescriptor = 1280
Content of GenDCDescriptor =
        0x47 0x4e 0x44 0x43 0x01 0x00 0x00 0x00
...
```

Note that
* gendc is supported as U3V camera's payload type from U3V v1.2
* `GNDC` (`0x47 0x4e 0x44 0x43`) is the signature of GenDCDescriptor of the beginning of U3V payload
* I only have U3V camera whose data format is GenDC; I have never tested on GigE.

Reference: https://www.emva.org/wp-content/uploads/GenICam_GenDC_v1_1.pdf