### PR TITLE
ci: disable mingw32 for now

### DIFF
--- a/.github/workflows/aravis-mingw.yml
+++ b/.github/workflows/aravis-mingw.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         include:
           - { sys: mingw64, env: x86_64 }
-          - { sys: mingw32, env: i686 }
+          # - { sys: mingw32, env: i686 } # mingw32 is missing gst-plugins-good package, disabled for now
           - { sys: ucrt64,  env: ucrt-x86_64 }
           # - { sys: clang64, env: clang-x86_64 } # clang64 is missing several packages, disabled for now
     defaults:


### PR DESCRIPTION
gst-plugins-goods and libusb seems to be missing:

```
  Enter a selection (default=all): error: target not found: mingw-w64-i686-gst-plugins-good
  error: target not found: mingw-w64-i686-libusb
```