### PR TITLE
Add missing private header.

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -188,6 +188,7 @@ library_private_headers = [
 	'arvgvinterfaceprivate.h',
 	'arvgvspprivate.h',
 	'arvgvstreamprivate.h',
+	'arvgentlsystemprivate.h',
 	'arvgentlinterfaceprivate.h',
 	'arvgentldeviceprivate.h',
 	'arvgentlstreamprivate.h',


### PR DESCRIPTION
The corresponding sources and headers were defined, but not the private headers.