### PR TITLE
Fix feature node access mode retrieval.

### DIFF
--- a/src/arvdevice.c
+++ b/src/arvdevice.c
@@ -356,7 +356,8 @@ arv_device_get_feature_access_mode (ArvDevice *device, const char *feature)
 	g_return_val_if_fail (feature != NULL, ARV_GC_ACCESS_MODE_UNDEFINED);
 
 	node = arv_device_get_feature (device, feature);
-	return ARV_IS_GC_FEATURE_NODE (node) && arv_gc_feature_node_get_actual_access_mode (ARV_GC_FEATURE_NODE (node));
+	g_return_val_if_fail (ARV_IS_GC_FEATURE_NODE (node), ARV_GC_ACCESS_MODE_UNDEFINED);
+	return arv_gc_feature_node_get_actual_access_mode (ARV_GC_FEATURE_NODE (node));
 }
 
 /**


### PR DESCRIPTION
Previously  the result was casted to a boolean, always returning `ARV_GC_ACCESS_MODE_RO` or `ARV_GC_ACCESS_MODE_WO`.
Now it returns the correct enum.