### PR TITLE
aravis-tools: Correct appstream metainfo description and file name

### DIFF
--- a/viewer/data/meson.build
+++ b/viewer/data/meson.build
@@ -4,7 +4,7 @@ appdata_conf = configuration_data()
 appdata_conf.set ('ARAVIS_API_VERSION', aravis_api_version)
 
 configure_file (input: files('org.aravis.viewer.appdata.xml.in'),
-		output: 'org.aravis.viewer-@0@.appdata.xml'.format (aravis_api_version),
+		output: 'org.aravis.viewer.metainfo.xml'.format (aravis_api_version),
 		configuration: appdata_conf,
 		install_dir: aravis_app_data_dir)
 

--- a/viewer/data/meson.build
+++ b/viewer/data/meson.build
@@ -4,7 +4,7 @@ appdata_conf = configuration_data()
 appdata_conf.set ('ARAVIS_API_VERSION', aravis_api_version)
 
 configure_file (input: files('org.aravis.viewer.appdata.xml.in'),
-		output: 'org.aravis.viewer.metainfo.xml'.format (aravis_api_version),
+		output: 'org.aravis.viewer-@0@.metainfo.xml'.format (aravis_api_version),
 		configuration: appdata_conf,
 		install_dir: aravis_app_data_dir)
 

--- a/viewer/data/org.aravis.viewer.appdata.xml.in
+++ b/viewer/data/org.aravis.viewer.appdata.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright 2014-2023 Emmanuel Pacaud <emmanuel.pacaud@free.fr> -->
 <component type="desktop-application">
-  <id>org.aravis.viewer</id>
+  <id>org.aravis.viewer-@ARAVIS_API_VERSION@</id>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>LGPL-2.0-or-later</project_license>
   <name>Aravis Viewer</name>

--- a/viewer/data/org.aravis.viewer.appdata.xml.in
+++ b/viewer/data/org.aravis.viewer.appdata.xml.in
@@ -7,9 +7,9 @@
   <name>Aravis Viewer</name>
   <summary>Viewer for industial camera video stream</summary>
   <description>
-    Aravis Viewer is a simple viewer displaying video streams from USB3 and ethernet industrial cameras supporting the
+    <p>Aravis Viewer is a simple viewer displaying video streams from USB3 and ethernet industrial cameras supporting the
     GENICAM specification. It allows to control basic acquisition parameters (like framerate, exposure and gain), and to
-    save raw still images.
+    save raw still images.</p>
   </description>
   <screenshots>
     <screenshot type="default">


### PR DESCRIPTION
Dear aravis maintainers,

this pull request fixes a [bug reported](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1078195) during debian packaging, applying the patch offered by @petterreinholdtsen.
It corrects appstream metainfo validation errors, adding missing `<p>` to description and making sure file name match ID.
Also it uses the new `metainfo.xml` ending replacing the obsolete `appdata.xml` ending.

Thanks for considering it.