### PR TITLE
usb3vision: handle gendc payload

### DIFF
--- a/src/arvbuffer.c
+++ b/src/arvbuffer.c
@@ -42,7 +42,8 @@ arv_buffer_part_is_image (ArvBuffer *buffer, guint part_id)
                 part_id < buffer->priv->n_parts &&
                 (buffer->priv->payload_type == ARV_BUFFER_PAYLOAD_TYPE_IMAGE ||
                  buffer->priv->payload_type == ARV_BUFFER_PAYLOAD_TYPE_EXTENDED_CHUNK_DATA ||
-                 buffer->priv->payload_type == ARV_BUFFER_PAYLOAD_TYPE_MULTIPART) &&
+                 buffer->priv->payload_type == ARV_BUFFER_PAYLOAD_TYPE_MULTIPART ||
+				 buffer->priv->payload_type == ARV_BUFFER_PAYLOAD_TYPE_GENDC_CONTAINER ) &&
                 (buffer->priv->parts[part_id].data_type == ARV_BUFFER_PART_DATA_TYPE_2D_IMAGE ||
                  buffer->priv->parts[part_id].data_type == ARV_BUFFER_PART_DATA_TYPE_2D_PLANE_BIPLANAR ||
                  buffer->priv->parts[part_id].data_type == ARV_BUFFER_PART_DATA_TYPE_2D_PLANE_TRIPLANAR ||
@@ -244,6 +245,77 @@ arv_buffer_get_chunk_data (ArvBuffer *buffer, guint64 chunk_id, size_t *size)
 	};
 
 	return NULL;
+}
+
+/**
+ * arv_buffer_has_gendc:
+ * @buffer: a #ArvBuffer
+ *
+ * Returns: %TRUE if @buffer has a payload type that contains GenDC Data.
+ *
+ * Since: 0.10.0
+ */
+
+gboolean
+arv_buffer_has_gendc (ArvBuffer *buffer)
+{
+	return ARV_IS_BUFFER (buffer) &&
+		buffer->priv->status == ARV_BUFFER_STATUS_SUCCESS &&
+		buffer->priv->has_gendc;
+}
+
+/**
+ * arv_buffer_get_gendc_data:
+ * @buffer: a #ArvBuffer
+ * @size: (allow-none): location to store chunk data size, or %NULL
+ *
+ * GenDC Data accessor.
+ *
+ * Returns: (array length=size) (element-type guint8): a pointer to the GenDC Data .
+ *
+ * Since: 0.10.0
+ **/
+
+const void *
+arv_buffer_get_gendc_data (ArvBuffer *buffer, size_t *size)
+{
+	g_return_val_if_fail (arv_buffer_has_gendc (buffer), NULL);
+	g_return_val_if_fail (buffer->priv->data != NULL, NULL);
+
+	if (size != NULL)
+		*size = buffer->priv->gendc_data_size;
+
+	if (*size == 0)
+		return NULL;
+
+	return buffer->priv->data + buffer->priv->gendc_data_offset;
+}
+
+/**
+ * arv_buffer_get_gendc_descriptor:
+ * @buffer: a #ArvBuffer
+ * @size: (allow-none): location to store chunk data size, or %NULL
+ *
+ * GenDC Descriptor accessor.
+ *
+ * Returns: (array length=size) (element-type guint8): a pointer to the GenDC Descriptor.
+ *
+ * Since: 0.10.0
+ **/
+
+const void *
+arv_buffer_get_gendc_descriptor (ArvBuffer *buffer, size_t *size)
+{
+	g_return_val_if_fail (arv_buffer_has_gendc (buffer), NULL);
+	g_return_val_if_fail (buffer->priv->data != NULL, NULL);
+
+	if (size != NULL)
+		*size = buffer->priv->gendc_descriptor_size;
+
+	if (*size == 0)
+		return NULL;
+
+	return buffer->priv->data;
 }
 
 /**

--- a/src/arvbuffer.h
+++ b/src/arvbuffer.h
@@ -87,7 +87,9 @@ typedef enum {
 	ARV_BUFFER_PAYLOAD_TYPE_JPEG2000 = 		0x0007,
 	ARV_BUFFER_PAYLOAD_TYPE_H264 = 			0x0008,
 	ARV_BUFFER_PAYLOAD_TYPE_MULTIZONE_IMAGE = 	0x0009,
-	ARV_BUFFER_PAYLOAD_TYPE_MULTIPART =             0x000a
+	ARV_BUFFER_PAYLOAD_TYPE_MULTIPART =             0x000a,
+	ARV_BUFFER_PAYLOAD_TYPE_GENDC_CONTAINER =       0x000b, 
+	ARV_BUFFER_PAYLOAD_TYPE_GENDC_COMPONENT_DATA =  0x000c
 } ArvBufferPayloadType;
 
 typedef enum {
@@ -158,6 +160,10 @@ ARV_API gint			arv_buffer_get_image_y			(ArvBuffer *buffer);
 
 ARV_API gboolean		arv_buffer_has_chunks		(ArvBuffer *buffer);
 ARV_API const void *		arv_buffer_get_chunk_data	(ArvBuffer *buffer, guint64 chunk_id, size_t *size);
+
+ARV_API gboolean		arv_buffer_has_gendc			(ArvBuffer *buffer);
+ARV_API const void *	arv_buffer_get_gendc_data		(ArvBuffer *buffer, size_t *size);
+ARV_API const void *	arv_buffer_get_gendc_descriptor (ArvBuffer *buffer, size_t *size);
 
 G_END_DECLS
 

--- a/src/arvbufferprivate.h
+++ b/src/arvbufferprivate.h
@@ -65,6 +65,11 @@ typedef struct {
 
         guint n_parts;
         ArvBufferPartInfos *parts;
+
+	gboolean has_gendc;
+	guint32 gendc_descriptor_size;
+	guint64 gendc_data_size;
+	guint64 gendc_data_offset;
 } ArvBufferPrivate;
 
 struct _ArvBuffer {

--- a/src/arvuvstream.c
+++ b/src/arvuvstream.c
@@ -186,7 +186,8 @@ void LIBUSB_CALL arv_uv_stream_leader_cb (struct libusb_transfer *transfer)
                                         (packet, &ctx->buffer->priv->has_chunks);
                                 ctx->buffer->priv->chunk_endianness = G_LITTLE_ENDIAN;
                                 if (ctx->buffer->priv->payload_type == ARV_BUFFER_PAYLOAD_TYPE_IMAGE ||
-                                    ctx->buffer->priv->payload_type == ARV_BUFFER_PAYLOAD_TYPE_EXTENDED_CHUNK_DATA) {
+                                    ctx->buffer->priv->payload_type == ARV_BUFFER_PAYLOAD_TYPE_EXTENDED_CHUNK_DATA ||
+									ctx->buffer->priv->payload_type == ARV_BUFFER_PAYLOAD_TYPE_GENDC_CONTAINER ) {
                                         arv_buffer_set_n_parts(ctx->buffer, 1);
                                         ctx->buffer->priv->parts[0].data_offset = 0;
                                         ctx->buffer->priv->parts[0].component_id = 0;
@@ -222,6 +223,7 @@ static
 void LIBUSB_CALL arv_uv_stream_payload_cb (struct libusb_transfer *transfer)
 {
 	ArvUvStreamBufferContext *ctx = transfer->user_data;
+	int component_count;
 
         if (ctx->buffer != NULL) {
                 if (ctx->is_aborting) {
@@ -230,6 +232,41 @@ void LIBUSB_CALL arv_uv_stream_payload_cb (struct libusb_transfer *transfer)
                         switch (transfer->status) {
                                 case LIBUSB_TRANSFER_COMPLETED:
                                         ctx->total_payload_transferred += transfer->actual_length;
+
+										if (ctx->buffer->priv->payload_type == ARV_BUFFER_PAYLOAD_TYPE_GENDC_CONTAINER){
+											if(!arv_uvsp_packet_is_gendc (ctx->buffer->priv->data)){
+												arv_warning_sp ("Invalid GenDC Container: Signature shows %.4s which is supposed to be GNDC", ctx->buffer->priv->data);
+											}else{
+												ctx->buffer->priv->has_gendc = TRUE;
+												ctx->buffer->priv->gendc_data_offset = arv_uvsp_packet_get_gendc_dataoffset(ctx->buffer->priv->data);
+												ctx->buffer->priv->gendc_descriptor_size = arv_uvsp_packet_get_gendc_descriptorsize(ctx->buffer->priv->data);
+												ctx->buffer->priv->gendc_data_size = arv_uvsp_packet_get_gendc_datasize(ctx->buffer->priv->data);
+												component_count = (int) arv_uvsp_packet_get_gendc_componentcount(ctx->buffer->priv->data);
+												
+												for(int ith_component = 0; ith_component < component_count; ++ith_component){
+													int64_t ith_component_offset = arv_uvsp_packet_get_gendc_componentoffset(ctx->buffer->priv->data, ith_component);
+
+													if (arv_uvsp_packet_get_gendc_iscomponentvalid(ctx->buffer->priv->data + ith_component_offset)
+														&& arv_uvsp_packet_get_gendc_componenttypeid(ctx->buffer->priv->data + ith_component_offset) == 0x1 ){
+
+														guint64 partoffset = arv_uvsp_packet_get_gendc_partoffset(ctx->buffer->priv->data + ith_component_offset, 0);
+
+														ctx->buffer->priv->parts[0].data_offset = arv_uvsp_packet_get_gendc_partdatapffset(ctx->buffer->priv->data + partoffset);
+														ctx->buffer->priv->parts[0].component_id = ith_component;
+														ctx->buffer->priv->parts[0].data_type = ARV_BUFFER_PART_DATA_TYPE_2D_IMAGE;
+														ctx->buffer->priv->parts[0].pixel_format = arv_uvsp_packet_get_gendc_componentpixelformat(ctx->buffer->priv->data + ith_component_offset);
+														ctx->buffer->priv->parts[0].width = arv_uvsp_packet_get_gendc_partdimension_x(ctx->buffer->priv->data + partoffset);
+														ctx->buffer->priv->parts[0].width = arv_uvsp_packet_get_gendc_partdimension_y(ctx->buffer->priv->data + partoffset);
+														ctx->buffer->priv->parts[0].x_offset = 0;
+														ctx->buffer->priv->parts[0].y_offset = 0;
+														ctx->buffer->priv->parts[0].x_padding = arv_uvsp_packet_get_gendc_partpadding_x(ctx->buffer->priv->data + partoffset);
+														ctx->buffer->priv->parts[0].y_padding = arv_uvsp_packet_get_gendc_partpadding_y(ctx->buffer->priv->data + partoffset);
+
+														break;
+													}
+												}
+											}
+										}
                                         break;
                                 default:
                                         arv_warning_stream_thread ("Payload transfer failed (%s)",
@@ -557,6 +594,7 @@ arv_uv_stream_thread_sync (void *data)
 	void *incoming_buffer;
 	guint64 offset;
 	size_t transferred;
+	int component_count;
 
 	arv_info_stream_thread ("Start sync USB3Vision stream thread");
 
@@ -634,7 +672,8 @@ arv_uv_stream_thread_sync (void *data)
                                                         (packet, &buffer->priv->has_chunks);
 						buffer->priv->chunk_endianness = G_LITTLE_ENDIAN;
 						if (buffer->priv->payload_type == ARV_BUFFER_PAYLOAD_TYPE_IMAGE ||
-						    buffer->priv->payload_type == ARV_BUFFER_PAYLOAD_TYPE_EXTENDED_CHUNK_DATA) {
+						    buffer->priv->payload_type == ARV_BUFFER_PAYLOAD_TYPE_EXTENDED_CHUNK_DATA ||
+							buffer->priv->payload_type == ARV_BUFFER_PAYLOAD_TYPE_GENDC_CONTAINER) {
                                                         arv_buffer_set_n_parts(buffer, 1);
                                                         buffer->priv->parts[0].data_offset = 0;
                                                         buffer->priv->parts[0].component_id = 0;
@@ -708,6 +747,41 @@ arv_uv_stream_thread_sync (void *data)
                                                                         packet, transferred);
                                                         offset += transferred;
                                                         thread_data->statistics.n_transferred_bytes += transferred;
+
+														if (buffer->priv->payload_type == ARV_BUFFER_PAYLOAD_TYPE_GENDC_CONTAINER){
+															if(!arv_uvsp_packet_is_gendc (buffer->priv->data)){
+																arv_warning_sp ("Invalid GenDC Container: Signature shows %.4s which is supposed to be GNDC", buffer->priv->data);      
+															}else{
+																buffer->priv->has_gendc = TRUE;
+																buffer->priv->gendc_data_offset = arv_uvsp_packet_get_gendc_dataoffset(buffer->priv->data);
+																buffer->priv->gendc_descriptor_size = arv_uvsp_packet_get_gendc_descriptorsize(buffer->priv->data);
+																buffer->priv->gendc_data_size = arv_uvsp_packet_get_gendc_datasize(buffer->priv->data);
+
+																component_count = (int) arv_uvsp_packet_get_gendc_componentcount(buffer->priv->data);
+																for(int ith_component = 0; ith_component < component_count; ++ith_component){
+																	int64_t ith_component_offset = arv_uvsp_packet_get_gendc_componentoffset(buffer->priv->data, ith_component);    
+
+																	// only if the component is valid and have an image data (GDC_INTENSITY from SFNC)
+																	if (arv_uvsp_packet_get_gendc_iscomponentvalid(buffer->priv->data + ith_component_offset)
+																	&& arv_uvsp_packet_get_gendc_componenttypeid(buffer->priv->data + ith_component_offset) == 0x1 ){       
+																		guint64 partoffset = arv_uvsp_packet_get_gendc_partoffset(buffer->priv->data + ith_component_offset, 0);
+																		buffer->priv->parts[0].data_offset = arv_uvsp_packet_get_gendc_partdatapffset(buffer->priv->data + partoffset);
+																		buffer->priv->parts[0].component_id = ith_component;
+																		buffer->priv->parts[0].data_type = ARV_BUFFER_PART_DATA_TYPE_2D_IMAGE;
+																		buffer->priv->parts[0].pixel_format = arv_uvsp_packet_get_gendc_componentpixelformat(buffer->priv->data + ith_component_offset);
+																		buffer->priv->parts[0].width = arv_uvsp_packet_get_gendc_partdimension_x(buffer->priv->data + partoffset);
+																		buffer->priv->parts[0].width = arv_uvsp_packet_get_gendc_partdimension_y(buffer->priv->data + partoffset);
+																		buffer->priv->parts[0].x_offset = 0;
+																		buffer->priv->parts[0].y_offset = 0;
+																		buffer->priv->parts[0].x_padding = arv_uvsp_packet_get_gendc_partpadding_x(buffer->priv->data + partoffset);
+																		buffer->priv->parts[0].y_padding = arv_uvsp_packet_get_gendc_partpadding_y(buffer->priv->data + partoffset);
+
+																		break;
+																	}
+																}
+															}
+														}
+
                                                 } else {
                                                         buffer->priv->status = ARV_BUFFER_STATUS_SIZE_MISMATCH;
                                                         thread_data->statistics.n_ignored_bytes += transferred;


### PR DESCRIPTION
The image data can be retrieved using the multipart or image accessors for now.