### PR TITLE
Can set the pixelformat when talking to v4l2 devices

### DIFF
--- a/src/arvv4l2device.c
+++ b/src/arvv4l2device.c
@@ -547,7 +547,10 @@ arv_v4l2_device_write_memory (ArvDevice *device, guint64 address, guint32 size, 
                         case ARV_V4L2_ADDRESS_PIXEL_FORMAT:
                                 for (i = 0; i < priv->pixel_formats->len; i++) {
                                         if (g_array_index(priv->pixel_formats, guint32, i) == value.i32)
+                                        {
                                                 priv->pixel_format_idx = i;
+                                                break;
+                                        }
                                 }
                                 if (i == priv->pixel_formats->len)
                                         found = FALSE;


### PR DESCRIPTION
I'm trying to get aravis working with

- MONO_8 images
- v4l2loopback

I added to the `ArvV4l2GenicamPixelFormat pixel_format_map[]`: `{V4L2_PIX_FMT_GREY,             ARV_PIXEL_FORMAT_MONO_8},` but aravis would still complain that the pixel format wasn't found. I believe this patch fixes the problem. We weren't breaking out of the loop when a pixelformat match was found, so the `if (i == priv->pixel_formats->len)` check immediately below this if would always fire and we would always have `found = FALSE`.

Is v4l2 supposed to work? I'm seeing another error after this: `stream> Failed to start stream acquisition (V4l2 user pointer method not supported (Invalid argument))`, but this may be due to v4l2loopback. Suggestions to make this work? I can move this to an issue also.

Thanks