### PR TITLE
Fix `arv_buffer_get_chunk_data` for extended chunk data.

### DIFF
--- a/src/arvgvspprivate.h
+++ b/src/arvgvspprivate.h
@@ -377,7 +377,8 @@ arv_gvsp_leader_packet_get_buffer_payload_type (const ArvGvspPacket *packet, gbo
 
                 if (has_chunks != NULL)
                         *has_chunks = ((payload_type & 0x4000) != 0 ||
-                                       (payload_type == 0x0004));
+                                       (payload_type == ARV_BUFFER_PAYLOAD_TYPE_CHUNK_DATA) ||
+                                       (payload_type == ARV_BUFFER_PAYLOAD_TYPE_EXTENDED_CHUNK_DATA));
 
                 return (ArvBufferPayloadType) (payload_type & 0x3fff);
         }


### PR DESCRIPTION
Before the fix with a FLIR Blackfly S BFS-PGE-23S3C in chunk mode I received lots of `** (process:1179494): CRITICAL **: 08:18:03.408: arv_buffer_get_chunk_data: assertion 'arv_buffer_has_chunks (buffer)' failed` errors, as this camera only supports `ARV_BUFFER_PAYLOAD_TYPE_EXTENDED_CHUNK_DATA`.