### PR TITLE
Workaround for BlackFly U16 pixel endianness issues

### DIFF
--- a/src/arvcamera.h
+++ b/src/arvcamera.h
@@ -98,6 +98,7 @@ ARV_API const char *	arv_camera_get_pixel_format_as_string			(ArvCamera *camera,
 ARV_API gint64 *	arv_camera_dup_available_pixel_formats			(ArvCamera *camera, guint *n_pixel_formats, GError **error);
 ARV_API const char **	arv_camera_dup_available_pixel_formats_as_strings	(ArvCamera *camera, guint *n_pixel_formats, GError **error);
 ARV_API const char **	arv_camera_dup_available_pixel_formats_as_display_names	(ArvCamera *camera, guint *n_pixel_formats, GError **error);
+ARV_API gboolean	arv_camera_has_incorrect_pixel_endianness(ArvCamera *camera);
 
 /* Acquisition control */
 


### PR DESCRIPTION
Proposed solution for the endianness problem discussed here: https://github.com/AravisProject/aravis/issues/921

`ArvCamera` detects devices known to have pixel endianness issues using a model/vendor table, the result can be queried through `arv_camera_has_incorrect_pixel_endianness`.  This is used by the viewer to byte-swap pixels.

Shortcomings:
- It would be better to do the byte-swapping transparently in aravis as the packets are received and not in the viewer
- The user should be able to control the table of devices without having to recompile Aravis, or at least specify an option to activate the fix
- This code assumes the machine is little endian
- Code not optimized for the case where the rows have to be aligned AND the pixels byte-swapped
- Only handles MONO_U16
