### PR TITLE
Experimental support for the NV12 pixel format

### DIFF
--- a/src/arvenums.h
+++ b/src/arvenums.h
@@ -269,6 +269,7 @@ typedef guint32 ArvPixelFormat;
 #define ARV_PIXEL_FORMAT_RGB_565P		((ArvPixelFormat) 0x02100035u)
 
 #define ARV_PIXEL_FORMAT_YCBCR_422_8_PACKED 	((ArvPixelFormat) 0x0210003Bu)
+#define ARV_PIXEL_FORMAT_NV12			((ArvPixelFormat) 0x020c5555u)
 
 /* Custom */
 

--- a/src/arvmisc.c
+++ b/src/arvmisc.c
@@ -915,6 +915,13 @@ ArvGstCapsInfos arv_gst_caps_infos[] = {
  * They were discussed in bug https://gitlab.freedesktop.org/gstreamer/gst-plugins-bad/-/issues/86, but not implemented. */
 
 	{
+		ARV_PIXEL_FORMAT_NV12,
+		"video/x-raw, format=(string)NV12",
+		"video/x-raw", 		"NV12",
+		"video/x-raw-yuv, bpp=(int)12, depth=(int)8",
+		"video/x-raw-yuv",	0,	0,	ARV_MAKE_FOURCC ('N','V','1','2')
+	},
+	{
 		ARV_PIXEL_FORMAT_YUV_422_PACKED,
 		"video/x-raw, format=(string)UYVY",
 		"video/x-raw",		"UYVY",

--- a/src/arvv4l2misc.c
+++ b/src/arvv4l2misc.c
@@ -16,6 +16,7 @@ typedef struct {
 
 static ArvV4l2GenicamPixelFormat pixel_format_map[] = {
         {V4L2_PIX_FMT_YUYV,             ARV_PIXEL_FORMAT_YUV_422_YUYV_PACKED},
+        {V4L2_PIX_FMT_NV12,             ARV_PIXEL_FORMAT_NV12},
         {V4L2_PIX_FMT_GREY,             ARV_PIXEL_FORMAT_MONO_8},
 /* Disable these formats for now, makes gstreamer crash:
         {V4L2_PIX_FMT_RGB24,            ARV_PIXEL_FORMAT_RGB_8_PACKED},

--- a/src/arvv4l2stream.c
+++ b/src/arvv4l2stream.c
@@ -357,19 +357,11 @@ arv_v4l2_stream_start_acquisition (ArvStream *stream, GError **error)
         if ( bit_per_pixel < 1 ||
              thread_data->image_height * bytes_per_line > payload_size) {
                 g_set_error (error, ARV_DEVICE_ERROR, ARV_DEVICE_ERROR_PROTOCOL_ERROR,
-                             "Invalid v4l2 pixel format");
+                             "Invalid v4l2 pixel format: bit_per_pixel < 1 || image_height * bytes_per_line > payload_size");
                 return FALSE;
         }
 
-        // round each line up to the next byte
-        bytes_per_line_data = (thread_data->image_width * bit_per_pixel + 7) / 8;
-        if (bytes_per_line < bytes_per_line_data) {
-                g_set_error (error, ARV_DEVICE_ERROR, ARV_DEVICE_ERROR_PROTOCOL_ERROR,
-                             "Invalid v4l2 pixel format");
-                return FALSE;
-        }
-
-        thread_data->image_x_padding = bytes_per_line - bytes_per_line_data;
+        thread_data->image_x_padding = 0;
         thread_data->frame_id = 0;
 
 	priv->thread = g_thread_new ("arv_v4l2_stream", arv_v4l2_stream_thread, priv->thread_data);


### PR DESCRIPTION
Hi. This patch adds support for NV12. This has some issues, and isn't ready to merge as is.

I don't have genicam hardware that produces this pixel format, but I do have such a v4l2 stream (via v4l2loopback) that this patch enables. Concerns:

- The value of ARV_PIXEL_FORMAT_NV12 is made up. I don't entirely understand where this is supposed to come from, and the 5555 part is arbitrary
- arvv4l2stream.c was assuming that an image is made up of rows with `bytes_per_line_data` each, and the whole thing has `payload_size * bytes_per_line_data` bytes. This isn't true for NV12. It has bytes_per_line = width and payload_size = width*height*1.5 and bytes_per_line_data isn't well-defined. Can we simply remove bytes_per_line_data and the logic that uses it?

Thanks