### PR TITLE
gvstream: Change socket-buffer default to auto

### DIFF
--- a/src/arvgvstream.c
+++ b/src/arvgvstream.c
@@ -1828,8 +1828,8 @@ arv_gv_stream_class_init (ArvGvStreamClass *gv_stream_class)
 		g_param_spec_enum ("socket-buffer", "Socket buffer",
 				   "Socket buffer behaviour",
 				   ARV_TYPE_GV_STREAM_SOCKET_BUFFER,
-				   ARV_GV_STREAM_SOCKET_BUFFER_FIXED,
-				  G_PARAM_CONSTRUCT |  G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)
+				   ARV_GV_STREAM_SOCKET_BUFFER_AUTO,
+				   G_PARAM_CONSTRUCT | G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)
 		);
         /**
          * ArvGvStream:socket-buffer-size:


### PR DESCRIPTION
GStreamer aravissrc object creates new streams when it receives new caps. It It changed Aravis to rely on the default receive buffer size since it no longer asked the operating system for full frame sized buffer.

Since 0.8.32 the stream object can be received from the aravissrc through stream object notification for modification. I believe the original default value of auto serves more users.