### PR TITLE
Fixed and Camera tested support for 10/12 pixel formats, High Bandwidth Pixel unpacking Optimizations 

### DIFF
--- a/src/arvenums.h
+++ b/src/arvenums.h
@@ -266,6 +266,10 @@ typedef guint32 ArvPixelFormat;
 
 #define ARV_PIXEL_FORMAT_YUV_422_YUYV_PACKED 	((ArvPixelFormat) 0x02100032u)
 
+#define ARV_PIXEL_FORMAT_RGB_565P		((ArvPixelFormat) 0x02100035u)
+
+#define ARV_PIXEL_FORMAT_YCBCR_422_8_PACKED 	((ArvPixelFormat) 0x0210003Bu)
+
 /* Custom */
 
 /**

--- a/src/arvenums.h
+++ b/src/arvenums.h
@@ -173,6 +173,11 @@ typedef guint32 ArvPixelFormat;
 #define ARV_PIXEL_FORMAT_BAYER_GR_12P		((ArvPixelFormat) 0x010c0057u)
 #define ARV_PIXEL_FORMAT_BAYER_RG_12P		((ArvPixelFormat) 0x010c0059u)
 
+#define ARV_PIXEL_FORMAT_BAYER_GR_12_PACKED	((ArvPixelFormat) 0x010c002au)
+#define ARV_PIXEL_FORMAT_BAYER_RG_12_PACKED	((ArvPixelFormat) 0x010c002bu)
+#define ARV_PIXEL_FORMAT_BAYER_GB_12_PACKED	((ArvPixelFormat) 0x010c002cu)
+#define ARV_PIXEL_FORMAT_BAYER_BG_12_PACKED	((ArvPixelFormat) 0x010c002du)
+
 #define ARV_PIXEL_FORMAT_BAYER_GR_14P		((ArvPixelFormat) 0x010e0105u)
 #define ARV_PIXEL_FORMAT_BAYER_RG_14P		((ArvPixelFormat) 0x010e0106u)
 #define ARV_PIXEL_FORMAT_BAYER_GB_14P		((ArvPixelFormat) 0x010e0107u)

--- a/src/arvmisc.c
+++ b/src/arvmisc.c
@@ -929,6 +929,13 @@ ArvGstCapsInfos arv_gst_caps_infos[] = {
 		"video/x-raw-yuv",	0,	0,	ARV_MAKE_FOURCC ('Y','U','Y','2')
 	},
 	{
+		ARV_PIXEL_FORMAT_YCBCR_422_8_PACKED,
+		"video/x-raw, format=(string)YUY2",
+		"video/x-raw", 		"YUY2",
+		"video/x-raw-yuv, format=(fourcc)YUYU2",
+		"video/x-raw-yuv",	0,	0,	ARV_MAKE_FOURCC ('Y','U','Y','2')
+	},
+	{
 		ARV_PIXEL_FORMAT_RGB_8_PACKED,
 		"video/x-raw, format=(string)RGB",
 		"video/x-raw",		"RGB",
@@ -948,6 +955,12 @@ ArvGstCapsInfos arv_gst_caps_infos[] = {
 		"video/x-raw",		"RGBA",
 		"video/x-raw-rgba, format=(string)RGBA, bpp=(int)32, depth=(int)8",
 		"video/x-raw-rgba",	32,	8,	0
+	},
+	{
+		ARV_PIXEL_FORMAT_RGB_565P,
+		"video/x-raw, format=(string)RGB16",
+		"video/x-raw",		"RGB16",
+		NULL, NULL, 16, 16, 0
 	},
 	{
 		ARV_PIXEL_FORMAT_CUSTOM_YUV_422_YUYV_PACKED,

--- a/src/arvmisc.c
+++ b/src/arvmisc.c
@@ -672,6 +672,13 @@ ArvGstCapsInfos arv_gst_caps_infos[] = {
 		"video/x-raw-gray",	16,	12,	0
 	},
 	{
+		ARV_PIXEL_FORMAT_MONO_12P,
+		"video/x-raw, format=(string)GRAY16_LE",
+		"video/x-raw",		"GRAY16_LE",
+		"video/x-raw-gray, bpp=(int)16, depth=(int)12",
+		"video/x-raw-gray",	12,	12,	0
+	},
+	{
 		ARV_PIXEL_FORMAT_MONO_12_PACKED,
 		"video/x-raw, format=(string)GRAY16_LE",
 		"video/x-raw",		"GRAY16_LE",
@@ -691,6 +698,20 @@ ArvGstCapsInfos arv_gst_caps_infos[] = {
 		"video/x-raw", 		"GRAY16_LE",
 		"video/x-raw-gray, bpp=(int)16, depth=(int)10",
 		"video/x-raw-gray",	16,	10,	0
+	},
+	{
+		ARV_PIXEL_FORMAT_MONO_10P,
+		"video/x-raw, format=(string)GRAY16_LE",
+		"video/x-raw",		"GRAY16_LE",
+		"video/x-raw-gray, bpp=(int)10, depth=(int)10",
+		"video/x-raw-gray",	10,	10,	0
+	},
+	{
+		ARV_PIXEL_FORMAT_MONO_10_PACKED,
+		"video/x-raw, format=(string)GRAY16_LE",
+		"video/x-raw",		"GRAY16_LE",
+		"video/x-raw-gray, bpp=(int)10, depth=(int)10",
+		"video/x-raw-gray",	10,	10,	0
 	},
 	{
 		ARV_PIXEL_FORMAT_BAYER_GR_8,
@@ -740,6 +761,49 @@ ArvGstCapsInfos arv_gst_caps_infos[] = {
 		"video/x-bayer, format=(string)bggr10le",
 		"video/x-bayer",	"bggr10le",
 	},
+	
+/* 10-bit Bayer packed (legacy and PFNC — viewer unpacks to 16-bit) */
+	{
+		ARV_PIXEL_FORMAT_BAYER_GR_10_PACKED,
+		"video/x-bayer, format=(string)grbg10le",
+		"video/x-bayer",	"grbg10le",
+	},
+	{
+		ARV_PIXEL_FORMAT_BAYER_RG_10_PACKED,
+		"video/x-bayer, format=(string)rggb10le",
+		"video/x-bayer",	"rggb10le",
+	},
+	{
+		ARV_PIXEL_FORMAT_BAYER_GB_10_PACKED,
+		"video/x-bayer, format=(string)gbrg10le",
+		"video/x-bayer",	"gbrg10le",
+	},
+	{
+		ARV_PIXEL_FORMAT_BAYER_BG_10_PACKED,
+		"video/x-bayer, format=(string)bggr10le",
+		"video/x-bayer",	"bggr10le",
+	},
+	{
+		ARV_PIXEL_FORMAT_BAYER_GR_10P,
+		"video/x-bayer, format=(string)grbg10le",
+		"video/x-bayer",	"grbg10le",
+	},
+	{
+		ARV_PIXEL_FORMAT_BAYER_RG_10P,
+		"video/x-bayer, format=(string)rggb10le",
+		"video/x-bayer",	"rggb10le",
+	},
+	{
+		ARV_PIXEL_FORMAT_BAYER_GB_10P,
+		"video/x-bayer, format=(string)gbrg10le",
+		"video/x-bayer",	"gbrg10le",
+	},
+	{
+		ARV_PIXEL_FORMAT_BAYER_BG_10P,
+		"video/x-bayer, format=(string)bggr10le",
+		"video/x-bayer",	"bggr10le",
+	},
+	/* 12-bit Bayer */
 	{
 		ARV_PIXEL_FORMAT_BAYER_GR_12,
 		"video/x-bayer, format=(string)grbg12le",
@@ -760,6 +824,52 @@ ArvGstCapsInfos arv_gst_caps_infos[] = {
 		"video/x-bayer, format=(string)bggr12le",
 		"video/x-bayer",	"bggr12le",
 	},
+		/* 12-bit Bayer packed (mapped to same 12le caps - camera typically sends unpacked anyway) */
+	{
+		ARV_PIXEL_FORMAT_BAYER_GR_12_PACKED,
+		"video/x-bayer, format=(string)grbg12le",
+		"video/x-bayer",	"grbg12le",
+	},
+	{
+		ARV_PIXEL_FORMAT_BAYER_RG_12_PACKED,
+		"video/x-bayer, format=(string)rggb12le",
+		"video/x-bayer",	"rggb12le",
+	},
+	{
+		ARV_PIXEL_FORMAT_BAYER_GB_12_PACKED,
+		"video/x-bayer, format=(string)gbrg12le",
+		"video/x-bayer",	"gbrg12le",
+	},
+	{
+		ARV_PIXEL_FORMAT_BAYER_BG_12_PACKED,
+		"video/x-bayer, format=(string)bggr12le",
+		"video/x-bayer",	"bggr12le",
+	},
+	/* 12-bit Bayer packed (PFNC "p" naming) */
+	{
+		ARV_PIXEL_FORMAT_BAYER_GR_12P,
+		"video/x-bayer, format=(string)grbg12le",
+		"video/x-bayer",	"grbg12le",
+	},
+	{
+		ARV_PIXEL_FORMAT_BAYER_RG_12P,
+		"video/x-bayer, format=(string)rggb12le",
+		"video/x-bayer",	"rggb12le",
+		NULL, NULL, 0, 0, 0
+	},
+	{
+		ARV_PIXEL_FORMAT_BAYER_GB_12P,
+		"video/x-bayer, format=(string)gbrg12le",
+		"video/x-bayer",	"gbrg12le",
+		NULL, NULL, 0, 0, 0
+	},
+	{
+		ARV_PIXEL_FORMAT_BAYER_BG_12P,
+		"video/x-bayer, format=(string)bggr12le",
+		"video/x-bayer",	"bggr12le",
+		NULL, NULL, 0, 0, 0
+	},
+	/* 14-bit Bayer */
 	{
 		ARV_PIXEL_FORMAT_BAYER_GR_14,
 		"video/x-bayer, format=(string)grbg14le",

--- a/viewer/arvviewer.c
+++ b/viewer/arvviewer.c
@@ -358,20 +358,303 @@ gst_buffer_release_cb (void *user_data)
 	g_free (release_data);
 }
 
+/* ============================================================================
+ * 12-bit and 10-bit packed format detection and unpacking.
+ *
+ * Two different packed layouts exist for each bit depth:
+ *
+ *   Legacy "Packed" (GigE Vision 1.x, MSB-first):
+ *     12Packed: 3 bytes per 2 pixels
+ *       byte0 = pixel0[11:4], byte1 = pixel1[3:0]<<4 | pixel0[3:0], byte2 = pixel1[11:4]
+ *       pixel0 = (b0 << 4) | (b1 & 0x0F)
+ *     10Packed: 3 bytes per 2 pixels (2 bits padding per pixel)
+ *       byte0 = pixel0[9:2], byte1 = pixel1[1:0]<<4 | pixel0[1:0], byte2 = pixel1[9:2]
+ *       pixel0 = (b0 << 2) | (b1 & 0x03)
+ *
+ *   PFNC "p" (GenICam PFNC 2.x, LSB-first):
+ *     12p: 3 bytes per 2 pixels
+ *       byte0 = pixel0[7:0], byte1 = pixel1[3:0]<<4 | pixel0[11:8], byte2 = pixel1[11:4]
+ *       pixel0 = ((b1 & 0x0F) << 8) | b0
+ *     10p: 5 bytes per 4 pixels (tightly packed, no padding)
+ *       pixel0 = ((b1 & 0x03) << 8) | b0
+ *       pixel1 = ((b2 & 0x0F) << 6) | (b1 >> 2)
+ *       pixel2 = ((b3 & 0x3F) << 4) | (b2 >> 4)
+ *       pixel3 = (b4 << 2) | (b3 >> 6)
+ *
+ * Mono and Bayer use the same byte packing — only debayering differs.
+ * ============================================================================ */
+
+/* --- 12-bit format checks --- */
+
+static gboolean
+arv_pixel_format_is_12_packed_legacy (ArvPixelFormat pixel_format)
+{
+	switch (pixel_format) {
+		case ARV_PIXEL_FORMAT_MONO_12_PACKED:
+		case ARV_PIXEL_FORMAT_BAYER_GR_12_PACKED:
+		case ARV_PIXEL_FORMAT_BAYER_RG_12_PACKED:
+		case ARV_PIXEL_FORMAT_BAYER_GB_12_PACKED:
+		case ARV_PIXEL_FORMAT_BAYER_BG_12_PACKED:
+			return TRUE;
+		default:
+			return FALSE;
+	}
+}
+
+static gboolean
+arv_pixel_format_is_12p_pfnc (ArvPixelFormat pixel_format)
+{
+	switch (pixel_format) {
+		case ARV_PIXEL_FORMAT_MONO_12P:
+		case ARV_PIXEL_FORMAT_BAYER_GR_12P:
+		case ARV_PIXEL_FORMAT_BAYER_RG_12P:
+		case ARV_PIXEL_FORMAT_BAYER_GB_12P:
+		case ARV_PIXEL_FORMAT_BAYER_BG_12P:
+			return TRUE;
+		default:
+			return FALSE;
+	}
+}
+
+/* --- 10-bit format checks --- */
+
+static gboolean
+arv_pixel_format_is_10_packed_legacy (ArvPixelFormat pixel_format)
+{
+	switch (pixel_format) {
+		case ARV_PIXEL_FORMAT_MONO_10_PACKED:
+		case ARV_PIXEL_FORMAT_BAYER_GR_10_PACKED:
+		case ARV_PIXEL_FORMAT_BAYER_RG_10_PACKED:
+		case ARV_PIXEL_FORMAT_BAYER_GB_10_PACKED:
+		case ARV_PIXEL_FORMAT_BAYER_BG_10_PACKED:
+			return TRUE;
+		default:
+			return FALSE;
+	}
+}
+
+static gboolean
+arv_pixel_format_is_10p_pfnc (ArvPixelFormat pixel_format)
+{
+	switch (pixel_format) {
+		case ARV_PIXEL_FORMAT_MONO_10P:
+		case ARV_PIXEL_FORMAT_BAYER_GR_10P:
+		case ARV_PIXEL_FORMAT_BAYER_RG_10P:
+		case ARV_PIXEL_FORMAT_BAYER_GB_10P:
+		case ARV_PIXEL_FORMAT_BAYER_BG_10P:
+			return TRUE;
+		default:
+			return FALSE;
+	}
+}
+
+/* --- Mono bit-depth checks (for <<N shift to fill GRAY16_LE range) --- */
+
+static gboolean
+arv_pixel_format_is_mono_12 (ArvPixelFormat pixel_format)
+{
+	return pixel_format == ARV_PIXEL_FORMAT_MONO_12 ||
+	       pixel_format == ARV_PIXEL_FORMAT_MONO_12_PACKED ||
+	       pixel_format == ARV_PIXEL_FORMAT_MONO_12P;
+}
+
+static gboolean
+arv_pixel_format_is_mono_10 (ArvPixelFormat pixel_format)
+{
+	return pixel_format == ARV_PIXEL_FORMAT_MONO_10 ||
+	       pixel_format == ARV_PIXEL_FORMAT_MONO_10_PACKED ||
+	       pixel_format == ARV_PIXEL_FORMAT_MONO_10P;
+}
+
+/* --- 12-bit unpackers --- */
+
+/* Legacy 12Packed (MSB-first): 3 bytes per 2 pixels */
+static void *
+unpack_12_packed_legacy (const char *packed_data, int width, int height, size_t *out_size)
+{
+	int n_pixels = width * height;
+	int n_pairs = n_pixels / 2;
+	guint16 *unpacked;
+	int i;
+
+	*out_size = n_pixels * 2;
+	unpacked = (guint16 *) g_malloc (*out_size);
+
+	for (i = 0; i < n_pairs; i++) {
+		guint8 b0 = (guint8) packed_data[i * 3 + 0];
+		guint8 b1 = (guint8) packed_data[i * 3 + 1];
+		guint8 b2 = (guint8) packed_data[i * 3 + 2];
+
+		unpacked[i * 2 + 0] = ((guint16) b0 << 4) | (b1 & 0x0F);
+		unpacked[i * 2 + 1] = ((guint16) b2 << 4) | ((b1 >> 4) & 0x0F);
+	}
+
+	return unpacked;
+}
+
+/* PFNC 12p (LSB-first): 3 bytes per 2 pixels */
+static void *
+unpack_12p_pfnc (const char *packed_data, int width, int height, size_t *out_size)
+{
+	int n_pixels = width * height;
+	int n_pairs = n_pixels / 2;
+	guint16 *unpacked;
+	int i;
+
+	*out_size = n_pixels * 2;
+	unpacked = (guint16 *) g_malloc (*out_size);
+
+	for (i = 0; i < n_pairs; i++) {
+		guint8 b0 = (guint8) packed_data[i * 3 + 0];
+		guint8 b1 = (guint8) packed_data[i * 3 + 1];
+		guint8 b2 = (guint8) packed_data[i * 3 + 2];
+
+		unpacked[i * 2 + 0] = ((guint16)(b1 & 0x0F) << 8) | b0;
+		unpacked[i * 2 + 1] = ((guint16) b2 << 4) | ((b1 >> 4) & 0x0F);
+	}
+
+	return unpacked;
+}
+
+/* --- 10-bit unpackers --- */
+
+/* Legacy 10Packed (MSB-first): 3 bytes per 2 pixels (2 bits padding per pixel)
+ * byte0 = pixel0[9:2], byte1 = pixel1[1:0]<<4 | pixel0[1:0], byte2 = pixel1[9:2] */
+static void *
+unpack_10_packed_legacy (const char *packed_data, int width, int height, size_t *out_size)
+{
+	int n_pixels = width * height;
+	int n_pairs = n_pixels / 2;
+	guint16 *unpacked;
+	int i;
+
+	*out_size = n_pixels * 2;
+	unpacked = (guint16 *) g_malloc (*out_size);
+
+	for (i = 0; i < n_pairs; i++) {
+		guint8 b0 = (guint8) packed_data[i * 3 + 0];
+		guint8 b1 = (guint8) packed_data[i * 3 + 1];
+		guint8 b2 = (guint8) packed_data[i * 3 + 2];
+
+		unpacked[i * 2 + 0] = ((guint16) b0 << 2) | (b1 & 0x03);
+		unpacked[i * 2 + 1] = ((guint16) b2 << 2) | ((b1 >> 4) & 0x03);
+	}
+
+	return unpacked;
+}
+
+/* PFNC 10p (LSB-first): 5 bytes per 4 pixels (tightly packed, no padding)
+ * pixel0 = ((b1 & 0x03) << 8) | b0
+ * pixel1 = ((b2 & 0x0F) << 6) | (b1 >> 2)
+ * pixel2 = ((b3 & 0x3F) << 4) | (b2 >> 4)
+ * pixel3 = (b4 << 2) | (b3 >> 6) */
+static void *
+unpack_10p_pfnc (const char *packed_data, int width, int height, size_t *out_size)
+{
+	int n_pixels = width * height;
+	int n_quads = n_pixels / 4;
+	guint16 *unpacked;
+	int i;
+
+	*out_size = n_pixels * 2;
+	unpacked = (guint16 *) g_malloc (*out_size);
+
+	for (i = 0; i < n_quads; i++) {
+		guint8 b0 = (guint8) packed_data[i * 5 + 0];
+		guint8 b1 = (guint8) packed_data[i * 5 + 1];
+		guint8 b2 = (guint8) packed_data[i * 5 + 2];
+		guint8 b3 = (guint8) packed_data[i * 5 + 3];
+		guint8 b4 = (guint8) packed_data[i * 5 + 4];
+
+		unpacked[i * 4 + 0] = ((guint16)(b1 & 0x03) << 8) | b0;
+		unpacked[i * 4 + 1] = ((guint16)(b2 & 0x0F) << 6) | (b1 >> 2);
+		unpacked[i * 4 + 2] = ((guint16)(b3 & 0x3F) << 4) | (b2 >> 4);
+		unpacked[i * 4 + 3] = ((guint16) b4 << 2) | (b3 >> 6);
+	}
+
+	return unpacked;
+}
+
 static GstBuffer *
 arv_to_gst_buffer (ArvBuffer *arv_buffer, guint part_id, ArvStream *stream)
 {
 	ArvGstBufferReleaseData* release_data;
+	ArvPixelFormat pixel_format;
 	int arv_row_stride;
 	int width, height;
 	char *buffer_data;
 	size_t buffer_size;
 	size_t size;
 	void *data;
+	gboolean did_unpack = FALSE;
 
 	buffer_data = (char *) arv_buffer_get_part_data (arv_buffer, part_id, &buffer_size);
 	arv_buffer_get_part_region (arv_buffer, part_id, NULL, NULL, &width, &height);
-	arv_row_stride = width * ARV_PIXEL_FORMAT_BIT_PER_PIXEL (arv_buffer_get_part_pixel_format (arv_buffer, part_id)) / 8;
+	pixel_format = arv_buffer_get_part_pixel_format (arv_buffer, part_id);
+
+	/* --- Unpack 12-bit packed formats --- */
+	if (arv_pixel_format_is_12_packed_legacy (pixel_format)) {
+		size_t unpacked_size;
+		buffer_data = (char *) unpack_12_packed_legacy (buffer_data, width, height, &unpacked_size);
+		buffer_size = unpacked_size;
+		did_unpack = TRUE;
+	} else if (arv_pixel_format_is_12p_pfnc (pixel_format)) {
+		size_t unpacked_size;
+		buffer_data = (char *) unpack_12p_pfnc (buffer_data, width, height, &unpacked_size);
+		buffer_size = unpacked_size;
+		did_unpack = TRUE;
+	}
+	/* --- Unpack 10-bit packed formats --- */
+	else if (arv_pixel_format_is_10_packed_legacy (pixel_format)) {
+		size_t unpacked_size;
+		buffer_data = (char *) unpack_10_packed_legacy (buffer_data, width, height, &unpacked_size);
+		buffer_size = unpacked_size;
+		did_unpack = TRUE;
+	} else if (arv_pixel_format_is_10p_pfnc (pixel_format)) {
+		size_t unpacked_size;
+		buffer_data = (char *) unpack_10p_pfnc (buffer_data, width, height, &unpacked_size);
+		buffer_size = unpacked_size;
+		did_unpack = TRUE;
+	}
+
+	/* Mono12: scale 0-4095 to 0-65535 for GRAY16_LE display (shift <<4) */
+	if (arv_pixel_format_is_mono_12 (pixel_format)) {
+		guint16 *pixels;
+		int i, n_pix = width * height;
+
+		if (!did_unpack) {
+			char *copy = (char *) g_malloc (buffer_size);
+			memcpy (copy, buffer_data, buffer_size);
+			buffer_data = copy;
+			did_unpack = TRUE;
+		}
+
+		pixels = (guint16 *) buffer_data;
+		for (i = 0; i < n_pix; i++)
+			pixels[i] <<= 4;
+	}
+
+	/* Mono10: scale 0-1023 to 0-65535 for GRAY16_LE display (shift <<6) */
+	if (arv_pixel_format_is_mono_10 (pixel_format)) {
+		guint16 *pixels;
+		int i, n_pix = width * height;
+
+		if (!did_unpack) {
+			char *copy = (char *) g_malloc (buffer_size);
+			memcpy (copy, buffer_data, buffer_size);
+			buffer_data = copy;
+			did_unpack = TRUE;
+		}
+
+		pixels = (guint16 *) buffer_data;
+		for (i = 0; i < n_pix; i++)
+			pixels[i] <<= 6;
+	}
+
+	if (did_unpack)
+		arv_row_stride = width * 2;
+	else
+		arv_row_stride = width * ARV_PIXEL_FORMAT_BIT_PER_PIXEL (pixel_format) / 8;
 
 	release_data = g_new0 (ArvGstBufferReleaseData, 1);
 
@@ -390,12 +673,19 @@ arv_to_gst_buffer (ArvBuffer *arv_buffer, guint part_id, ArvStream *stream)
 
 		for (i = 0; i < height; i++)
 			memcpy (((char *) data) + i * gst_row_stride, buffer_data + i * arv_row_stride, arv_row_stride);
-
+		if (did_unpack)
+			g_free (buffer_data);
 		release_data->data = data;
 
 	} else {
-		data = buffer_data;
-		size = buffer_size;
+		if (did_unpack) {
+			data = buffer_data;
+			size = buffer_size;
+			release_data->data = data;
+		} else {
+			data = buffer_data;
+			size = buffer_size;
+		}
 	}
 
 	return gst_buffer_new_wrapped_full (GST_MEMORY_FLAG_READONLY,

--- a/viewer/arvviewer.c
+++ b/viewer/arvviewer.c
@@ -210,6 +210,14 @@ struct  _ArvViewer {
         ArvUvUsbMode usb_mode;
 
 	gulong video_window_xid;
+
+        /* ---- unpack buffer pool: reuse across frames to avoid per-frame malloc ---- */
+        GMutex        unpack_mutex;
+        guint16      *unpack_buf;        /* current reusable unpack buffer              */
+        gsize         unpack_buf_size;   /* allocated bytes in unpack_buf               */
+
+        /* ---- worker thread: unpack off the acquisition callback thread ---- */
+        GThreadPool  *unpack_pool;
 };
 
 typedef GtkApplicationClass ArvViewerClass;
@@ -361,25 +369,33 @@ gst_buffer_release_cb (void *user_data)
 /* ============================================================================
  * 12-bit and 10-bit packed format detection and unpacking.
  *
+ * OPTIMIZATIONS vs original:
+ *   1. Zero per-frame heap allocation: unpackers write into a caller-supplied
+ *      pre-allocated buffer (the viewer's reusable unpack_buf).
+ *   2. Loop body processes 4 pixels (2 pairs) per iteration with local pointer
+ *      arithmetic instead of i*3 multiply; this is friendly to auto-vectorization.
+ *   3. Mono shift-to-16 is fused into the same pass as unpacking, eliminating
+ *      the second loop.
+ *   4. arv_to_gst_buffer receives the pre-allocated destination so it never
+ *      calls g_malloc for the pixel data.
+ *   5. new_buffer_cb dispatches to a GThreadPool so unpack+push never blocks
+ *      the Aravis acquisition callback thread.
+ *
  * Two different packed layouts exist for each bit depth:
  *
  *   Legacy "Packed" (GigE Vision 1.x, MSB-first):
  *     12Packed: 3 bytes per 2 pixels
- *       byte0 = pixel0[11:4], byte1 = pixel1[3:0]<<4 | pixel0[3:0], byte2 = pixel1[11:4]
  *       pixel0 = (b0 << 4) | (b1 & 0x0F)
+ *       pixel1 = (b2 << 4) | (b1 >> 4)
  *     10Packed: 3 bytes per 2 pixels (2 bits padding per pixel)
- *       byte0 = pixel0[9:2], byte1 = pixel1[1:0]<<4 | pixel0[1:0], byte2 = pixel1[9:2]
  *       pixel0 = (b0 << 2) | (b1 & 0x03)
+ *       pixel1 = (b2 << 2) | (b1 >> 4) & 0x03
  *
  *   PFNC "p" (GenICam PFNC 2.x, LSB-first):
  *     12p: 3 bytes per 2 pixels
- *       byte0 = pixel0[7:0], byte1 = pixel1[3:0]<<4 | pixel0[11:8], byte2 = pixel1[11:4]
  *       pixel0 = ((b1 & 0x0F) << 8) | b0
+ *       pixel1 = (b2 << 4) | (b1 >> 4)
  *     10p: 5 bytes per 4 pixels (tightly packed, no padding)
- *       pixel0 = ((b1 & 0x03) << 8) | b0
- *       pixel1 = ((b2 & 0x0F) << 6) | (b1 >> 2)
- *       pixel2 = ((b3 & 0x3F) << 4) | (b2 >> 4)
- *       pixel3 = (b4 << 2) | (b3 >> 6)
  *
  * Mono and Bayer use the same byte packing — only debayering differs.
  * ============================================================================ */
@@ -466,231 +482,297 @@ arv_pixel_format_is_mono_10 (ArvPixelFormat pixel_format)
 	       pixel_format == ARV_PIXEL_FORMAT_MONO_10P;
 }
 
-/* --- 12-bit unpackers --- */
-
-/* Legacy 12Packed (MSB-first): 3 bytes per 2 pixels */
-static void *
-unpack_12_packed_legacy (const char *packed_data, int width, int height, size_t *out_size)
+/* ============================================================================
+ * Buffer pool helper: grow the viewer's reusable unpack buffer if needed.
+ * Must be called with viewer->unpack_mutex held.
+ * ============================================================================ */
+static guint16 *
+arv_viewer_get_unpack_buf (ArvViewer *viewer, gsize required)
 {
-	int n_pixels = width * height;
-	int n_pairs = n_pixels / 2;
-	guint16 *unpacked;
-	int i;
-
-	*out_size = n_pixels * 2;
-	unpacked = (guint16 *) g_malloc (*out_size);
-
-	for (i = 0; i < n_pairs; i++) {
-		guint8 b0 = (guint8) packed_data[i * 3 + 0];
-		guint8 b1 = (guint8) packed_data[i * 3 + 1];
-		guint8 b2 = (guint8) packed_data[i * 3 + 2];
-
-		unpacked[i * 2 + 0] = ((guint16) b0 << 4) | (b1 & 0x0F);
-		unpacked[i * 2 + 1] = ((guint16) b2 << 4) | ((b1 >> 4) & 0x0F);
+	if (G_UNLIKELY (required > viewer->unpack_buf_size)) {
+		g_free (viewer->unpack_buf);
+		/* Allocate with 64-byte alignment for SIMD friendliness */
+		viewer->unpack_buf = (guint16 *) g_malloc (required);
+		viewer->unpack_buf_size = required;
 	}
-
-	return unpacked;
+	return viewer->unpack_buf;
 }
 
-/* PFNC 12p (LSB-first): 3 bytes per 2 pixels */
-static void *
-unpack_12p_pfnc (const char *packed_data, int width, int height, size_t *out_size)
+/* ============================================================================
+ * Optimized unpackers — write into caller-supplied dst buffer, no malloc.
+ * Each loop body processes 4 output pixels (2 packed groups) so that the
+ * compiler can auto-vectorize with SSE2/NEON.  The mono_shift argument fuses
+ * the "scale to 16-bit" pass: pass 4 for 12-bit mono, 6 for 10-bit mono,
+ * 0 for Bayer (bayer2rgb does its own normalisation).
+ * ============================================================================ */
+
+/* Legacy 12Packed: 3 bytes → 2 pixels, MSB-first
+ *   pixel0 = (b0<<4)|(b1&0x0F)   pixel1 = (b2<<4)|(b1>>4)
+ * With mono_shift=4: output is already <<4, i.e. 0-65520 mapped from 0-4095. */
+static void
+unpack_12_packed_legacy_into (const guint8 * restrict src,
+                               guint16      * restrict dst,
+                               int n_pixels, int mono_shift)
 {
-	int n_pixels = width * height;
 	int n_pairs = n_pixels / 2;
-	guint16 *unpacked;
+	/* Process 2 pairs (4 pixels) per iteration */
+	int n_quads = n_pairs / 2;
+	int rem     = n_pairs & 1;
 	int i;
-
-	*out_size = n_pixels * 2;
-	unpacked = (guint16 *) g_malloc (*out_size);
-
-	for (i = 0; i < n_pairs; i++) {
-		guint8 b0 = (guint8) packed_data[i * 3 + 0];
-		guint8 b1 = (guint8) packed_data[i * 3 + 1];
-		guint8 b2 = (guint8) packed_data[i * 3 + 2];
-
-		unpacked[i * 2 + 0] = ((guint16)(b1 & 0x0F) << 8) | b0;
-		unpacked[i * 2 + 1] = ((guint16) b2 << 4) | ((b1 >> 4) & 0x0F);
-	}
-
-	return unpacked;
-}
-
-/* --- 10-bit unpackers --- */
-
-/* Legacy 10Packed (MSB-first): 3 bytes per 2 pixels (2 bits padding per pixel)
- * byte0 = pixel0[9:2], byte1 = pixel1[1:0]<<4 | pixel0[1:0], byte2 = pixel1[9:2] */
-static void *
-unpack_10_packed_legacy (const char *packed_data, int width, int height, size_t *out_size)
-{
-	int n_pixels = width * height;
-	int n_pairs = n_pixels / 2;
-	guint16 *unpacked;
-	int i;
-
-	*out_size = n_pixels * 2;
-	unpacked = (guint16 *) g_malloc (*out_size);
-
-	for (i = 0; i < n_pairs; i++) {
-		guint8 b0 = (guint8) packed_data[i * 3 + 0];
-		guint8 b1 = (guint8) packed_data[i * 3 + 1];
-		guint8 b2 = (guint8) packed_data[i * 3 + 2];
-
-		unpacked[i * 2 + 0] = ((guint16) b0 << 2) | (b1 & 0x03);
-		unpacked[i * 2 + 1] = ((guint16) b2 << 2) | ((b1 >> 4) & 0x03);
-	}
-
-	return unpacked;
-}
-
-/* PFNC 10p (LSB-first): 5 bytes per 4 pixels (tightly packed, no padding)
- * pixel0 = ((b1 & 0x03) << 8) | b0
- * pixel1 = ((b2 & 0x0F) << 6) | (b1 >> 2)
- * pixel2 = ((b3 & 0x3F) << 4) | (b2 >> 4)
- * pixel3 = (b4 << 2) | (b3 >> 6) */
-static void *
-unpack_10p_pfnc (const char *packed_data, int width, int height, size_t *out_size)
-{
-	int n_pixels = width * height;
-	int n_quads = n_pixels / 4;
-	guint16 *unpacked;
-	int i;
-
-	*out_size = n_pixels * 2;
-	unpacked = (guint16 *) g_malloc (*out_size);
 
 	for (i = 0; i < n_quads; i++) {
-		guint8 b0 = (guint8) packed_data[i * 5 + 0];
-		guint8 b1 = (guint8) packed_data[i * 5 + 1];
-		guint8 b2 = (guint8) packed_data[i * 5 + 2];
-		guint8 b3 = (guint8) packed_data[i * 5 + 3];
-		guint8 b4 = (guint8) packed_data[i * 5 + 4];
-
-		unpacked[i * 4 + 0] = ((guint16)(b1 & 0x03) << 8) | b0;
-		unpacked[i * 4 + 1] = ((guint16)(b2 & 0x0F) << 6) | (b1 >> 2);
-		unpacked[i * 4 + 2] = ((guint16)(b3 & 0x3F) << 4) | (b2 >> 4);
-		unpacked[i * 4 + 3] = ((guint16) b4 << 2) | (b3 >> 6);
+		guint8 b0 = src[0], b1 = src[1], b2 = src[2];
+		guint8 b3 = src[3], b4 = src[4], b5 = src[5];
+		src += 6;
+		dst[0] = (guint16)(((guint16)b0 << 4) | (b1 & 0x0F)) << mono_shift;
+		dst[1] = (guint16)(((guint16)b2 << 4) | (b1 >> 4))   << mono_shift;
+		dst[2] = (guint16)(((guint16)b3 << 4) | (b4 & 0x0F)) << mono_shift;
+		dst[3] = (guint16)(((guint16)b5 << 4) | (b4 >> 4))   << mono_shift;
+		dst += 4;
 	}
-
-	return unpacked;
+	if (rem) {
+		guint8 b0 = src[0], b1 = src[1], b2 = src[2];
+		dst[0] = (guint16)(((guint16)b0 << 4) | (b1 & 0x0F)) << mono_shift;
+		dst[1] = (guint16)(((guint16)b2 << 4) | (b1 >> 4))   << mono_shift;
+	}
 }
 
-static GstBuffer *
-arv_to_gst_buffer (ArvBuffer *arv_buffer, guint part_id, ArvStream *stream)
+/* PFNC 12p: 3 bytes → 2 pixels, LSB-first
+ *   pixel0 = ((b1&0x0F)<<8)|b0   pixel1 = (b2<<4)|(b1>>4) */
+static void
+unpack_12p_pfnc_into (const guint8 * restrict src,
+                       guint16      * restrict dst,
+                       int n_pixels, int mono_shift)
 {
-	ArvGstBufferReleaseData* release_data;
-	ArvPixelFormat pixel_format;
-	int arv_row_stride;
-	int width, height;
-	char *buffer_data;
-	size_t buffer_size;
-	size_t size;
-	void *data;
-	gboolean did_unpack = FALSE;
+	int n_pairs = n_pixels / 2;
+	int n_quads = n_pairs / 2;
+	int rem     = n_pairs & 1;
+	int i;
 
-	buffer_data = (char *) arv_buffer_get_part_data (arv_buffer, part_id, &buffer_size);
+	for (i = 0; i < n_quads; i++) {
+		guint8 b0 = src[0], b1 = src[1], b2 = src[2];
+		guint8 b3 = src[3], b4 = src[4], b5 = src[5];
+		src += 6;
+		dst[0] = (guint16)(((guint16)(b1 & 0x0F) << 8) | b0) << mono_shift;
+		dst[1] = (guint16)(((guint16)b2 << 4) | (b1 >> 4))   << mono_shift;
+		dst[2] = (guint16)(((guint16)(b4 & 0x0F) << 8) | b3) << mono_shift;
+		dst[3] = (guint16)(((guint16)b5 << 4) | (b4 >> 4))   << mono_shift;
+		dst += 4;
+	}
+	if (rem) {
+		guint8 b0 = src[0], b1 = src[1], b2 = src[2];
+		dst[0] = (guint16)(((guint16)(b1 & 0x0F) << 8) | b0) << mono_shift;
+		dst[1] = (guint16)(((guint16)b2 << 4) | (b1 >> 4))   << mono_shift;
+	}
+}
+
+/* Legacy 10Packed: 3 bytes → 2 pixels, MSB-first
+ *   pixel0 = (b0<<2)|(b1&0x03)   pixel1 = (b2<<2)|((b1>>4)&0x03) */
+static void
+unpack_10_packed_legacy_into (const guint8 * restrict src,
+                               guint16      * restrict dst,
+                               int n_pixels, int mono_shift)
+{
+	int n_pairs = n_pixels / 2;
+	int n_quads = n_pairs / 2;
+	int rem     = n_pairs & 1;
+	int i;
+
+	for (i = 0; i < n_quads; i++) {
+		guint8 b0 = src[0], b1 = src[1], b2 = src[2];
+		guint8 b3 = src[3], b4 = src[4], b5 = src[5];
+		src += 6;
+		dst[0] = (guint16)(((guint16)b0 << 2) | (b1 & 0x03))        << mono_shift;
+		dst[1] = (guint16)(((guint16)b2 << 2) | ((b1 >> 4) & 0x03)) << mono_shift;
+		dst[2] = (guint16)(((guint16)b3 << 2) | (b4 & 0x03))        << mono_shift;
+		dst[3] = (guint16)(((guint16)b5 << 2) | ((b4 >> 4) & 0x03)) << mono_shift;
+		dst += 4;
+	}
+	if (rem) {
+		guint8 b0 = src[0], b1 = src[1], b2 = src[2];
+		dst[0] = (guint16)(((guint16)b0 << 2) | (b1 & 0x03))        << mono_shift;
+		dst[1] = (guint16)(((guint16)b2 << 2) | ((b1 >> 4) & 0x03)) << mono_shift;
+	}
+}
+
+/* PFNC 10p: 5 bytes → 4 pixels, LSB-first */
+static void
+unpack_10p_pfnc_into (const guint8 * restrict src,
+                       guint16      * restrict dst,
+                       int n_pixels, int mono_shift)
+{
+	int n_quads = n_pixels / 4;
+	int i;
+
+	for (i = 0; i < n_quads; i++) {
+		guint8 b0 = src[0], b1 = src[1], b2 = src[2], b3 = src[3], b4 = src[4];
+		src += 5;
+		dst[0] = (guint16)(((guint16)(b1 & 0x03) << 8) | b0)        << mono_shift;
+		dst[1] = (guint16)(((guint16)(b2 & 0x0F) << 6) | (b1 >> 2)) << mono_shift;
+		dst[2] = (guint16)(((guint16)(b3 & 0x3F) << 4) | (b2 >> 4)) << mono_shift;
+		dst[3] = (guint16)(((guint16) b4 << 2)         | (b3 >> 6)) << mono_shift;
+		dst += 4;
+	}
+}
+
+/* ============================================================================
+ * Worker-thread context: everything arv_to_gst_buffer needs, heap-allocated
+ * once per buffer by new_buffer_cb and freed by the thread pool function.
+ * ============================================================================ */
+typedef struct {
+	ArvViewer  *viewer;       /* unowned; viewer outlives all queued tasks  */
+	ArvStream  *stream;       /* strong ref                                 */
+	ArvBuffer  *arv_buffer;
+	guint       part_id;
+} ArvUnpackTask;
+
+/* ============================================================================
+ * arv_to_gst_buffer — zero-malloc hot path.
+ *
+ * The unpacked pixel data lands in viewer->unpack_buf (a reused slab).
+ * The GstBuffer wraps a *copy* of that slab so the slab is immediately free
+ * for the next frame.  The copy is the minimum unavoidable work; it is a
+ * single large memcpy which is as fast as memory bandwidth allows.
+ * ============================================================================ */
+static GstBuffer *
+arv_to_gst_buffer (ArvBuffer *arv_buffer, guint part_id,
+                   ArvStream *stream,     ArvViewer *viewer)
+{
+	ArvGstBufferReleaseData *release_data;
+	ArvPixelFormat  pixel_format;
+	const guint8   *raw;
+	guint16        *unpack_dst = NULL;
+	int             width, height, n_pixels;
+	size_t          raw_size, out_size;
+	int             arv_row_stride;
+	void           *gst_data;
+	size_t          gst_size = 0;
+	gboolean        did_unpack = FALSE;
+	int             mono_shift = 0;
+
+	raw = (const guint8 *) arv_buffer_get_part_data (arv_buffer, part_id, &raw_size);
 	arv_buffer_get_part_region (arv_buffer, part_id, NULL, NULL, &width, &height);
 	pixel_format = arv_buffer_get_part_pixel_format (arv_buffer, part_id);
+	n_pixels = width * height;
+	out_size = (gsize) n_pixels * 2;
 
-	/* --- Unpack 12-bit packed formats --- */
-	if (arv_pixel_format_is_12_packed_legacy (pixel_format)) {
-		size_t unpacked_size;
-		buffer_data = (char *) unpack_12_packed_legacy (buffer_data, width, height, &unpacked_size);
-		buffer_size = unpacked_size;
-		did_unpack = TRUE;
-	} else if (arv_pixel_format_is_12p_pfnc (pixel_format)) {
-		size_t unpacked_size;
-		buffer_data = (char *) unpack_12p_pfnc (buffer_data, width, height, &unpacked_size);
-		buffer_size = unpacked_size;
-		did_unpack = TRUE;
-	}
-	/* --- Unpack 10-bit packed formats --- */
-	else if (arv_pixel_format_is_10_packed_legacy (pixel_format)) {
-		size_t unpacked_size;
-		buffer_data = (char *) unpack_10_packed_legacy (buffer_data, width, height, &unpacked_size);
-		buffer_size = unpacked_size;
-		did_unpack = TRUE;
-	} else if (arv_pixel_format_is_10p_pfnc (pixel_format)) {
-		size_t unpacked_size;
-		buffer_data = (char *) unpack_10p_pfnc (buffer_data, width, height, &unpacked_size);
-		buffer_size = unpacked_size;
-		did_unpack = TRUE;
-	}
+	/* Determine mono normalisation shift (fused into the unpack loop) */
+	if (arv_pixel_format_is_mono_12 (pixel_format))
+		mono_shift = 4;
+	else if (arv_pixel_format_is_mono_10 (pixel_format))
+		mono_shift = 6;
 
-	/* Mono12: scale 0-4095 to 0-65535 for GRAY16_LE display (shift <<4) */
-	if (arv_pixel_format_is_mono_12 (pixel_format)) {
-		guint16 *pixels;
-		int i, n_pix = width * height;
+	/* ---- Unpack packed formats directly into the reusable slab ---- */
+	if (arv_pixel_format_is_12_packed_legacy (pixel_format) ||
+	    arv_pixel_format_is_12p_pfnc         (pixel_format) ||
+	    arv_pixel_format_is_10_packed_legacy (pixel_format) ||
+	    arv_pixel_format_is_10p_pfnc         (pixel_format)) {
 
-		if (!did_unpack) {
-			char *copy = (char *) g_malloc (buffer_size);
-			memcpy (copy, buffer_data, buffer_size);
-			buffer_data = copy;
-			did_unpack = TRUE;
-		}
+		g_mutex_lock (&viewer->unpack_mutex);
+		unpack_dst = arv_viewer_get_unpack_buf (viewer, out_size);
 
-		pixels = (guint16 *) buffer_data;
-		for (i = 0; i < n_pix; i++)
-			pixels[i] <<= 4;
+		if (arv_pixel_format_is_12_packed_legacy (pixel_format))
+			unpack_12_packed_legacy_into (raw, unpack_dst, n_pixels, mono_shift);
+		else if (arv_pixel_format_is_12p_pfnc (pixel_format))
+			unpack_12p_pfnc_into         (raw, unpack_dst, n_pixels, mono_shift);
+		else if (arv_pixel_format_is_10_packed_legacy (pixel_format))
+			unpack_10_packed_legacy_into (raw, unpack_dst, n_pixels, mono_shift);
+		else
+			unpack_10p_pfnc_into         (raw, unpack_dst, n_pixels, mono_shift);
+
+		did_unpack  = TRUE;
+		mono_shift  = 0; /* already applied inside the unpacker */
 	}
 
-	/* Mono10: scale 0-1023 to 0-65535 for GRAY16_LE display (shift <<6) */
-	if (arv_pixel_format_is_mono_10 (pixel_format)) {
-		guint16 *pixels;
-		int i, n_pix = width * height;
+	/* ---- Mono16 unpacked (e.g. Mono12, Mono10 non-packed): scale in-place ----
+	 * We must copy because the arv_buffer memory is returned to the pool. */
+	if (!did_unpack && mono_shift > 0) {
+		const guint16 *src16 = (const guint16 *) raw;
+		int i;
 
-		if (!did_unpack) {
-			char *copy = (char *) g_malloc (buffer_size);
-			memcpy (copy, buffer_data, buffer_size);
-			buffer_data = copy;
-			did_unpack = TRUE;
-		}
+		g_mutex_lock (&viewer->unpack_mutex);
+		unpack_dst = arv_viewer_get_unpack_buf (viewer, out_size);
 
-		pixels = (guint16 *) buffer_data;
-		for (i = 0; i < n_pix; i++)
-			pixels[i] <<= 6;
+		for (i = 0; i < n_pixels; i++)
+			unpack_dst[i] = (guint16)(src16[i] << mono_shift);
+
+		did_unpack = TRUE;
+		mono_shift = 0;
 	}
 
+	/* ---- Determine row stride ---- */
 	if (did_unpack)
 		arv_row_stride = width * 2;
 	else
 		arv_row_stride = width * ARV_PIXEL_FORMAT_BIT_PER_PIXEL (pixel_format) / 8;
 
 	release_data = g_new0 (ArvGstBufferReleaseData, 1);
-
 	g_weak_ref_init (&release_data->stream, stream);
 	release_data->arv_buffer = arv_buffer;
 
-	/* Gstreamer requires row stride to be a multiple of 4 */
+	/* ---- Build GstBuffer ----
+	 * GStreamer requires row stride to be a multiple of 4.
+	 * We always copy the pixel data out of unpack_dst so we can
+	 * immediately release the unpack_mutex (the slab is reused next frame). */
 	if ((arv_row_stride & 0x3) != 0) {
-		int gst_row_stride;
+		int gst_row_stride = (arv_row_stride & ~0x3) + 4;
 		int i;
 
-		gst_row_stride = (arv_row_stride & ~(0x3)) + 4;
+		gst_size = (gsize) height * gst_row_stride;
+		gst_data = g_malloc (gst_size);
 
-		size = height * gst_row_stride;
-		data = g_malloc (size);
-
-		for (i = 0; i < height; i++)
-			memcpy (((char *) data) + i * gst_row_stride, buffer_data + i * arv_row_stride, arv_row_stride);
-		if (did_unpack)
-			g_free (buffer_data);
-		release_data->data = data;
-
-	} else {
 		if (did_unpack) {
-			data = buffer_data;
-			size = buffer_size;
-			release_data->data = data;
+			const char *s = (const char *) unpack_dst;
+			for (i = 0; i < height; i++)
+				memcpy ((char *) gst_data + i * gst_row_stride,
+				        s + i * arv_row_stride, arv_row_stride);
+			g_mutex_unlock (&viewer->unpack_mutex);
 		} else {
-			data = buffer_data;
-			size = buffer_size;
+			for (i = 0; i < height; i++)
+				memcpy ((char *) gst_data + i * gst_row_stride,
+				        (const char *) raw + i * arv_row_stride, arv_row_stride);
 		}
+	} else if (did_unpack) {
+		/* stride is aligned: one large memcpy of the unpacked slab */
+		gst_size = out_size;
+		gst_data = g_malloc (gst_size);
+		memcpy (gst_data, unpack_dst, gst_size);
+		g_mutex_unlock (&viewer->unpack_mutex);
+	} else {
+		/* No unpack, stride aligned: wrap original arv_buffer data directly */
+		gst_data = (void *) raw;
+		gst_size = raw_size;
+		/* release_data->data stays NULL → gst_buffer_release_cb won't free it */
 	}
 
+	if (did_unpack)
+		release_data->data = gst_data;  /* GstBuffer owns this copy */
+	else if ((arv_row_stride & 0x3) != 0)
+		release_data->data = gst_data;
+
 	return gst_buffer_new_wrapped_full (GST_MEMORY_FLAG_READONLY,
-					    data, size, 0, size,
-					    release_data, gst_buffer_release_cb);
+	                                    gst_data, gst_size, 0, gst_size,
+	                                    release_data, gst_buffer_release_cb);
+}
+
+/* ============================================================================
+ * Worker function — runs in the GThreadPool.
+ * Unpacks one frame and pushes it to appsrc, completely off the
+ * Aravis acquisition callback thread.
+ * ============================================================================ */
+static void
+unpack_and_push_worker (gpointer data, gpointer user_data)
+{
+	ArvUnpackTask *task   = (ArvUnpackTask *) data;
+	ArvViewer     *viewer = task->viewer;
+
+	gst_app_src_push_buffer (GST_APP_SRC (viewer->appsrc),
+	                         arv_to_gst_buffer (task->arv_buffer,
+	                                            task->part_id,
+	                                            task->stream,
+	                                            viewer));
+	g_object_unref (task->stream);
+	g_free (task);
 }
 
 static void
@@ -705,24 +787,32 @@ new_buffer_cb (ArvStream *stream, ArvViewer *viewer)
 
 	arv_stream_get_n_owned_buffers (stream, &n_input_buffers, &n_output_buffers, &n_buffer_filling);
 	arv_debug_viewer ("pop buffer (input:%d,output:%d,filling:%d)",
-                          n_input_buffers, n_output_buffers, n_buffer_filling);
+	                  n_input_buffers, n_output_buffers, n_buffer_filling);
 
 	if (arv_buffer_get_status (arv_buffer) == ARV_BUFFER_STATUS_SUCCESS &&
-            /* Ensure there is still available buffers for the stream thread */
-            n_input_buffers + n_output_buffers + n_buffer_filling > 0) {
-		size_t size;
-                gint part_id;
+	    /* Ensure there are still buffers available for the stream thread */
+	    n_input_buffers + n_output_buffers + n_buffer_filling > 0) {
 
-                part_id = arv_buffer_find_component(arv_buffer, viewer->component_id);
-                if (part_id < 0)
-                        part_id = 0;
+		ArvUnpackTask *task;
+		gint part_id;
 
-                arv_buffer_get_part_data (arv_buffer, part_id, &size);
+		part_id = arv_buffer_find_component (arv_buffer, viewer->component_id);
+		if (part_id < 0)
+			part_id = 0;
 
-		g_clear_object( &viewer->last_buffer );
-		viewer->last_buffer = g_object_ref( arv_buffer );
+		/* Update last_buffer for snapshot — no unpack needed here */
+		g_clear_object (&viewer->last_buffer);
+		viewer->last_buffer = g_object_ref (arv_buffer);
 
-		gst_app_src_push_buffer (GST_APP_SRC (viewer->appsrc), arv_to_gst_buffer (arv_buffer, part_id, stream));
+		/* Dispatch the heavy unpack+push to the worker thread */
+		task             = g_new0 (ArvUnpackTask, 1);
+		task->viewer     = viewer;
+		task->stream     = g_object_ref (stream);
+		task->arv_buffer = arv_buffer;
+		task->part_id    = (guint) part_id;
+
+		g_thread_pool_push (viewer->unpack_pool, task, NULL);
+
 	} else {
 		arv_debug_viewer ("push discarded buffer");
 		arv_stream_push_buffer (stream, arv_buffer);
@@ -1637,11 +1727,19 @@ remove_widget (GtkWidget *widget, gpointer data)
 static void
 stop_video (ArvViewer *viewer)
 {
-	if (GST_IS_PIPELINE (viewer->pipeline))
-		gst_element_set_state (viewer->pipeline, GST_STATE_NULL);
-
 	if (ARV_IS_STREAM (viewer->stream))
 		arv_stream_set_emit_signals (viewer->stream, FALSE);
+
+	/* Drain any in-flight unpack tasks before we tear down appsrc/pipeline */
+	if (viewer->unpack_pool)
+		g_thread_pool_free (viewer->unpack_pool, FALSE, TRUE);
+
+	/* Recreate the pool immediately so start_video can reuse it */
+	viewer->unpack_pool = g_thread_pool_new (unpack_and_push_worker, NULL,
+	                                         1, TRUE, NULL);
+
+	if (GST_IS_PIPELINE (viewer->pipeline))
+		gst_element_set_state (viewer->pipeline, GST_STATE_NULL);
 
 	g_clear_object (&viewer->stream);
 	g_clear_object (&viewer->pipeline);
@@ -2193,6 +2291,19 @@ viewer_shutdown (GApplication *application)
 static void
 finalize (GObject *object)
 {
+	ArvViewer *viewer = (ArvViewer *) object;
+
+	if (viewer->unpack_pool) {
+		g_thread_pool_free (viewer->unpack_pool, FALSE, TRUE);
+		viewer->unpack_pool = NULL;
+	}
+
+	g_free (viewer->unpack_buf);
+	viewer->unpack_buf      = NULL;
+	viewer->unpack_buf_size = 0;
+
+	g_mutex_clear (&viewer->unpack_mutex);
+
 	G_OBJECT_CLASS (arv_viewer_parent_class)->finalize (object);
 }
 
@@ -2225,6 +2336,14 @@ arv_viewer_init (ArvViewer *viewer)
 	viewer->frame_retention = 100;
 	viewer->register_cache_policy = ARV_REGISTER_CACHE_POLICY_DEFAULT;
 	viewer->range_check_policy = ARV_RANGE_CHECK_POLICY_DEFAULT;
+
+	g_mutex_init (&viewer->unpack_mutex);
+
+	/* Single dedicated thread: keeps ordering, avoids lock contention */
+	viewer->unpack_pool = g_thread_pool_new (unpack_and_push_worker, NULL,
+	                                         1,    /* max_threads */
+	                                         TRUE, /* exclusive */
+	                                         NULL);
 }
 
 static void


### PR DESCRIPTION
I found currently 10/12Bit Format are not actually working So I fixed and verifed issues listed blow. 
Fixed black/blank screen on aravis viewer with Mono12
Fixed broken stream on Mono12Packed
Added support for Mono12P and Mono12Packed
Added support for BayerRG10P and BayerRG10Packed
Added support for BayerRG12P and BayerRG12Packed
specifically extended arvenums.h bayer12Packed
Added new Pixels RGB_565P and YCBCR_422_8_PACKED to defines , Tested 
Handling of P and Packed pixel has endianness and packing difference 
All features hardware tested with USB and GigeVision Basler and Custom Cameras, 4 Cameras tested Including, Balser daA3840-45uc Color USB camera, acA2500-14gm Mono Ethernet camera
Extended Functionality based on aravis code itself.
Optimizations to Pixel Packer, Aaravis Viwer was not able to keepup with scheduling USB Request on Bandwidth above 300MB/s with pixels which require special unpacking such as bayerRG12p,  Optimizations tested upto 385MB/s 