### PR TITLE
Make sure to only disable frame rate if necessary.

### DIFF
--- a/src/arvcamera.c
+++ b/src/arvcamera.c
@@ -1381,6 +1381,7 @@ gboolean arv_camera_get_frame_rate_enable(ArvCamera* camera, GError** error)
 			{
 				return arv_camera_get_boolean(camera, "AcquisitionFrameRateEnable", error);
 			}
+			break;
 		case ARV_CAMERA_VENDOR_PROSILICA:
 		case ARV_CAMERA_VENDOR_TIS:
 		default:

--- a/src/arvcamera.c
+++ b/src/arvcamera.c
@@ -1377,12 +1377,8 @@ gboolean arv_camera_get_frame_rate_enable(ArvCamera* camera, GError** error)
 		case ARV_CAMERA_VENDOR_MATRIX_VISION:
 		case ARV_CAMERA_VENDOR_IMPERX:
 		case ARV_CAMERA_VENDOR_UNKNOWN:
-			if (arv_camera_is_feature_available(camera, "AcquisitionFrameRateEnable", error))
+			if (arv_camera_is_feature_available(camera, "AcquisitionFrameRateEnable", NULL))
 			{
-				if (error != NULL)
-				{
-					return TRUE;
-				}
 				return arv_camera_get_boolean(camera, "AcquisitionFrameRateEnable", error);
 			}
 		case ARV_CAMERA_VENDOR_PROSILICA:
@@ -1424,7 +1420,11 @@ arv_camera_set_trigger (ArvCamera *camera, const char *source, GError **error)
 	g_return_if_fail (ARV_IS_CAMERA (camera));
 	g_return_if_fail (source != NULL);
 
-	arv_camera_set_frame_rate_enable (camera, FALSE, &local_error);
+	if (arv_camera_get_frame_rate_enable(camera, &local_error)) {
+		if (local_error == NULL) {
+			arv_camera_set_frame_rate_enable (camera, FALSE, &local_error);
+		}
+	}
 
 	if (local_error == NULL) {
 			has_trigger_selector = arv_camera_is_feature_available(camera, "TriggerSelector", &local_error);


### PR DESCRIPTION
Previously irrespective of whether a trigger was set or not the frame rate was tried to be disabled. However, this failed (at least for an Allied Vision-Alvium G1-1240c) if already a trigger was set, causing the whole set_trigger call to fail.
The failure was actually introduced with https://github.com/AravisProject/aravis/pull/877/files#diff-d7be5be1f918127f4161b7f5a654290347f3334e434d14a61eb04e013b85dd99R1388 where the local_error was for the first time checked (Before that it was set but ignored).

This also fixes a bug where the wrong error pointer was checked in arv_camera_get_frame_rate_enable.