### PR TITLE
Tag device id with transport to avoid GEV/U3V id collision

### DIFF
--- a/src/arvgvinterface.c
+++ b/src/arvgvinterface.c
@@ -293,7 +293,12 @@ arv_gv_interface_device_infos_new (GInetAddress *interface_address,
                 infos->serial = g_strdup (infos->mac);
         }
 
-	infos->id = g_strdup_printf ("%s-%s-%s", infos->vendor, infos->model, infos->serial);
+	/* Append the transport tag so a device that reports the same
+	 * vendor/model/serial over both GigE and USB3 gets a DISTINCT id per
+	 * interface -- otherwise the two collide and arv_open_device() returns
+	 * the first-matching interface (USB3Vision precedes GigEVision), so a
+	 * GigE selection silently opens the USB device. */
+	infos->id = g_strdup_printf ("%s-%s-%s-eth", infos->vendor, infos->model, infos->serial);
 	arv_str_strip (infos->id, ARV_DEVICE_NAME_ILLEGAL_CHARACTERS, ARV_DEVICE_NAME_REPLACEMENT_CHARACTER);
 
 	infos->vendor_alias_serial = g_strdup_printf ("%s-%s", arv_vendor_alias_lookup (infos->vendor), infos->serial);

--- a/src/arvuvinterface.c
+++ b/src/arvuvinterface.c
@@ -62,7 +62,10 @@ arv_uv_interface_device_infos_new (const char *manufacturer,
 	g_return_val_if_fail (guid != NULL, NULL);
 
 	infos = g_new (ArvUvInterfaceDeviceInfos, 1);
-	infos->id = g_strdup_printf ("%s-%s-%s", manufacturer, product, serial_nbr);
+	/* Transport tag: see arvgvinterface.c -- keep GigE ("-eth") and USB3
+	 * ("-usb") ids distinct so a dual-transport camera with identical
+	 * vendor/model/serial no longer collides into one ambiguous id. */
+	infos->id = g_strdup_printf ("%s-%s-%s-usb", manufacturer, product, serial_nbr);
 	infos->manufacturer = g_strdup (manufacturer);
 	infos->vendor_alias_serial = g_strdup_printf ("%s-%s", arv_vendor_alias_lookup (manufacturer), serial_nbr);
 	infos->vendor_serial = g_strdup_printf ("%s-%s", manufacturer, serial_nbr);


### PR DESCRIPTION
A camera that reports the same vendor/model/serial over both GigE Vision and USB3 Vision produced an identical device id on each interface. Because arv_open_device() returns the first matching interface and USB3Vision is enumerated before GigEVision, selecting the GigE device silently opened the USB one.

Append a transport tag ("-eth" / "-usb") to the id built in each interface so the two are distinct and each resolves to the intended device.