### PR TITLE
Wip/gv underrun fixes

### DIFF
--- a/src/arvbuffer.h
+++ b/src/arvbuffer.h
@@ -44,6 +44,7 @@ G_BEGIN_DECLS
  * @ARV_BUFFER_STATUS_FILLING: the image is currently being filled
  * @ARV_BUFFER_STATUS_ABORTED: the filling was aborted before completion
  * @ARV_BUFFER_STATUS_PAYLOAD_NOT_SUPPORTED: payload not yet supported
+ * @ARV_BUFFER_STATUS_UNDERRUN: buffer found late in input queue and timeout reached before all packets are received
  */
 
 typedef enum {
@@ -56,7 +57,8 @@ typedef enum {
 	ARV_BUFFER_STATUS_SIZE_MISMATCH,
 	ARV_BUFFER_STATUS_FILLING,
 	ARV_BUFFER_STATUS_ABORTED,
-        ARV_BUFFER_STATUS_PAYLOAD_NOT_SUPPORTED
+        ARV_BUFFER_STATUS_PAYLOAD_NOT_SUPPORTED,
+        ARV_BUFFER_STATUS_UNDERRUN
 } ArvBufferStatus;
 
 /**

--- a/src/arvgvstream.c
+++ b/src/arvgvstream.c
@@ -162,6 +162,8 @@ struct _ArvGvStreamThreadData {
 
 	gboolean use_packet_socket;
 
+        guint64 underrun_frame_id;
+
 	/* Statistics */
 
 	guint64 n_completed_buffers;
@@ -373,10 +375,13 @@ _find_frame_data (ArvGvStreamThreadData *thread_data,
 
 	buffer = arv_stream_pop_input_buffer (thread_data->stream);
 	if (buffer == NULL) {
-		thread_data->n_underruns++;
-
+                if (thread_data->underrun_frame_id != frame_id) {
+                        thread_data->n_underruns++;
+                        thread_data->underrun_frame_id = frame_id;
+                }
 		return NULL;
 	}
+        thread_data->underrun_frame_id = 0;
 
 	n_packets = _compute_n_expected_packets (packet,
                                                  buffer->priv->allocated_size,


### PR DESCRIPTION
An incomplete attempt to detect underrun conditions, as a fix to #849 .

The complete implementation should take resent packets into account.