### PR TITLE
Workaround for BlackFly U16 pixel endianness issues

### DIFF
--- a/src/arvmisc.h
+++ b/src/arvmisc.h
@@ -37,6 +37,9 @@ ARV_API guint                   arv_get_minor_version           (void);
 ARV_API guint                   arv_get_micro_version           (void);
 
 ARV_API const char *		arv_pixel_format_to_gst_caps_string		(ArvPixelFormat pixel_format);
+ARV_API const char *		arv_pixel_format_and_vendor_model_to_gst_caps_string (ArvPixelFormat pixel_format,
+										      const char *vendor_name,
+										      const char *model_name);
 ARV_API ArvPixelFormat		arv_pixel_format_from_gst_caps			(const char *name, const char *format,
                                                                                  int bpp, int depth);
 ARV_API const char *		arv_pixel_format_to_gst_0_10_caps_string	(ArvPixelFormat pixel_format);

--- a/viewer/arvviewer.c
+++ b/viewer/arvviewer.c
@@ -1477,7 +1477,11 @@ start_video (ArvViewer *viewer)
 	set_camera_widgets(viewer);
 	pixel_format = arv_camera_get_pixel_format (viewer->camera, NULL);
 
-	caps_string = arv_pixel_format_to_gst_caps_string (pixel_format);
+	caps_string = arv_pixel_format_and_vendor_model_to_gst_caps_string
+		(pixel_format,
+		 arv_camera_get_vendor_name (viewer->camera, NULL),
+		 arv_camera_get_model_name (viewer->camera, NULL));
+									    
 	if (caps_string == NULL) {
 		g_message ("GStreamer cannot understand this camera pixel format: 0x%x!", (int) pixel_format);
 		stop_video (viewer);


### PR DESCRIPTION
Continuation of https://github.com/AravisProject/aravis/pull/922

As requested, only arvmisc and arvviewer were modified, endianness is handled by the gstreamer plugin.
