### PR TITLE
v4l2 fixes

### DIFF
--- a/src/arvdomparser.c
+++ b/src/arvdomparser.c
@@ -147,6 +147,21 @@ arv_dom_parser_characters (void *user_data, const xmlChar *ch, int len)
 		ArvDomNode *node;
 		char *text;
 
+                // Skip leading whitespace
+                while(len > 0 &&
+                      (*ch == '\n' ||
+                       *ch == '\r' ||
+                       *ch == '\t' ||
+                       *ch == ' '))
+                {
+                        ch++;
+                        len--;
+                }
+                // If nothing is left, we're done
+                if(len == 0)
+                        return;
+            
+
 		text = g_strndup ((char *) ch, len);
 		node = ARV_DOM_NODE (arv_dom_document_create_text_node (ARV_DOM_DOCUMENT (state->document), text));
 

--- a/src/arvv4l2device.c
+++ b/src/arvv4l2device.c
@@ -126,6 +126,9 @@ arv_v4l2_device_get_genicam_xml (ArvDevice *device, size_t *size)
 {
 	ArvV4l2DevicePrivate *priv = arv_v4l2_device_get_instance_private (ARV_V4L2_DEVICE (device));
 
+        if (size != NULL)
+                *size = priv->genicam_xml_size;
+
 	return priv->genicam_xml;
 }
 

--- a/src/arvv4l2device.c
+++ b/src/arvv4l2device.c
@@ -351,20 +351,17 @@ _set_frame_rate (ArvV4l2Device *device, double frame_rate)
 
         return TRUE;
 }
-
-static void
+static gboolean
 _control_stream (ArvV4l2Device *device, gboolean enable)
 {
         ArvV4l2DevicePrivate *priv = arv_v4l2_device_get_instance_private (ARV_V4L2_DEVICE (device));
         enum v4l2_buf_type type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
 
-        if (arv_v4l2_ioctl (priv->device_fd, enable ? VIDIOC_STREAMON : VIDIOC_STREAMOFF, &type) == -1) {
-                arv_warning_device ("v4l2 stream %s failed (%s)",
-                                    enable ? "start" : "stop",
-                                    strerror (errno));
-        } else {
-                arv_info_device ("Stream %s for device '%s'", enable ? "started" : "stopped", priv->device_file);
-        }
+        if (arv_v4l2_ioctl (priv->device_fd, enable ? VIDIOC_STREAMON : VIDIOC_STREAMOFF, &type) == -1)
+                return FALSE;
+
+        arv_info_device ("Stream %s for device '%s'", enable ? "started" : "stopped", priv->device_file);
+        return TRUE;
 }
 
 static gboolean
@@ -527,7 +524,14 @@ arv_v4l2_device_write_memory (ArvDevice *device, guint64 address, guint32 size, 
                 memcpy (&value, buffer, sizeof (value));
                 switch (address) {
                         case ARV_V4L2_ADDRESS_ACQUISITION_COMMAND:
-                                _control_stream (v4l2_device, value.i32 != 0);
+                                if( !_control_stream (v4l2_device, value.i32 != 0) ) {
+                                        g_set_error (error, ARV_DEVICE_ERROR, ARV_DEVICE_ERROR_PROTOCOL_ERROR,
+                                                     "v4l2 stream %s failed (%s)",
+                                                     value.i32 != 0 ? "start" : "stop",
+                                                     strerror (errno));
+                                        return FALSE;
+                                }
+
                                 break;
                         case ARV_V4L2_ADDRESS_GAIN:
                                 arv_v4l2_set_ctrl (priv->device_fd, V4L2_CID_GAIN, value.i32);

--- a/src/arvv4l2misc.c
+++ b/src/arvv4l2misc.c
@@ -16,6 +16,7 @@ typedef struct {
 
 static ArvV4l2GenicamPixelFormat pixel_format_map[] = {
         {V4L2_PIX_FMT_YUYV,             ARV_PIXEL_FORMAT_YUV_422_YUYV_PACKED},
+        {V4L2_PIX_FMT_GREY,             ARV_PIXEL_FORMAT_MONO_8},
 /* Disable these formats for now, makes gstreamer crash:
         {V4L2_PIX_FMT_RGB24,            ARV_PIXEL_FORMAT_RGB_8_PACKED},
         {V4L2_PIX_FMT_BGR24,            ARV_PIXEL_FORMAT_BGR_8_PACKED},

--- a/src/arvv4l2stream.c
+++ b/src/arvv4l2stream.c
@@ -361,7 +361,7 @@ arv_v4l2_stream_start_acquisition (ArvStream *stream, GError **error)
                 return FALSE;
         }
 
-        bytes_per_line_data = (thread_data->image_width  / bit_per_pixel + 7) * 8;
+        bytes_per_line_data = thread_data->image_width * bit_per_pixel / 8;
         if (bytes_per_line < bytes_per_line_data) {
                 g_set_error (error, ARV_DEVICE_ERROR, ARV_DEVICE_ERROR_PROTOCOL_ERROR,
                              "Invalid v4l2 pixel format");

--- a/src/arvv4l2stream.c
+++ b/src/arvv4l2stream.c
@@ -274,7 +274,7 @@ arv_v4l2_stream_start_acquisition (ArvStream *stream, GError **error)
         guint32 bit_per_pixel;
         guint32 bytes_per_line;
         guint32 payload_size;
-        guint32 width_pixels;
+        guint32 bytes_per_line_data;
         guint32 index = 0;
         guint32 n_buffers = 0;
 
@@ -361,14 +361,14 @@ arv_v4l2_stream_start_acquisition (ArvStream *stream, GError **error)
                 return FALSE;
         }
 
-        width_pixels = (thread_data->image_width  / bit_per_pixel + 7) * 8;
-        if (bytes_per_line < width_pixels) {
+        bytes_per_line_data = (thread_data->image_width  / bit_per_pixel + 7) * 8;
+        if (bytes_per_line < bytes_per_line_data) {
                 g_set_error (error, ARV_DEVICE_ERROR, ARV_DEVICE_ERROR_PROTOCOL_ERROR,
                              "Invalid v4l2 pixel format");
                 return FALSE;
         }
 
-        thread_data->image_x_padding = bytes_per_line - width_pixels;
+        thread_data->image_x_padding = bytes_per_line - bytes_per_line_data;
         thread_data->frame_id = 0;
 
 	priv->thread = g_thread_new ("arv_v4l2_stream", arv_v4l2_stream_thread, priv->thread_data);


### PR DESCRIPTION
Hello. Thanks for merging the last one. Here are a few more patches. After these:

- I can use aravis with the latest mrcam frontend see my YUYV webcam images
- Same with MONO_8 images from v4l2loopback
- `arv-tool-0.10 genicam -n /dev/video0` doesn't spit out gigabytes of spaces

Note that https://github.com/AravisProject/aravis/commit/a458b346a279eab40e4665dfea3bb825293c0864 and https://github.com/AravisProject/aravis/commit/bb7faf2b45502a702ca324d14871d2a5785f4394 definitely address a bug, but I'm not sure the interpretation I guessed was correct. So maybe these do not fix the bug correctly, but it's correct-enough to work with mono_8 images.

Thanks!