### PR TITLE
gst: workaround for BlackFly U16 pixel endianness issues

### DIFF
--- a/src/arvmisc.h
+++ b/src/arvmisc.h
@@ -37,6 +37,9 @@ ARV_API guint                   arv_get_minor_version           (void);
 ARV_API guint                   arv_get_micro_version           (void);
 
 ARV_API const char *		arv_pixel_format_to_gst_caps_string		(ArvPixelFormat pixel_format);
+ARV_API const char *		arv_pixel_format_to_gst_caps_string_full        (ArvPixelFormat pixel_format,
+                                                                                 const char *vendor_name,
+                                                                                 const char *model_name);
 ARV_API ArvPixelFormat		arv_pixel_format_from_gst_caps			(const char *name, const char *format,
                                                                                  int bpp, int depth);
 ARV_API const char *		arv_pixel_format_to_gst_0_10_caps_string	(ArvPixelFormat pixel_format);

--- a/tests/misc.c
+++ b/tests/misc.c
@@ -207,6 +207,13 @@ caps_string_test (void)
                 caps_string = arv_pixel_format_to_gst_caps_string (caps_data[i].pixel_format);
                 g_assert (caps_string != NULL);
         }
+
+        for (i = 0; i < G_N_ELEMENTS (caps_data); i++) {
+                const char *caps_string;
+
+                caps_string = arv_pixel_format_to_gst_caps_string_full (caps_data[i].pixel_format, "Vendor", "Model");
+                g_assert (caps_string != NULL);
+        }
 }
 
 struct {

--- a/viewer/arvviewer.c
+++ b/viewer/arvviewer.c
@@ -1479,16 +1479,20 @@ start_video (ArvViewer *viewer)
 	set_camera_widgets(viewer);
 	pixel_format = arv_camera_get_pixel_format (viewer->camera, NULL);
 
-	caps_string = arv_pixel_format_to_gst_caps_string (pixel_format);
-	if (caps_string == NULL) {
-		g_message ("GStreamer cannot understand this camera pixel format: 0x%x!", (int) pixel_format);
-		stop_video (viewer);
-		return FALSE;
+        caps_string = arv_pixel_format_to_gst_caps_string_full
+                (pixel_format,
+                 arv_camera_get_vendor_name (viewer->camera, NULL),
+                 arv_camera_get_model_name (viewer->camera, NULL));
+
+        if (caps_string == NULL) {
+                g_message ("GStreamer cannot understand this camera pixel format: 0x%x!", (int) pixel_format);
+                stop_video (viewer);
+                return FALSE;
         } else if (g_str_has_prefix (caps_string, "video/x-bayer") && !has_bayer2rgb) {
-		g_message ("GStreamer bayer plugin is required for pixel format: 0x%x!", (int) pixel_format);
-		stop_video (viewer);
-		return FALSE;
-	}
+                g_message ("GStreamer bayer plugin is required for pixel format: 0x%x!", (int) pixel_format);
+                stop_video (viewer);
+                return FALSE;
+        }
 
         arv_camera_set_acquisition_mode (viewer->camera, ARV_ACQUISITION_MODE_CONTINUOUS, NULL);
 	arv_camera_start_acquisition (viewer->camera, NULL);


### PR DESCRIPTION
This camera send Mono16 in big endian, while it should send little endian data. Use the right gst caps string according to an exception list.