### PR TITLE
v4l bytes_per_line_data: round the size up to the next byte

### DIFF
--- a/src/arvv4l2stream.c
+++ b/src/arvv4l2stream.c
@@ -361,7 +361,8 @@ arv_v4l2_stream_start_acquisition (ArvStream *stream, GError **error)
                 return FALSE;
         }
 
-        bytes_per_line_data = thread_data->image_width * bit_per_pixel / 8;
+        // round each line up to the next byte
+        bytes_per_line_data = (thread_data->image_width * bit_per_pixel + 7) / 8;
         if (bytes_per_line < bytes_per_line_data) {
                 g_set_error (error, ARV_DEVICE_ERROR, ARV_DEVICE_ERROR_PROTOCOL_ERROR,
                              "Invalid v4l2 pixel format");


### PR DESCRIPTION
Since my interpretation of bytes_per_line_data appears to be correct (a458b346a279eab40e4665dfea3bb825293c0864 was merged), this patch has the logic you intended to add.