### PR TITLE
added FLIR Xsc-series to the legacy list. Fixes #444

### DIFF
--- a/src/arvgcport.c
+++ b/src/arvgcport.c
@@ -76,6 +76,7 @@ static ArvGvLegacyInfos arv_gc_port_legacy_infos[] = {
    { .vendor_selection = "Sony",                                .model_selection = "XCG_CPSeries"},
    { .vendor_selection = "TeledyneDALSA",                       .model_selection = "ICE"},
    { .vendor_selection = "Xenics",                              .model_selection = "Wildcat"},
+   { .vendor_selection = "FLIR",                                .model_selection = "XscSeries"},
 };
 
 typedef struct {


### PR DESCRIPTION
This makes the FLIR A6261sc work. Since the model is just "XscSeries", presumably the camera in #444 is covered by this.

Thanks!