### PR TITLE
arv_gc_node_set_integer_value. error to local_error

### DIFF
--- a/src/arvgcintegernode.c
+++ b/src/arvgcintegernode.c
@@ -233,7 +233,7 @@ arv_gc_integer_node_get_integer_value (ArvGcInteger *gc_integer, GError **error)
 	GError *local_error = NULL;
 	gint64 value;
 
-	value_node = _get_value_node (gc_integer_node, error);
+	value_node = _get_value_node (gc_integer_node, &local_error);
 	if (value_node == NULL) {
                 if (local_error != NULL)
                         g_propagate_prefixed_error (error, local_error, "[%s] ",

--- a/src/arvgcintegernode.c
+++ b/src/arvgcintegernode.c
@@ -258,7 +258,7 @@ arv_gc_integer_node_set_integer_value (ArvGcInteger *gc_integer, gint64 value, G
 	ArvGcPropertyNode *value_node;
 	GError *local_error = NULL;
 
-	value_node = _get_value_node (gc_integer_node, error);
+	value_node = _get_value_node (gc_integer_node, &local_error);
 	if (value_node == NULL) {
                 if (local_error != NULL)
                         g_propagate_prefixed_error (error, local_error, "[%s] ",


### PR DESCRIPTION
It seemed strange to me to check the local_error variable for NULL when no one was working with it. I think something like this was meant