### PR TITLE
gst: set_trigger & software_trigger added for `aravissrc`

### DIFF
--- a/gst/gstaravis.h
+++ b/gst/gstaravis.h
@@ -79,11 +79,15 @@ struct _GstAravis {
 	guint64 timestamp_offset;
 	guint64 last_timestamp;
 
+	gboolean set_trigger;
+
 	char *features;
 };
 
 struct _GstAravisClass {
 	GstPushSrcClass parent_class;
+
+    void (*trigger) (GstAravis *src);
 };
 
 GType gst_aravis_get_type (void);

--- a/gst/gstaravis.h
+++ b/gst/gstaravis.h
@@ -79,7 +79,8 @@ struct _GstAravis {
 	guint64 timestamp_offset;
 	guint64 last_timestamp;
 
-	gboolean set_trigger;
+	char *trigger_source;
+	gboolean trigger_mode;
 
 	char *features;
 };
@@ -87,7 +88,7 @@ struct _GstAravis {
 struct _GstAravisClass {
 	GstPushSrcClass parent_class;
 
-    void (*trigger) (GstAravis *src);
+    void (*software_trigger) (GstAravis *src);
 };
 
 GType gst_aravis_get_type (void);


### PR DESCRIPTION
## Overview
 - `set-trigger` and `software-trigger` have been added to `aravissrc`
 - Tested on iRAYPLE's [A5051CU545E](https://www.irayple.com/en/productDetail/555)
```
 - USB3.0 interface, 5Gbps theoretical transfer bandwidth, power supply via USB interface
 - Compatible with USB3.0 Vision protocol and GenICam standard
 - Support Software Trigger/Hardware Trigger/Free Run Mode
 - Resolution: 800 × 600
 - Frame Rate: 545 fps
```
```sh
$ arv-tool-0.10 features PixelFormat
Dahua Technology  (USB3)
        Enumeration  : [RW] 'PixelFormat'
            EnumEntry   : 'BayerGB10Packed'
            EnumEntry   : 'BayerRG10Packed'
            EnumEntry   : 'BayerGB10'
            EnumEntry   : 'BayerRG10'
            EnumEntry   : 'BayerGB8'
            EnumEntry   : 'BayerRG8'
```
   

## Example
- `set-trigger`(bool) and `software-trigger`(func) are added
```
# export GST_PLUGIN_PATH=$GST_PLUGIN_PATH:<ARAVIS_ROOT>/build/gst

$ gst-inspect-1.0 aravissrc

  ...

  set-trigger         : Configures the camera in trigger mode
                        flags: readable, writable
                        Boolean. Default: false
  typefind            : Run typefind before negotiating (deprecated, non-functional)
                        flags: readable, writable, deprecated
                        Boolean. Default: false
  usb-mode            : USB mode (synchronous/asynchronous)
                        flags: readable, writable
                        Enum "GstArvUsbMode" Default: 1, "default"
                           (0): sync             - Synchronous
                           (1): async            - Asynchronous
                           (1): default          - Default
  v-binning           : CCD vertical binning
                        flags: readable, writable
                        Integer. Range: 1 - 2147483647 Default: -1 

Element Actions:
  "software-trigger" :  void user_function (GstElement* object);
```

## Python

<details>
<summary>arv-software-trigger.py</summary>

```py
import gi
import threading
import time

gi.require_version('Gst', '1.0')
from gi.repository import Gst, GLib

# Initialize GStreamer
Gst.init(None)

def main():

    # File to save timestamps
    output_file = open("timestamps.txt", "w")

    def on_handoff(fakesink, buffer, pad, user_data):
        # Retrieve the timestamp from the buffer
        timestamp = buffer.pts
        # Convert to nanoseconds and write to file
        output_file.write(f"{timestamp}\n")

    # Create GStreamer elements
    aravissrc = Gst.ElementFactory.make("aravissrc", "source")
    aravissrc.set_property("exposure", 1700)
    aravissrc.set_property("do-timestamp", True)
    aravissrc.set_property("set-trigger", True) 

    bayer_caps = Gst.Caps.from_string("video/x-bayer,format=rggb,width=800,height=600")
    bayer2rgb = Gst.ElementFactory.make("bayer2rgb", "bayer2rgb")

    videoconvert = Gst.ElementFactory.make("videoconvert", "videoconvert")
    
    fakesink = Gst.ElementFactory.make("fakesink", "fakesink")
    fakesink.set_property("signal-handoffs", True)

    # Create a new pipeline
    pipeline = Gst.Pipeline.new("mypipeline")

    # Add elements to the pipeline
    pipeline.add(aravissrc)
    pipeline.add(bayer2rgb)
    pipeline.add(videoconvert)
    pipeline.add(fakesink)

    # Link the elements with the capsfilter in between
    aravissrc.link_filtered(bayer2rgb, bayer_caps)
    bayer2rgb.link(videoconvert)
    videoconvert.link(fakesink)

    # Connect the handoff signal to the callback function
    fakesink.connect("handoff", on_handoff, None)

    # Function to trigger the camera
    def trigger_camera():
        while True:
            time.sleep(0.002)  # Sleep for 2 milliseconds (500fps)
            aravissrc.emit("software-trigger")

    # Create and start the trigger thread
    trigger_thread = threading.Thread(target=trigger_camera)
    trigger_thread.daemon = True  # Daemonize thread so it exits when the main program does
    trigger_thread.start()

    # Start the pipeline
    pipeline.set_state(Gst.State.PLAYING)

    # Run the pipeline
    loop = GLib.MainLoop()
    try:
        loop.run()
    except KeyboardInterrupt:
        pass

    # Clean up
    pipeline.set_state(Gst.State.NULL)
    output_file.close()

if __name__ == "__main__":
    main()
```
</details>

## Result

![Figure_1](https://github.com/user-attachments/assets/59cdf1f2-c754-4f28-9d4c-4f2297458af2)
