### PR TITLE
Clang format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,23 @@
+# https://clang.llvm.org/docs/ClangFormatStyleOptions.html
+# Glib has formatting at https://wiki.apertis.org/Guidelines/Coding_conventions#Code_formatting
+# https://gitlab.gnome.org/GNOME/glib/-/blob/main/.clang-format
+# But we do not follow it fully
+BasedOnStyle: GNU
+AllowShortIfStatementsOnASingleLine: AllIfsAndElse
+AllowShortLoopsOnASingleLine: true
+BinPackParameters: false
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Linux
+BreakBeforeTernaryOperators: false
+ColumnLimit: 0
+ContinuationIndentWidth: 8
+Cpp11BracedListStyle: false
+FixNamespaceComments: false
+IndentCaseLabels: true
+IndentGotoLabels: false
+IndentWidth: 8
+SeparateDefinitionBlocks: Always
+SortIncludes: Never
+SpaceAfterCStyleCast: true
+SpaceBeforeParens: Always
+UseTab: Always

--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -1,0 +1,34 @@
+name: Clang Format Check
+
+on:
+  pull_request:
+    paths:
+      - '**/*.cpp'
+      - '**/*.h'
+
+jobs:
+  clang-format:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Fetch pull request changes
+      run: git fetch origin +refs/pull/${{ github.event.pull_request.number }}/merge
+
+    - name: Generate diff of changes
+      run: git diff origin/main...HEAD > changes.diff
+
+    - name: Run clang-format-diff
+      run: |
+        cat changes.diff | clang-format-diff -p1 -i
+
+    - name: Check for formatting changes
+      run: |
+        if ! git diff --exit-code
+        then
+          echo "Clang-format found issues in the following files:"
+          git diff --name-only
+          exit 1
+        fi


### PR DESCRIPTION
The source code has some lines indented with tabs and some lines indented with spaces expecting different tab widths.

This clang-format definition helps format code close to what I see the most code is formatted to.

Visual Studio Code has a [Clang-Format extension](https://marketplace.visualstudio.com/items?itemName=xaver.clang-format) that is able to make use of this definition, as I expect many other editors have their own plugins.

I did not test the workflow, but it may be close to something to check if PR is trying to push new badly formatted code. I find Codacy to also have some clang-tidy tool, but I am not familiar with that.
