### PR TITLE
Better documentation, error messages, defaults regarding the gige socket-buffer-size

### DIFF
--- a/src/arvgvstream.c
+++ b/src/arvgvstream.c
@@ -1831,7 +1831,7 @@ arv_gv_stream_class_init (ArvGvStreamClass *gv_stream_class)
 		g_param_spec_enum ("socket-buffer", "Socket buffer",
 				   "Socket buffer behaviour",
 				   ARV_TYPE_GV_STREAM_SOCKET_BUFFER,
-				   ARV_GV_STREAM_SOCKET_BUFFER_FIXED,
+				   ARV_GV_STREAM_SOCKET_BUFFER_AUTO,
 				  G_PARAM_CONSTRUCT |  G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)
 		);
         /**

--- a/src/arvgvstream.c
+++ b/src/arvgvstream.c
@@ -1821,7 +1821,10 @@ arv_gv_stream_class_init (ArvGvStreamClass *gv_stream_class)
         /**
          * ArvGvStream:socket-buffer:
          *
-         * Incoming socket buffer policy.
+         * Incoming socket buffer policy. Controls the buffer size we try to with setsockopt(..., SO_RCVBUF, ...).
+         * ARV_GV_STREAM_SOCKET_BUFFER_FIXED means "use a buffer of the size given by the socket-buffer-size property,
+         * if given; if socket-buffer-size is not given or <=0, don't set anything". ARV_GV_STREAM_SOCKET_BUFFER_AUTO
+         * means "use a buffer that fits one-frame-worth of data or socket-buffer-size, whichever is smaller"
          */
 	g_object_class_install_property (
 		object_class, ARV_GV_STREAM_PROPERTY_SOCKET_BUFFER,
@@ -1835,7 +1838,8 @@ arv_gv_stream_class_init (ArvGvStreamClass *gv_stream_class)
          * ArvGvStream:socket-buffer-size:
          *
          * Size in bytes of the incoming socket buffer. A greater value helps to lower the number of missings packets,
-         * as the expense of an increased memory usage.
+         * as the expense of an increased memory usage. See the documentation for the "socket-buffer" property above for
+         * details
          */
 	g_object_class_install_property (
 		object_class, ARV_GV_STREAM_PROPERTY_SOCKET_BUFFER_SIZE,

--- a/src/arvnetwork.c
+++ b/src/arvnetwork.c
@@ -463,14 +463,16 @@ arv_socket_set_recv_buffer_size (int socket_fd, gint buffer_size)
 	int result;
 
 #ifndef G_OS_WIN32
-	result = setsockopt (socket_fd, SOL_SOCKET, SO_RCVBUF, &buffer_size, sizeof (buffer_size));
+	#define T gint
 #else
-	{
-		DWORD _buffer_size=buffer_size;
-		result = setsockopt (socket_fd, SOL_SOCKET, SO_RCVBUF,
-				     (const char*) &_buffer_size, sizeof (_buffer_size));
-	}
+	#define T DWORD
 #endif
+
+	T _buffer_size=buffer_size;
+	result = setsockopt (socket_fd, SOL_SOCKET, SO_RCVBUF,
+			     (const char*) &_buffer_size, sizeof (_buffer_size));
+
+#undef T
 
 	return result == 0;
 }


### PR DESCRIPTION
These are the result of me encountering and debugging packet-dropping issues: https://github.com/AravisProject/aravis/issues/894

Primarily these patches add more error reporting and documentation. With the extended error messages I think it makes sense to change the default socket-buffer policy to `ARV_GV_STREAM_SOCKET_BUFFER_AUTO`, which this patch series does.

There's one more thing I would change also, but want to get your thoughts about all this first:

If setsockopt() returns success, but doesn't actually give us the requested buffer, we currently:

- Report a `arv_warning_interface()`
- `arv_socket_set_recv_buffer_size()` returns FALSE
But the caller of `arv_socket_set_recv_buffer_size()` doesn't do anything with this FALSE, and things continue as normal. I would make this a hard error, and I'd change the `arv_warning_interface()` to something that would be seen even without any `ARV_DEBUG` flags.

Thanks much