### PR TITLE
Add IDS GV-58C1LE-M to the legacy list

### DIFF
--- a/docs/reference/aravis/building.md
+++ b/docs/reference/aravis/building.md
@@ -60,6 +60,16 @@ sudo dnf install libxml2-devel glib2-devel cmake libusb1-devel gobject-introspec
                  g++ meson gettext
 ```
 
+
+## NixOS development shell
+
+Use the following command to enter a development shell with
+all required dependencies:
+
+```sh
+nix-shell -p aravis.buildInputs aravis.nativeBuildInputs
+```
+
 ## Building on macOS
 
 Using the GNU build system on macOS is not directly supported, but can be

--- a/src/arvgcport.c
+++ b/src/arvgcport.c
@@ -64,6 +64,7 @@ static ArvGvLegacyInfos arv_gc_port_legacy_infos[] = {
    { .vendor_selection = "AT_Automation_Technology_GmbH",       .model_selection = "C6_X_GigE"},
    { .vendor_selection = "DO3THINK",                            .model_selection = "MGV518"},
    { .vendor_selection = "EVK",                                 .model_selection = "HELIOS"},
+   { .vendor_selection = "IDS_Imaging_Development_Systems_GmbH",.model_selection = "GV_58CxLE_M"},
    { .vendor_selection = "IDS_Imaging_Development_Systems_GmbH",.model_selection = "GV_524xCP_NIR"},
    { .vendor_selection = "IDS_Imaging_Development_Systems_GmbH",.model_selection = "GV_599xCP_C"},
    { .vendor_selection = "Imperx",                              .model_selection = "IpxGEVCamera"},


### PR DESCRIPTION
Following some forum pointers related to IDS cameras. 

TLDR camera also needs `arv-tool-0.10 control UserSetLoad` for `arv-test` and `aravissrc` to work properly and doesn't work in viewer. Following is a sleuthing story that someone might find useful

## Unpatched
```
GigEVision:NNetworkInterfaces       FAILURE 16777216
GigEVision:NStreamChannels          FAILURE 16777216
```
## Patched

```
Found 1 device
Testing 'IDS:GV-58CxLE-M'
Genicam:Load                        SUCCESS 
Genicam:Schema                      SUCCESS Schema validation disabled
Properties:SensorSizeReadout        SUCCESS 
Properties:SensorSizeCheck          IGNORED 
Properties:GainAvailable            SUCCESS 
Properties:GainReadout              SUCCESS 
Properties:ExposureTimeAvailable    SUCCESS 
Properties:ExposureTimeReadout      SUCCESS 
MultipleAcquisitionA:BufferCheck    SUCCESS 10/10
MultipleAcquisitionA:FrameRate      SUCCESS 10.00 Hz
SingleAcquisition:BufferCheck       SUCCESS 
SoftwareTrigger:BufferCheck         FAILURE <FrameStart> or <AcquisisitonStart> feature missing for trigger setting
MultipleAcquisitionB:BufferCheck    SUCCESS 10/10
MultipleAcquisitionB:FrameRate      SUCCESS 5.00 Hz
Multipart:NoSupport                 SUCCESS 
Chunks:NoSupport                    FAILURE 
GigEVision:NNetworkInterfaces       SUCCESS 1
GigEVision:NStreamChannels          SUCCESS 1
GigEVision:StreamChannel            SUCCESS
```

but with a catch, as it also needs issuing:
```sh
arv-tool-0.10 control UserSetLoad
```

without this, neither `arv-test` nor capture works correctly:

```
Found 1 device
Testing 'IDS:GV-58CxLE-M'
Genicam:Load                        SUCCESS 
Genicam:Schema                      SUCCESS Schema validation disabled
Properties:SensorSizeReadout        SUCCESS 
Properties:SensorSizeCheck          IGNORED 
Properties:GainAvailable            SUCCESS 
Properties:GainReadout              SUCCESS 
Properties:ExposureTimeAvailable    SUCCESS 
Properties:ExposureTimeReadout      SUCCESS 
MultipleAcquisitionA:BufferCheck    FAILURE 0/10 cb_buffer_err
MultipleAcquisitionA:FrameRate      FAILURE Missing timestamp information
SingleAcquisition:BufferCheck       FAILURE Buffer transfer failure
SoftwareTrigger:BufferCheck         FAILURE [AcquisitionMode] [AcquisitionMode] [AcquisitionModeValueControl] GigEVision write_register error (busy)
MultipleAcquisitionB:BufferCheck    FAILURE [AcquisitionMode] [AcquisitionMode] [AcquisitionModeValueControl] GigEVision write_register error (busy)
Multipart:NoSupport                 FAILURE [ArvGevSCCFGMultipart] [ArvGevSCCAPMultipartReg] GigEVision read_register error (busy)
Chunks:NoSupport                    FAILURE 
GigEVision:NNetworkInterfaces       FAILURE [ArvGevNumberOfNetworkInterfaces] GigEVision read_register error (busy)

** (arv-test-0.10:1738797): CRITICAL **: 18:01:48.682: arv_gc_integer_get_value: assertion 'error == NULL || *error == NULL' failed
GigEVision:NStreamChannels          FAILURE [ArvGevNumberOfNetworkInterfaces] GigEVision read_register error (busy)
GigEVision:StreamChannel            SUCCESS
```

I noticed there's some change when I run vendor acquisition app before trying aravis apps and it indeed did something that made `aravissrc` work. Used wireshark to capture both tools, using `gvcp` filter. Then extracted unknown register writes using

```sh
tshark -r aravis.pcapng \
  -Y "gvcp.cmd.command == 0x0082" \
  -T fields \
  -e frame.time_relative \
  -e gvcp.bootstrap.custom.register.write \
  -e gvcp.bootstrap.custom.register.value
```

then matched with genicam addresses.

#### aravis
```
9.663941076	0x800000d0	0x01000000
^ AcqStop
9.707916215	0x80010aa4	0x01000801
^ PixelFormat
9.719240396	0x80010a40	0x00000000
^ OffsetX
9.721880796	0x80010a4c	0x00000000
^ OffsetY
9.724564091	0x80010a40	0x08000000
^ OffsetX ?!?
9.727211411	0x80010a4c	0x08000000
^ OffsetY ?!?
9.746149663	0x80010f3c	0x0e000000
^ TriggerSelector ReadOutStart
9.747231035	0x80010f38	0x00000000
^ TriggerMode Off
9.775369538		
9.777290382		
9.780626532	0x800000c4	0x01000000
^ AcqStart
11.952692745	0x800000d0	0x01000000
^ AcqStop
```

#### vendor

```2.042839782	0x800109f0	0x00000000
^ LineSelector
2.046003879	0x80010f3c	0x0e000000
2.048225635	0x80010f3c	0x0e000000
2.051303718	0x800109f0	0x00000000
2.054452031	0x80010f3c	0x0e000000
^ TriggerSelector ReadOutStart
2.056573790	0x80010f44	0x05000000
^ TriggerSource Line0????
2.057687331	0x80010f3c	0x0e000000
^ TriggerSelector ReadOutStart
2.058863950	0x800109f0	0x00000000
2.061970603	0x800109f0	0x01000000
2.066282213	0x800109f0	0x02000000
2.069398339	0x800109f0	0x03000000
2.072566964	0x800109f0	0x00000000
2.074648405	0x800109f0	0x01000000
^ LineSelector Line1
2.075765250	0x800109f0	0x02000000
^ LineSelector Line2
2.076830725	0x800109f0	0x03000000
^ LineSelector Line3
2.110876318	0x8000013c	0x00000000
2.115048901	0x8000013c	0x00000000
^ BinnningSelector Sensor
2.119245837	0x800002ec	0x01000000
2.122366074	0x800002ec	0x01000000
^ DecimationSelector Region0
+ GAIN
2.173472533	0x8000873c	0x0a000000
^ GainSelector AnalogAll
2.178618655	0x8000873c	0x0a000000
^ GainSelector AnalogAll
2.179707053	0x8000873c	0x0a000000
^ GainSelector AnalogAll
2.184898682	0x8000873c	0x0a000000
^ GainSelector AnalogAll
2.185992783	0x8000873c	0x14000000
^ GainSelector DigitalAll
2.191228220	0x8000873c	0x0a000000
^ GainSelector AnalogAll
^ GainSelector
+ /GAIN
2.198030589	0x80011034	0x00000000
^ UserSetSelector
2.199915022	0x80011028	0x01000000
^ UserSetLoad
3.964756414	0x800000b8	0x01000000
^ AcquisitionMode MultiFrame
3.968808432	0x800000a4	0x64000000
^ AcquisitionFrameCount -- 100 frames
3.983025006	0x800000c4	0x01000000
^ AcqStart
7.383069081	0x800000d0	0x01000000
^ AcqStop
```

which revealed `UserSetLoad` (vendor example calls `peak_Camera_ResetToDefaultSettings` so presumably that's the default preset).

I've also tried `ResetToFactoryDefaults` to be sure but it doesn't make any difference. Camera is on latest firmware (3.80.26143).

For some reason `arv-viewer` while showing FPS only displays black picture, while `aravissrc` works fine (tried fiddling with exposure/gain).

I've added a documentation commit for building on NixOS.