### PR TITLE
xml: make error struct constant

### DIFF
--- a/src/arvxmlschema.c
+++ b/src/arvxmlschema.c
@@ -69,7 +69,7 @@ typedef struct {
 } XmlSchemaError;
 
 static void
-_structured_error_handler (void *ctx, xmlErrorPtr error)
+_structured_error_handler (void *ctx, const xmlError* error)
 {
 	XmlSchemaError *schema_error = ctx;
 


### PR DESCRIPTION
As of https://gitlab.gnome.org/GNOME/libxml2/-/commit/61034116d0a3c8b295c6137956adc3ae55720711, the error struct in the callback is const

I could also add a cast to `xmlStructuredErrorFunc` on the use sites so it compiles against both new and old versions of libxml without warnings/errors.