### PR TITLE
Add AnalogControl feature to Root category

### DIFF
--- a/src/arv-fake-camera.xml
+++ b/src/arv-fake-camera.xml
@@ -21,6 +21,7 @@
 		<pFeature>DeviceControl</pFeature>
 		<pFeature>ImageFormatControl</pFeature>
 		<pFeature>AcquisitionControl</pFeature>
+		<pFeature>AnalogControl</pFeature>
 		<pFeature>TransportLayerControl</pFeature>
 		<pFeature>Debug</pFeature>
 	</Category>


### PR DESCRIPTION
There are pFeatures like _GainRaw_ in XML, but _Root_ does not reference _AnalogControl_