### PR TITLE
Add arv_camera_get_frame_rate_enable method.

### DIFF
--- a/src/arvcamera.c
+++ b/src/arvcamera.c
@@ -1354,6 +1354,55 @@ arv_camera_set_frame_rate_enable(ArvCamera *camera, gboolean enable, GError **er
 }
 
 /**
+ * arv_camera_get_frame_rate_enable:
+ * @camera: an #ArvCamera
+ * @error: a #GError placeholer, %NULL to ignore
+ *
+ * Returns: whether the upper frame rate limit is enabled.
+ *
+ * Implements vendor specific quirks if needed.
+ * Since: 0.8.31
+ */
+
+gboolean arv_camera_get_frame_rate_enable(ArvCamera* camera, GError** error)
+{
+	ArvCameraPrivate* priv = arv_camera_get_instance_private(camera);
+
+	g_return_val_if_fail(ARV_IS_CAMERA(camera), TRUE);
+
+	switch (priv->vendor)
+	{
+		case ARV_CAMERA_VENDOR_POINT_GREY_FLIR:
+			return arv_camera_get_boolean(camera,
+										  priv->has_acquisition_frame_rate_enabled
+											  ? "AcquisitionFrameRateEnabled"
+											  : "AcquisitionFrameRateEnable",
+										  error);
+		case ARV_CAMERA_VENDOR_BASLER:
+		case ARV_CAMERA_VENDOR_DALSA:
+		case ARV_CAMERA_VENDOR_RICOH:
+		case ARV_CAMERA_VENDOR_XIMEA:
+		case ARV_CAMERA_VENDOR_MATRIX_VISION:
+		case ARV_CAMERA_VENDOR_IMPERX:
+		case ARV_CAMERA_VENDOR_UNKNOWN:
+			if (arv_camera_is_feature_available(camera, "AcquisitionFrameRateEnable", error))
+			{
+				if (error != NULL)
+				{
+					return TRUE;
+				}
+				return arv_camera_get_boolean(camera, "AcquisitionFrameRateEnable", error);
+			}
+		case ARV_CAMERA_VENDOR_PROSILICA:
+		case ARV_CAMERA_VENDOR_TIS:
+		default:
+			break; /* No specific frame rate enable code */
+	}
+
+	return TRUE;
+}
+
+/**
  * arv_camera_set_trigger:
  * @camera: a #ArvCamera
  * @source: trigger source as string

--- a/src/arvcamera.h
+++ b/src/arvcamera.h
@@ -113,7 +113,8 @@ ARV_API ArvAcquisitionMode	arv_camera_get_acquisition_mode (ArvCamera *camera, G
 ARV_API void		arv_camera_set_frame_count		(ArvCamera *camera, gint64 frame_count, GError **error);
 ARV_API gint64		arv_camera_get_frame_count		(ArvCamera *camera, GError **error);
 ARV_API void		arv_camera_get_frame_count_bounds	(ArvCamera *camera, gint64 *min, gint64 *max, GError **error);
-ARV_API void            arv_camera_set_frame_rate_enable       (ArvCamera *camera, gboolean enable, GError **error);
+ARV_API gboolean        arv_camera_get_frame_rate_enable        (ArvCamera *camera, GError **error);
+ARV_API void            arv_camera_set_frame_rate_enable        (ArvCamera *camera, gboolean enable, GError **error);
 
 ARV_API gboolean	arv_camera_is_frame_rate_available	(ArvCamera *camera, GError **error);
 


### PR DESCRIPTION
This is corresponding to the arv_camera_set_frame_rate_enable method and includes some camera-specific quirks.

See also #876 for some other cleanups.