### PR TITLE
device: use const void* in `arv_device_write_memory`

### DIFF
--- a/src/arvdevice.c
+++ b/src/arvdevice.c
@@ -174,7 +174,7 @@ arv_device_read_memory (ArvDevice *device, guint64 address, guint32 size, void *
  **/
 
 gboolean
-arv_device_write_memory (ArvDevice *device, guint64 address, guint32 size, void *buffer, GError **error)
+arv_device_write_memory (ArvDevice *device, guint64 address, guint32 size, const void *buffer, GError **error)
 {
 	g_return_val_if_fail (ARV_IS_DEVICE (device), FALSE);
 	g_return_val_if_fail (buffer != NULL, FALSE);

--- a/src/arvdevice.h
+++ b/src/arvdevice.h
@@ -90,7 +90,7 @@ struct _ArvDeviceClass {
 	ArvGc *		(*get_genicam)		(ArvDevice *device);
 
 	gboolean	(*read_memory)		(ArvDevice *device, guint64 address, guint32 size, void *buffer, GError **error);
-	gboolean	(*write_memory)		(ArvDevice *device, guint64 address, guint32 size, void *buffer, GError **error);
+	gboolean	(*write_memory)		(ArvDevice *device, guint64 address, guint32 size, const void *buffer, GError **error);
 	gboolean	(*read_register)	(ArvDevice *device, guint64 address, guint32 *value, GError **error);
 	gboolean	(*write_register)	(ArvDevice *device, guint64 address, guint32 value, GError **error);
 #if ARAVIS_HAS_EVENT
@@ -115,7 +115,7 @@ ARV_API gboolean        arv_device_start_acquisition            (ArvDevice *devi
 ARV_API gboolean        arv_device_stop_acquisition             (ArvDevice *device, GError **error);
 
 ARV_API gboolean	arv_device_read_memory			(ArvDevice *device, guint64 address, guint32 size, void *buffer, GError **error);
-ARV_API gboolean	arv_device_write_memory			(ArvDevice *device, guint64 address, guint32 size, void *buffer, GError **error);
+ARV_API gboolean	arv_device_write_memory			(ArvDevice *device, guint64 address, guint32 size, const void *buffer, GError **error);
 ARV_API gboolean	arv_device_read_register		(ArvDevice *device, guint64 address, guint32 *value, GError **error);
 ARV_API gboolean	arv_device_write_register		(ArvDevice *device, guint64 address, guint32 value, GError **error);
 #if ARAVIS_HAS_EVENT


### PR DESCRIPTION
The purpose of this PR is to be able to generate a corresponding [FFI binding in Rust](https://docs.rs/aravis/latest/aravis/) without needing `mut` on the buffer to be written.