### PR TITLE
Add Gst 10/12/14/16-bit support

### DIFF
--- a/gst/gstaravis.c
+++ b/gst/gstaravis.c
@@ -174,6 +174,7 @@ gst_aravis_get_all_camera_caps (GstAravis *gst_aravis, GError **error)
 	}
 	if (local_error) {
 		g_propagate_error (error, local_error);
+		g_free (pixel_formats);
 		return NULL;
 	}
 

--- a/src/arvenums.h
+++ b/src/arvenums.h
@@ -126,9 +126,11 @@ typedef guint32 ArvPixelFormat;
 #define	ARV_PIXEL_FORMAT_MONO_8_SIGNED		((ArvPixelFormat) 0x01080002u)
 
 #define	ARV_PIXEL_FORMAT_MONO_10		((ArvPixelFormat) 0x01100003u)
+#define ARV_PIXEL_FORMAT_MONO_10P		((ArvPixelFormat) 0x010a0046u)
 #define ARV_PIXEL_FORMAT_MONO_10_PACKED		((ArvPixelFormat) 0x010c0004u)
 
 #define ARV_PIXEL_FORMAT_MONO_12		((ArvPixelFormat) 0x01100005u)
+#define ARV_PIXEL_FORMAT_MONO_12P		((ArvPixelFormat) 0x010c0047u)
 #define ARV_PIXEL_FORMAT_MONO_12_PACKED		((ArvPixelFormat) 0x010c0006u)
 
 #define ARV_PIXEL_FORMAT_MONO_14		((ArvPixelFormat) 0x01100025u)
@@ -150,11 +152,17 @@ typedef guint32 ArvPixelFormat;
 #define ARV_PIXEL_FORMAT_BAYER_GB_12		((ArvPixelFormat) 0x01100012u)
 #define ARV_PIXEL_FORMAT_BAYER_BG_12		((ArvPixelFormat) 0x01100013u)
 
+#define ARV_PIXEL_FORMAT_BAYER_GR_14		((ArvPixelFormat) 0x01100109u)
+#define ARV_PIXEL_FORMAT_BAYER_RG_14		((ArvPixelFormat) 0x0110010au)
+#define ARV_PIXEL_FORMAT_BAYER_GB_14		((ArvPixelFormat) 0x0110010bu)
+#define ARV_PIXEL_FORMAT_BAYER_BG_14		((ArvPixelFormat) 0x0110010cu)
+
 #define ARV_PIXEL_FORMAT_BAYER_GR_16		((ArvPixelFormat) 0x0110002eu)
 #define ARV_PIXEL_FORMAT_BAYER_RG_16		((ArvPixelFormat) 0x0110002fu)
 #define ARV_PIXEL_FORMAT_BAYER_GB_16		((ArvPixelFormat) 0x01100030u)
 #define ARV_PIXEL_FORMAT_BAYER_BG_16		((ArvPixelFormat) 0x01100031u)
 
+/* PFNC */
 #define ARV_PIXEL_FORMAT_BAYER_BG_10P		((ArvPixelFormat) 0x010a0052u)
 #define ARV_PIXEL_FORMAT_BAYER_GB_10P		((ArvPixelFormat) 0x010a0054u)
 #define ARV_PIXEL_FORMAT_BAYER_GR_10P		((ArvPixelFormat) 0x010a0056u)
@@ -165,15 +173,21 @@ typedef guint32 ArvPixelFormat;
 #define ARV_PIXEL_FORMAT_BAYER_GR_12P		((ArvPixelFormat) 0x010c0057u)
 #define ARV_PIXEL_FORMAT_BAYER_RG_12P		((ArvPixelFormat) 0x010c0059u)
 
-#define ARV_PIXEL_FORMAT_BAYER_GR_12_PACKED	((ArvPixelFormat) 0x010c002au)
-#define ARV_PIXEL_FORMAT_BAYER_RG_12_PACKED	((ArvPixelFormat) 0x010c002bu)
-#define ARV_PIXEL_FORMAT_BAYER_GB_12_PACKED	((ArvPixelFormat) 0x010c002cu)
-#define ARV_PIXEL_FORMAT_BAYER_BG_12_PACKED	((ArvPixelFormat) 0x010c002du)
+#define ARV_PIXEL_FORMAT_BAYER_GR_14P		((ArvPixelFormat) 0x010e0105u)
+#define ARV_PIXEL_FORMAT_BAYER_RG_14P		((ArvPixelFormat) 0x010e0106u)
+#define ARV_PIXEL_FORMAT_BAYER_GB_14P		((ArvPixelFormat) 0x010e0107u)
+#define ARV_PIXEL_FORMAT_BAYER_BG_14P		((ArvPixelFormat) 0x010e0108u)
 
+/* GigE Vision 2.0 */
 #define ARV_PIXEL_FORMAT_BAYER_GR_10_PACKED	((ArvPixelFormat) 0x010c0026u)
 #define ARV_PIXEL_FORMAT_BAYER_RG_10_PACKED	((ArvPixelFormat) 0x010c0027u)
 #define ARV_PIXEL_FORMAT_BAYER_GB_10_PACKED	((ArvPixelFormat) 0x010c0028u)
 #define ARV_PIXEL_FORMAT_BAYER_BG_10_PACKED	((ArvPixelFormat) 0x010c0029u)
+
+#define ARV_PIXEL_FORMAT_BAYER_GR_12_PACKED	((ArvPixelFormat) 0x010c002au)
+#define ARV_PIXEL_FORMAT_BAYER_RG_12_PACKED	((ArvPixelFormat) 0x010c002bu)
+#define ARV_PIXEL_FORMAT_BAYER_GB_12_PACKED	((ArvPixelFormat) 0x010c002cu)
+#define ARV_PIXEL_FORMAT_BAYER_BG_12_PACKED	((ArvPixelFormat) 0x010c002du)
 
 #define ARV_PIXEL_FORMAT_COORD3D_ABC_8          ((ArvPixelFormat) 0x021800B2u)
 #define ARV_PIXEL_FORMAT_COORD3D_ABC_8_PLANAR   ((ArvPixelFormat) 0x021800B3u)

--- a/src/arvmisc.c
+++ b/src/arvmisc.c
@@ -720,9 +720,89 @@ ArvGstCapsInfos arv_gst_caps_infos[] = {
 		"video/x-raw-bayer, format=(string)bggr, bpp=(int)8, depth=(int)8",
 		"video/x-raw-bayer",	8,	8,	ARV_MAKE_FOURCC ('b','g','g','r')
 	},
+	{
+		ARV_PIXEL_FORMAT_BAYER_GR_10,
+		"video/x-bayer, format=(string)grbg10le",
+		"video/x-bayer",	"grbg10le",
+	},
+	{
+		ARV_PIXEL_FORMAT_BAYER_RG_10,
+		"video/x-bayer, format=(string)rggb10le",
+		"video/x-bayer",	"rggb10le",
+	},
+	{
+		ARV_PIXEL_FORMAT_BAYER_GB_10,
+		"video/x-bayer, format=(string)gbrg10le",
+		"video/x-bayer",	"gbrg10le",
+	},
+	{
+		ARV_PIXEL_FORMAT_BAYER_BG_10,
+		"video/x-bayer, format=(string)bggr10le",
+		"video/x-bayer",	"bggr10le",
+	},
+	{
+		ARV_PIXEL_FORMAT_BAYER_GR_12,
+		"video/x-bayer, format=(string)grbg12le",
+		"video/x-bayer",	"grbg12le",
+	},
+	{
+		ARV_PIXEL_FORMAT_BAYER_RG_12,
+		"video/x-bayer, format=(string)rggb12le",
+		"video/x-bayer",	"rggb12le",
+	},
+	{
+		ARV_PIXEL_FORMAT_BAYER_GB_12,
+		"video/x-bayer, format=(string)gbrg12le",
+		"video/x-bayer",	"gbrg12le",
+	},
+	{
+		ARV_PIXEL_FORMAT_BAYER_BG_12,
+		"video/x-bayer, format=(string)bggr12le",
+		"video/x-bayer",	"bggr12le",
+	},
+	{
+		ARV_PIXEL_FORMAT_BAYER_GR_14,
+		"video/x-bayer, format=(string)grbg14le",
+		"video/x-bayer",	"grbg14le",
+	},
+	{
+		ARV_PIXEL_FORMAT_BAYER_RG_14,
+		"video/x-bayer, format=(string)rggb14le",
+		"video/x-bayer",	"rggb14le",
+	},
+	{
+		ARV_PIXEL_FORMAT_BAYER_GB_14,
+		"video/x-bayer, format=(string)gbrg14le",
+		"video/x-bayer",	"gbrg14le",
+	},
+	{
+		ARV_PIXEL_FORMAT_BAYER_BG_14,
+		"video/x-bayer, format=(string)bggr14le",
+		"video/x-bayer",	"bggr14le",
+	},
+	{
+		ARV_PIXEL_FORMAT_BAYER_GR_16,
+		"video/x-bayer, format=(string)grbg16le",
+		"video/x-bayer",	"grbg16le",
+	},
+	{
+		ARV_PIXEL_FORMAT_BAYER_RG_16,
+		"video/x-bayer, format=(string)rggb16le",
+		"video/x-bayer",	"rggb16le",
+	},
+	{
+		ARV_PIXEL_FORMAT_BAYER_GB_16,
+		"video/x-bayer, format=(string)gbrg16le",
+		"video/x-bayer",	"gbrg16le",
+	},
+	{
+		ARV_PIXEL_FORMAT_BAYER_BG_16,
+		"video/x-bayer, format=(string)bggr16le",
+		"video/x-bayer",	"bggr16le",
+	},
 
-/* Non 8bit bayer formats are not supported by gstreamer bayer plugin.
- * This feature is discussed in bug https://gitlab.freedesktop.org/gstreamer/gst-plugins-bad/-/issues/86 .*/
+/* The packed non 8bit bayer formats are not supported by gstreamer bayer plugin.
+ * They were discussed in bug https://gitlab.freedesktop.org/gstreamer/gst-plugins-bad/-/issues/86, but not implemented. */
 
 	{
 		ARV_PIXEL_FORMAT_YUV_422_PACKED,
@@ -962,20 +1042,22 @@ const char *
 arv_pixel_format_to_gst_0_10_caps_string (ArvPixelFormat pixel_format)
 {
 	int i;
+	const char *caps_string;
 
 	for (i = 0; i < G_N_ELEMENTS (arv_gst_caps_infos); i++)
 		if (arv_gst_caps_infos[i].pixel_format == pixel_format)
 			break;
 
-	if (i == G_N_ELEMENTS (arv_gst_caps_infos)) {
+	if (i == G_N_ELEMENTS (arv_gst_caps_infos) || arv_gst_caps_infos[i].gst_0_10_caps_string == NULL) {
 		arv_warning_misc ("[PixelFormat::to_gst_0_10_caps_string] 0x%08x not found", pixel_format);
 		return NULL;
 	}
 
+	caps_string = arv_gst_caps_infos[i].gst_0_10_caps_string;
 	arv_debug_misc ("[PixelFormat::to_gst_0_10_caps_string] 0x%08x -> %s",
-		      pixel_format, arv_gst_caps_infos[i].gst_0_10_caps_string);
+			pixel_format, caps_string);
 
-	return arv_gst_caps_infos[i].gst_0_10_caps_string;
+	return caps_string;
 }
 
 ArvPixelFormat
@@ -986,7 +1068,7 @@ arv_pixel_format_from_gst_0_10_caps (const char *name, int bpp, int depth, guint
 	g_return_val_if_fail (name != NULL, 0);
 
 	for (i = 0; i < G_N_ELEMENTS (arv_gst_caps_infos); i++) {
-		if (strcmp (name, arv_gst_caps_infos[i].name_0_10) != 0)
+		if (g_strcmp0 (name, arv_gst_caps_infos[i].name_0_10) != 0)
 			continue;
 
 		if (strcmp (name, "video/x-raw-yuv") == 0 &&


### PR DESCRIPTION
GStreamer 1.24 added support for more bit depths into bayer2rgb.

I only had Basler acA2440-20gc that implements BayerRG12. I tested on Testimage3 (for all pixel values) and Testimage6 (for correct colors) with command

```
gst-launch-1.0 -v aravissrc camera-name=192.168.0.20 ! video/x-bayer,format=rggb12le,framerate=1/1 ! \
  bayer2rgb ! video/x-raw,format=ARGB64_LE ! \
  videoconvert ! openjpegenc ! image/jp2 ! \
  filesink location=test-image-6.jp2
```

I also noticed a small potential leak in error path.