### PR TITLE
Fix compilation with libxml older than 2.12.

### DIFF
--- a/src/arvxmlschema.c
+++ b/src/arvxmlschema.c
@@ -30,6 +30,7 @@
 #include <libxml/parser.h>
 #include <libxml/valid.h>
 #include <libxml/xmlschemas.h>
+#include <libxml/xmlversion.h>
 #include <gio/gio.h>
 #include <arvdebugprivate.h>
 #include <arvmiscprivate.h>
@@ -69,7 +70,11 @@ typedef struct {
 } XmlSchemaError;
 
 static void
+#if LIBXML_VERSION >= 21200
 _structured_error_handler (void *ctx, const xmlError* error)
+#else
+_structured_error_handler (void *ctx, xmlErrorPtr error)
+#endif
 {
 	XmlSchemaError *schema_error = ctx;
 


### PR DESCRIPTION
#880 introduced compatibility with libxml 2.12, but also caused compilation errors on systems with only 2.11.
This fixes compilation for systems with older libxml versions.