### PR TITLE
Add timeout for auto packet size determination.

### DIFF
--- a/src/arvcamera.c
+++ b/src/arvcamera.c
@@ -3555,9 +3555,9 @@ arv_camera_gv_get_packet_size (ArvCamera *camera, GError **error)
  * @camera: a #ArvCamera
  * @error: a #GError placeholder, %NULL to ignore
  *
- * Automatically determine the biggest packet size that can be used data
- * streaming, and set GevSCPSPacketSize value accordingly. This function relies
- * on the GevSCPSFireTestPacket feature. If this feature is not available, the
+ * Automatically determine the biggest packet size that can be used for data
+ * streaming, and set GevSCPSPacketSize value accordingly. This function times
+ * out after 1 second. If this feature is not available, the
  * packet size will be set to a default value (1500 bytes).
  *
  * Returns: The packet size, in bytes.

--- a/src/arvgvdevice.c
+++ b/src/arvgvdevice.c
@@ -655,7 +655,7 @@ auto_packet_size (ArvGvDevice *gv_device, gboolean exit_early, GError **error)
 	guint16 port;
 	gboolean do_not_fragment;
 	guint max_size, min_size;
-	gint64 minimum, maximum, packet_size;
+	gint64 minimum, maximum, packet_size, initial_size;
 	guint inc;
 	char *buffer;
 	guint last_size = 0;
@@ -665,6 +665,7 @@ auto_packet_size (ArvGvDevice *gv_device, gboolean exit_early, GError **error)
 	g_return_val_if_fail (ARV_IS_GV_DEVICE (gv_device), 1500);
 
 	packet_size = arv_device_get_integer_feature_value (device, "ArvGevSCPSPacketSize", NULL);
+	initial_size = packet_size;
 
         /* PacketSize boundaries registers are device specific. Use the standard feature name for finding boundaries. If
          * this feature is not present in the device Genicam data, it will fallback to the default definition inserted
@@ -725,7 +726,7 @@ auto_packet_size (ArvGvDevice *gv_device, gboolean exit_early, GError **error)
 		do {
 			if (g_timer_elapsed (timer, NULL) > 1.0) {
 				arv_info_device ("[GvDevice::auto_packet_size] Could not finish sending test packets within 1s");
-				packet_size = arv_device_get_integer_feature_value (device, "ArvGevSCPSPacketSize", &local_error);
+				packet_size = initial_size;
 				break;
 			}
 

--- a/src/arvgvdevice.c
+++ b/src/arvgvdevice.c
@@ -724,7 +724,8 @@ auto_packet_size (ArvGvDevice *gv_device, gboolean exit_early, GError **error)
 
 		do {
 			if (g_timer_elapsed (timer, NULL) > 1.0) {
-				g_set_error (&local_error, ARV_DEVICE_ERROR, ARV_DEVICE_ERROR_TIMEOUT, "Could not finish sending test packets within 1s.");
+				arv_info_device ("[GvDevice::auto_packet_size] Could not finish sending test packets within 1s");
+				packet_size = arv_device_get_integer_feature_value (device, "ArvGevSCPSPacketSize", &local_error);
 				break;
 			}
 
@@ -788,7 +789,7 @@ auto_packet_size (ArvGvDevice *gv_device, gboolean exit_early, GError **error)
  * Automatically determine the biggest packet size that can be used for data streaming, and set ArvGevSCPSPacketSize value
  * accordingly. This function times out after 1 second.
  *
- * Returns: The automatic packet size, in bytes, which could be determined within 1 second.
+ * Returns: The automatic packet size, in bytes, or the current one if it could not be determined within 1 second.
  *
  * Since: 0.6.0
  */


### PR DESCRIPTION
Previously, we relied on the availability of the `GevSCPSFireTestPacket` feature. By adding a timeout we can now also support cameras without this feature.

This is a follow-up to #886 and, as mentioned in e30bdaf064a5e12434f448b3cc61e707260d91bd,  should also be able to deal with cameras such as the DMK 23G618 which takes 300ms to complete a single fire test packet command using `ArvGevSCPSFireTestPacket`.