### PR TITLE
Add GenTL namespace when using respective code.

### DIFF
--- a/src/arvgentldeviceprivate.h
+++ b/src/arvgentldeviceprivate.h
@@ -31,11 +31,17 @@
 #include <arvgentlsystemprivate.h>
 
 G_BEGIN_DECLS
+#ifdef G_CXX_STD_VERSION
+namespace GenTL {
+#endif
 
 ArvGenTLSystem *	arv_gentl_device_get_system                     (ArvGenTLDevice *device);
 DS_HANDLE       	arv_gentl_device_open_stream_handle             (ArvGenTLDevice *device);
 uint64_t	        arv_gentl_device_get_timestamp_tick_frequency   (ArvGenTLDevice *device);
 
+#ifdef G_CXX_STD_VERSION
+} /* end of namespace GenTL */
+#endif
 G_END_DECLS
 
 #endif

--- a/src/arvgentlsystemprivate.h
+++ b/src/arvgentlsystemprivate.h
@@ -31,6 +31,9 @@
 #include <GenTL_v1_5.h>
 
 G_BEGIN_DECLS
+#ifdef G_CXX_STD_VERSION
+namespace GenTL {
+#endif
 
 typedef struct {
     /* Global functions */
@@ -122,6 +125,9 @@ void 			arv_gentl_system_close_device_handle    (ArvGenTLSystem *system,
                                                                  const char *interface_id,
                                                                  DEV_HANDLE *device_handle);
 
+#ifdef G_CXX_STD_VERSION
+} /* end of namespace GenTL */
+#endif
 G_END_DECLS
 
 #endif

--- a/src/arvmiscprivate.h
+++ b/src/arvmiscprivate.h
@@ -88,7 +88,13 @@ ARV_API const char *	arv_vendor_alias_lookup	                (const char *vendor
 const char *            arv_protocol_from_transport_layer_type	(const char *transport_layer_type);
 const char *            arv_protocol_to_transport_layer_type	(const char *protocol);
 
+#ifdef G_CXX_STD_VERSION
+namespace GenTL {
+#endif
 const char *            arv_gentl_gc_error_to_string            (GC_ERROR error);
+#ifdef G_CXX_STD_VERSION
+} /* end of namespace GenTL */
+#endif
 
 /* this only wraps g_get_monotonic_time on non-windows platforms */
 gint64 arv_monotonic_time_us (void);


### PR DESCRIPTION
When compiling code with a C++ compiler the `GenTL_v1_5.h` header declares a couple of things inside an additional `GenTL` namespace.
If we compile for C++, we also need to use this namespace in order to compile successfully.