### PR TITLE
ci: fix setup related meson warning

### DIFF
--- a/.github/workflows/aravis-linux.yml
+++ b/.github/workflows/aravis-linux.yml
@@ -20,7 +20,7 @@ jobs:
         sudo apt install python3 libusb-1.0-0-dev gobject-introspection valgrind libgstreamer-plugins-bad1.0-dev libgtk-3-dev libgirepository1.0-dev python3-gi libunwind-dev gettext
     - name: Build
       run: |
-        meson --buildtype=plain -Ddocumentation=enabled -Dgst-plugin=enabled -Dintrospection=enabled -Dusb=disabled -Dviewer=enabled -Dgentl-producer=true . ./build
+        meson setup --buildtype=plain -Ddocumentation=enabled -Dgst-plugin=enabled -Dintrospection=enabled -Dusb=disabled -Dviewer=enabled -Dgentl-producer=true . ./build
         ninja -C ./build
         meson configure -Dusb=enabled build
         ninja -C ./build

--- a/.github/workflows/aravis-linux.yml
+++ b/.github/workflows/aravis-linux.yml
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: Install dependencies
       run: |
-        pip3 install meson ninja Markdown toml typogrify
+        pip3 install meson ninja Markdown toml typogrify gi-docgen
         sudo apt update
         sudo apt install python3 libusb-1.0-0-dev gobject-introspection valgrind libgstreamer-plugins-bad1.0-dev libgtk-3-dev libgirepository1.0-dev python3-gi libunwind-dev gettext
     - name: Build

--- a/.github/workflows/aravis-macos.yml
+++ b/.github/workflows/aravis-macos.yml
@@ -27,7 +27,7 @@ jobs:
         brew install meson ninja gcc gettext intltool libxml2 libusb gstreamer gnome-icon-theme gobject-introspection glib
     - name: Build
       run: |
-        meson --buildtype=plain -Ddocumentation=disabled -Dgst-plugin=enabled -Dintrospection=disabled -Dusb=enabled -Dviewer=enabled -Dgentl-producer=true . ./build
+        meson setup --buildtype=plain -Ddocumentation=disabled -Dgst-plugin=enabled -Dintrospection=disabled -Dusb=enabled -Dviewer=enabled -Dgentl-producer=true . ./build
         ninja -C ./build
       env:
         CC: gcc

--- a/.github/workflows/aravis-mingw.yml
+++ b/.github/workflows/aravis-mingw.yml
@@ -49,7 +49,7 @@ jobs:
     - name: meson
       run: |
         mkdir build
-        meson --buildtype=plain -Ddocumentation=disabled -Dgst-plugin=enabled -Dintrospection=enabled -Dusb=enabled -Dviewer=enabled -Dgv-n-buffers=1 -Dgentl-producer=true . ./build
+        meson setup --buildtype=plain -Ddocumentation=disabled -Dgst-plugin=enabled -Dintrospection=enabled -Dusb=enabled -Dviewer=enabled -Dgv-n-buffers=1 -Dgentl-producer=true . ./build
     - name: ninja install
       run: |
         ninja -C ./build --verbose install

--- a/.github/workflows/aravis-msvc.yml
+++ b/.github/workflows/aravis-msvc.yml
@@ -63,7 +63,7 @@ jobs:
         .\build\activate_build.ps1
         .\build\activate_run.ps1
         echo "::group::configure"
-        meson --prefix ${{ github.workspace }}\install --buildtype ${{ matrix.build_type_meson }} --pkg-config-path ${{ github.workspace }}\build -Ddocumentation=disabled -Dgst-plugin=disabled -Dintrospection=disabled -Dusb=enabled -Dviewer=disabled -Dgv-n-buffers=1 -Dgentl-producer=true . .\build
+        meson setup --prefix ${{ github.workspace }}\install --buildtype ${{ matrix.build_type_meson }} --pkg-config-path ${{ github.workspace }}\build -Ddocumentation=disabled -Dgst-plugin=disabled -Dintrospection=disabled -Dusb=enabled -Dviewer=disabled -Dgv-n-buffers=1 -Dgentl-producer=true . .\build
         echo "::endgroup::"
         echo "::group::compile"
         meson compile -C .\build -v


### PR DESCRIPTION
```
WARNING: Running the setup command as `meson [options]` instead of `meson setup [options]` is ambiguous and deprecated.
```