### PR TITLE
uvstream: Ensure req_payload_size is valid before attempting to stream

### DIFF
--- a/src/arvuvstream.c
+++ b/src/arvuvstream.c
@@ -957,7 +957,13 @@ arv_uv_stream_start_acquisition (ArvStream *stream, GError **error)
 	}
 
 	si_payload_size = MIN(si_req_payload_size , aligned_maximum_transfer_size);
-	si_payload_count=  si_req_payload_size / si_payload_size;
+	if (si_payload_size < 1) {
+		g_set_error (error, ARV_DEVICE_ERROR, ARV_DEVICE_ERROR_INVALID_PARAMETER,
+		             "Device reported an invalid USB payload size (SI_REQ_PAYLOAD_SIZE = 0x%016"
+		             G_GINT64_MODIFIER "x)", si_req_payload_size);
+		return FALSE;
+	}
+	si_payload_count = si_req_payload_size / si_payload_size;
 	si_transfer1_size = align(si_req_payload_size % si_payload_size, alignment);
 	si_transfer2_size = 0;
 


### PR DESCRIPTION
Hi!

I was debugging a use-reported issue in the [Syntalos](https://github.com/syntalos/syntalos) DAQ system, where the program was [crashing with SIGFPE](https://github.com/syntalos/syntalos/issues/172) while trying to start streaming from a USB3 Vision camera device using Aravis.

While I could not reproduce the issue locally, the crash report pointed inside Aravis, more specifically:
If a USB3-Vision camera reports `SI_REQ_PAYLOAD_SIZE == 0`, we compute `si_payload_size` as 0 as well and later divide by zero when trying to compute `si_payload_count`, causing the crash.

This patch fixes the crash by throwing an error instead and ensuring this value cannot be 0.

With this patch, instead of crashing, we set an error and exit gracefully.
The one thing I find odd though is that we hit this at all, because unless the camera is doing something strange, this value shouldn't be zero.

What do you think? IMHO this hardening change makes sense either way, however, it may be possible that the root cause that causes `SI_REQ_PAYLOAD_SIZE` to be zero is somewhere else, maybe in the camera itself, or maybe an odd combination of parameters causes it (the issue does seem intermittent though).

Thank you for making Aravis, it is invaluable for scientific software on Linux! And thank you for considering this patch!