### PR TITLE
chunkparser: allow to set string and integer features

### DIFF
--- a/src/arv-test.cfg
+++ b/src/arv-test.cfg
@@ -227,7 +227,8 @@ SoftwareTriggerDelay=1.0
 # GigEVision write_memory error (busy)
 SoftwareTriggerWait=0.2
 ChunksDelay=1.0
-ChunkList=Timestamp
+ChunkList=Scan3dCoordinateReferenceValue
+ChunkSelector=ChunkScan3dCoordinateReferenceSelector TranslationZ TranslationX RotationZ RotationX
 
 [Smartek:GC651M]
 

--- a/src/arvchunkparser.c
+++ b/src/arvchunkparser.c
@@ -228,6 +228,92 @@ arv_chunk_parser_get_float_value (ArvChunkParser *parser, ArvBuffer *buffer, con
 	return value;
 }
 
+static ArvGcNode *
+arv_chunk_parser_get_feature (ArvChunkParser *parser, const char *feature)
+{
+        g_return_val_if_fail (ARV_IS_CHUNK_PARSER(parser), NULL);
+	g_return_val_if_fail (parser->priv->genicam, NULL);
+
+	return arv_gc_get_node (parser->priv->genicam, feature);
+}
+
+static void *
+_get_feature (ArvChunkParser *parser, GType node_type, const char *feature, GError **error)
+{
+	void *node;
+
+	g_return_val_if_fail (ARV_IS_CHUNK_PARSER (parser), NULL);
+	g_return_val_if_fail (feature != NULL, NULL);
+
+	node = arv_chunk_parser_get_feature (parser, feature);
+
+	if (node == NULL) {
+		g_set_error (error, ARV_CHUNK_PARSER_ERROR, ARV_CHUNK_PARSER_ERROR_FEATURE_NOT_FOUND,
+			     "[%s] Not found", feature);
+		return NULL;
+	}
+
+	if (!(G_TYPE_CHECK_INSTANCE_TYPE ((node), node_type))) {
+		g_set_error (error, ARV_CHUNK_PARSER_ERROR, ARV_CHUNK_PARSER_ERROR_INVALID_FEATURE_TYPE,
+			     "[%s:%s] Not a %s", feature, G_OBJECT_TYPE_NAME (node), g_type_name (node_type));
+		return NULL;
+	}
+
+	return node;
+}
+
+/**
+ * arv_chunk_parser_set_string_feature_value:
+ * @parser: a #ArvChunkParser
+ * @feature: feature name
+ * @value: feature value
+ * @error: a #GError placeholder, %NULL to ignore
+ *
+ * Set a feature value using a string. The main use for this function is to set a Selector feature, in order to access
+ * the corresponding chunk value. As the Genicam data owned by the parser is not shared with the device, this function
+ * is limited to features that don't trigger device access.
+ *
+ * Since: 0.8.35
+ */
+
+void
+arv_chunk_parser_set_string_feature_value (ArvChunkParser *parser,
+                                           const char *feature, const char *value,
+                                           GError **error)
+{
+	ArvGcNode *node;
+
+	node = _get_feature (parser, ARV_TYPE_GC_STRING, feature, error);
+	if (node != NULL)
+		arv_gc_string_set_value (ARV_GC_STRING (node), value, error);
+}
+
+/**
+ * arv_chunk_parser_set_integer_feature_value:
+ * @parser: a #ArvChunkParser
+ * @feature: feature name
+ * @value: feature value
+ * @error: a #GError placeholder, %NULL to ignore
+ *
+ * Set a feature value using a 64 bit value. The main use for this function is to set a Selector feature, in order to
+ * access the corresponding chunk value. As the Genicam data owned by the parser is not shared with the device, this
+ * function is limited to features that don't trigger device access.
+ *
+ * Since: 0.8.35
+ */
+
+void
+arv_chunk_parser_set_integer_feature_value (ArvChunkParser *parser,
+                                            const char *feature, gint64 value,
+                                            GError **error)
+{
+	ArvGcNode *node;
+
+	node = _get_feature (parser, ARV_TYPE_GC_INTEGER, feature, error);
+	if (node != NULL)
+		arv_gc_integer_set_value (ARV_GC_INTEGER (node), value, error);
+}
+
 /**
  * arv_chunk_parser_new:
  * @xml: XML genicam data

--- a/src/arvchunkparser.h
+++ b/src/arvchunkparser.h
@@ -47,7 +47,8 @@ ARV_API GQuark		arv_chunk_parser_error_quark		(void);
 typedef enum {
 	ARV_CHUNK_PARSER_ERROR_INVALID_FEATURE_TYPE,
 	ARV_CHUNK_PARSER_ERROR_BUFFER_NOT_FOUND,
-	ARV_CHUNK_PARSER_ERROR_CHUNK_NOT_FOUND
+	ARV_CHUNK_PARSER_ERROR_CHUNK_NOT_FOUND,
+        ARV_CHUNK_PARSER_ERROR_FEATURE_NOT_FOUND
 } ArvChunkParserError;
 
 #define ARV_TYPE_CHUNK_PARSER             (arv_chunk_parser_get_type ())
@@ -62,6 +63,13 @@ ARV_API gint64			arv_chunk_parser_get_integer_value	(ArvChunkParser *parser, Arv
 									 const char *chunk, GError **error);
 ARV_API double			arv_chunk_parser_get_float_value	(ArvChunkParser *parser, ArvBuffer *buffer,
 									 const char *chunk, GError **error);
+
+ARV_API void		        arv_chunk_parser_set_string_feature_value	(ArvChunkParser *parser,
+                                                                                 const char *feature, const char *value,
+                                                                                 GError **error);
+ARV_API void		        arv_chunk_parser_set_integer_feature_value	(ArvChunkParser *parser,
+                                                                                 const char *feature, gint64 value,
+                                                                                 GError **error);
 
 G_END_DECLS
 


### PR DESCRIPTION
On some devices, chunk access requires a change of a local feature value. For example:

```
 <Enumeration NameSpace="Standard" Name="ChunkComponentSelector">
  <Visibility>Expert</Visibility>
  <EnumEntry NameSpace="Standard" Name="Range">
   <Value>0</Value>
  </EnumEntry>
  <EnumEntry NameSpace="Standard" Name="Normal">
   <Value>1</Value>
  </EnumEntry>
  <EnumEntry NameSpace="Standard" Name="Texture">
   <Value>2</Value>
  </EnumEntry>
  <Value>0</Value>
 </Enumeration>

  <Float NameSpace="Standard" Name="ChunkScan3dCoordinateOffset">
  <Visibility>Expert</Visibility>
  <ImposedAccessMode>RO</ImposedAccessMode>
  <pValue>ChunkScan3dCoordinateOffsetRegister</pValue>
  <Min>-3.40282e+38</Min>
  <Max>3.40282e+38</Max>
  <Inc>1e-6</Inc>
  <DisplayPrecision>6</DisplayPrecision>
 </Float>

 <FloatReg NameSpace="Custom" Name="ChunkScan3dCoordinateOffsetRegister">
  <Visibility>Expert</Visibility>
  <Address>0x8</Address>
  <pIndex Offset="16">ChunkComponentSelector</pIndex>
  <Length>8</Length>
  <AccessMode>RW</AccessMode>
  <pPort>Chunk</pPort>
  <pInvalidator>ChunkScan3dCoordinateSelector</pInvalidator>
  <pInvalidator>ChunkComponentSelector</pInvalidator>
  <Endianess>LittleEndian</Endianess>
 </FloatReg>
```

As the Genicam tree is owned by the parser and not shared with the device, in order to access to chunk data without a device instance, we need to provide an API to set the selector feature.

```
arv_chunk_parser_set_string_feature_value (parser,
					   "ChunkComponentSelector",
					   "Normal", &error);
normal_offset = arv_chunk_parser_get_float_value (parser,
						  "ChunkScan3dCoordinateOffset",
						  &error);
```